### PR TITLE
feat: skip invalid contact entries

### DIFF
--- a/paykit-lib/src/lib.rs
+++ b/paykit-lib/src/lib.rs
@@ -541,6 +541,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn known_contacts_skips_invalid_entries() {
+        let setup = TestSetup::new().await;
+
+        // Seed one valid contact.
+        let valid_contact = Keypair::random().public_key();
+        setup
+            .raw_session
+            .storage()
+            .put(format!("{PUBKY_FOLLOWS_PATH}{}", valid_contact), "")
+            .await
+            .unwrap();
+
+        // Seed an entry that cannot be parsed as a PublicKey.
+        setup
+            .raw_session
+            .storage()
+            .put(format!("{PUBKY_FOLLOWS_PATH}not-a-valid-public-key"), "")
+            .await
+            .unwrap();
+
+        // fetch_known_contacts should succeed, returning only the valid contact.
+        let contacts = get_known_contacts(&setup.reader_transport, &setup.public_key)
+            .await
+            .unwrap();
+
+        assert_eq!(contacts.len(), 1, "invalid entry should be skipped");
+        assert!(contacts.contains(&valid_contact));
+
+        setup.raw_session.signout().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_fetch_profile_success() {
         let setup = TestSetup::new().await;
 

--- a/paykit-lib/src/transport/pubky/unauthenticated_transport.rs
+++ b/paykit-lib/src/transport/pubky/unauthenticated_transport.rs
@@ -197,10 +197,8 @@ impl UnauthenticatedTransportRead for PubkyUnauthenticatedTransport {
                 match pk_str.parse::<PublicKey>() {
                     Ok(pk) => contacts.push(pk),
                     Err(err) => {
-                        error!(entry = %pk_str, error = %err, "invalid contact entry, cannot parse as PublicKey");
-                        return Err(PaykitError::InvalidData(format!(
-                            "invalid contact entry '{pk_str}': {err}"
-                        )));
+                        error!(entry = %pk_str, error = %err, "skipping invalid contact entry, cannot parse as PublicKey");
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
## Pull request overview

Updates Pubky contact discovery to be resilient to corrupted/invalid follow entries so a single bad entry no longer breaks `get_known_contacts` (issue https://github.com/pubky/paykit-rs/issues/12).

**Changes:**
- Skip (instead of erroring on) follow entries that fail `PublicKey` parsing in `fetch_known_contacts`.
- Add a regression test ensuring invalid contact entries are ignored while valid contacts are returned.

### Reviewed changes

Copilot reviewed 2 out of 2 changed files in this pull request and generated no comments.

| File | Description |
| ---- | ----------- |
| paykit-lib/src/transport/pubky/unauthenticated_transport.rs | Changes contact parsing loop to log+skip invalid public key strings instead of returning an error. |
| paykit-lib/src/lib.rs | Adds a tokio test covering “skip invalid known contacts” behavior. |