### PR TITLE
feat: error source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
@@ -617,7 +617,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2163,7 +2163,7 @@ dependencies = [
  "serde_bencode",
  "serde_bytes",
  "sha1_smol",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -2409,7 +2409,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -2440,7 +2440,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.2",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2512,10 +2512,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 name = "paykit-lib"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "pubky",
  "pubky-app-specs",
  "pubky-testnet",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2640,7 +2642,7 @@ dependencies = [
  "serde",
  "sha1_smol",
  "simple-dns",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -2665,7 +2667,7 @@ dependencies = [
  "pkarr",
  "rustls",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tower-http",
@@ -2688,7 +2690,7 @@ dependencies = [
  "hex",
  "pkarr",
  "rand 0.9.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2836,7 +2838,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2882,7 +2884,7 @@ dependencies = [
  "pubky-common",
  "reqwest",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -2926,7 +2928,7 @@ dependencies = [
  "pubky-timestamp",
  "rand 0.9.2",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -2981,7 +2983,7 @@ dependencies = [
  "serde_valid",
  "sqlx",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "toml",
@@ -3115,7 +3117,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -3136,7 +3138,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3267,7 +3269,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3360,7 +3362,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3409,7 +3411,7 @@ dependencies = [
  "http",
  "mime",
  "rand 0.9.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3561,7 +3563,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3905,7 +3907,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3989,7 +3991,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -4027,7 +4029,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -4052,7 +4054,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -4161,11 +4163,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4181,9 +4183,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4462,7 +4464,7 @@ dependencies = [
  "governor 0.8.1",
  "http",
  "pin-project",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tower",
  "tracing",
 ]

--- a/paykit-lib/Cargo.toml
+++ b/paykit-lib/Cargo.toml
@@ -18,9 +18,11 @@ default = ["pubky"]
 pubky = ["dep:pubky", "dep:pubky-app-specs"]
 
 [dependencies]
+anyhow = "1.0.102"
 async-trait = "0.1.89"
 pubky = { version = "0.6.0", optional = true }
 pubky-app-specs = { version = "0.3", optional = true }
+thiserror = "2.0.18"
 tracing = "0.1.44"
 
 [dev-dependencies]

--- a/paykit-lib/src/lib.rs
+++ b/paykit-lib/src/lib.rs
@@ -17,9 +17,12 @@
 //!
 //! For an architectural overview and example workflows, see `paykit-lib/README.md`.
 
-use std::{collections::HashMap, fmt};
+use std::collections::HashMap;
+#[cfg(not(feature = "pubky"))]
+use std::fmt;
 
-use tracing::{debug, instrument, warn};
+use thiserror::Error;
+use tracing::{debug, instrument};
 
 #[cfg(feature = "pubky")]
 pub use pubky::PublicKey;
@@ -67,21 +70,35 @@ pub use transport::{PubkyAuthenticatedTransport, PubkyUnauthenticatedTransport};
 pub type Result<T> = std::result::Result<T, PaykitError>;
 
 /// Domain-specific error type.
-#[derive(Debug)]
+///
+/// Variants that wrap an underlying cause carry a `source` field backed by
+/// [`anyhow::Error`] so that the standard [`std::error::Error::source`] chain
+/// is preserved while keeping the public API decoupled from upstream error
+/// types. Callers can downcast the source via [`anyhow::Error::downcast_ref`]
+/// when they need the original typed error.
+#[derive(Debug, Error)]
 pub enum PaykitError {
-    /// Placeholder for unimplemented logic in the current scaffold.
-    Unimplemented(&'static str),
     /// Wrapper for transport layer failures.
     ///
     /// Most user-facing failures bubble up through this variant, encapsulating
     /// lower-level SDK/network errors (timeouts, connection refused, permission
     /// denied, etc.).
-    Transport(String),
+    #[error("transport error: {context}")]
+    Transport {
+        /// Human-readable description of what went wrong.
+        context: String,
+        /// The underlying error that caused this failure.
+        #[source]
+        source: anyhow::Error,
+    },
+
     /// The requested resource does not exist.
     ///
     /// Returned when a profile or other resource is not found (404/GONE).
     /// Distinct from [`PaykitError::Profile`] which indicates the data exists but is malformed.
+    #[error("not found: {0}")]
     NotFound(String),
+
     /// Retrieved data is corrupt or structurally invalid.
     ///
     /// Returned when a resource was successfully fetched from the network but its
@@ -90,30 +107,23 @@ pub enum PaykitError {
     /// key. This is distinct from [`PaykitError::Transport`] (the network call
     /// itself failed) and [`PaykitError::Profile`] (profile-specific parse
     /// errors).
-    InvalidData(String),
+    #[error("invalid data: {context}")]
+    InvalidData {
+        /// Human-readable description of the data problem.
+        context: String,
+        /// The underlying error, when available.
+        #[source]
+        source: Option<anyhow::Error>,
+    },
+
     /// Profile data is malformed or invalid.
     ///
     /// Returned when profile data exists but cannot be parsed or validated.
     /// Distinct from [`PaykitError::NotFound`] which indicates the resource doesn't exist,
     /// and [`PaykitError::Transport`] which covers network/SDK errors.
+    #[error("profile error: {0}")]
     Profile(String),
 }
-
-impl fmt::Display for PaykitError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PaykitError::Unimplemented(label) => {
-                write!(f, "{label} is not implemented yet")
-            }
-            PaykitError::Transport(msg) => write!(f, "transport error: {msg}"),
-            PaykitError::NotFound(msg) => write!(f, "not found: {msg}"),
-            PaykitError::InvalidData(msg) => write!(f, "invalid data: {msg}"),
-            PaykitError::Profile(msg) => write!(f, "profile error: {msg}"),
-        }
-    }
-}
-
-impl std::error::Error for PaykitError {}
 
 /// Identifier for a payment method specification.
 ///
@@ -317,23 +327,16 @@ where
 
 fn map_error(label: &'static str, err: PaykitError) -> PaykitError {
     match err {
-        PaykitError::Transport(msg) => {
-            warn!(operation = label, error = %msg, "transport error");
-            PaykitError::Transport(format!("{label}: {msg}"))
-        }
-        PaykitError::NotFound(msg) => {
-            debug!(operation = label, error = %msg, "resource not found");
-            PaykitError::NotFound(format!("{label}: {msg}"))
-        }
-        PaykitError::InvalidData(msg) => {
-            warn!(operation = label, error = %msg, "invalid data");
-            PaykitError::InvalidData(format!("{label}: {msg}"))
-        }
-        PaykitError::Profile(msg) => {
-            warn!(operation = label, error = %msg, "profile error");
-            PaykitError::Profile(format!("{label}: {msg}"))
-        }
-        _ => err,
+        PaykitError::Transport { context, source } => PaykitError::Transport {
+            context: format!("{label}: {context}"),
+            source,
+        },
+        PaykitError::NotFound(msg) => PaykitError::NotFound(format!("{label}: {msg}")),
+        PaykitError::InvalidData { context, source } => PaykitError::InvalidData {
+            context: format!("{label}: {context}"),
+            source,
+        },
+        PaykitError::Profile(msg) => PaykitError::Profile(format!("{label}: {msg}")),
     }
 }
 

--- a/paykit-lib/src/transport/pubky/authenticated_transport.rs
+++ b/paykit-lib/src/transport/pubky/authenticated_transport.rs
@@ -44,7 +44,10 @@ impl AuthenticatedTransport for PubkyAuthenticatedTransport {
             .await
             .map_err(|err| {
                 error!(error = %err, "failed to put payment endpoint");
-                PaykitError::Transport(format!("put endpoint: {err}"))
+                PaykitError::Transport {
+                    context: "put endpoint".into(),
+                    source: err.into(),
+                }
             })?;
         debug!("payment endpoint stored successfully");
         Ok(())
@@ -56,7 +59,10 @@ impl AuthenticatedTransport for PubkyAuthenticatedTransport {
         debug!(path = %path, "deleting payment endpoint from storage");
         self.session.storage().delete(path).await.map_err(|err| {
             error!(error = %err, "failed to delete payment endpoint");
-            PaykitError::Transport(format!("delete endpoint: {err}"))
+            PaykitError::Transport {
+                context: "delete endpoint".into(),
+                source: err.into(),
+            }
         })?;
         debug!("payment endpoint removed successfully");
         Ok(())

--- a/paykit-lib/src/transport/pubky/unauthenticated_transport.rs
+++ b/paykit-lib/src/transport/pubky/unauthenticated_transport.rs
@@ -33,7 +33,10 @@ impl PubkyUnauthenticatedTransport {
         debug!("attempting to create PubkyUnauthenticatedTransport via PublicStorage::new()");
         let inner = SdkUnauthenticatedTransport::new().map_err(|err| {
             error!(error = %err, "failed to create Pubky public transport");
-            PaykitError::Transport(format!("failed to create Pubky public transport: {err}"))
+            PaykitError::Transport {
+                context: "failed to create Pubky public transport".into(),
+                source: err.into(),
+            }
         })?;
         debug!("PubkyUnauthenticatedTransport created successfully");
         Ok(Self { inner })
@@ -51,7 +54,10 @@ impl PubkyUnauthenticatedTransport {
             Ok(resp) => {
                 let bytes = resp.bytes().await.map_err(|err| {
                     error!(error = %err, "failed to read response bytes");
-                    PaykitError::Transport(format!("{label}: {err}"))
+                    PaykitError::Transport {
+                        context: label.to_string(),
+                        source: err.into(),
+                    }
                 })?;
                 if bytes.is_empty() {
                     debug!("resource is empty, returning None");
@@ -64,7 +70,10 @@ impl PubkyUnauthenticatedTransport {
                         valid_up_to = pos,
                         "response contains invalid UTF-8 — data may be corrupt"
                     );
-                    PaykitError::InvalidData(format!("{label}: invalid UTF-8 at byte {pos}"))
+                    PaykitError::InvalidData {
+                        context: format!("{label}: invalid UTF-8 at byte {pos}"),
+                        source: Some(err.into()),
+                    }
                 })?;
                 trace!(len = data.len(), "text resource fetched");
                 Ok(Some(data))
@@ -75,7 +84,10 @@ impl PubkyUnauthenticatedTransport {
             }
             Err(err) => {
                 error!(error = %err, "transport error during fetch");
-                Err(PaykitError::Transport(format!("{label}: {err}")))
+                Err(PaykitError::Transport {
+                    context: label.to_string(),
+                    source: err.into(),
+                })
             }
         }
     }
@@ -91,7 +103,10 @@ impl PubkyUnauthenticatedTransport {
             }
             Err(err) => {
                 error!(error = %err, "failed to create list builder");
-                return Err(PaykitError::Transport(format!("{label}: {err}")));
+                return Err(PaykitError::Transport {
+                    context: label.to_string(),
+                    source: err.into(),
+                });
             }
         };
 
@@ -106,9 +121,10 @@ impl PubkyUnauthenticatedTransport {
             }
             Err(err) => {
                 error!(error = %err, "list send failed");
-                Err(PaykitError::Transport(format!(
-                    "{label} send failed: {err}"
-                )))
+                Err(PaykitError::Transport {
+                    context: format!("{label} send failed"),
+                    source: err.into(),
+                })
             }
         }
     }
@@ -137,10 +153,13 @@ impl UnauthenticatedTransportRead for PubkyUnauthenticatedTransport {
                 .filter(|segment| !segment.is_empty())
                 .ok_or_else(|| {
                     error!(path = %resource.path, "invalid resource path for payment entry");
-                    PaykitError::InvalidData(format!(
-                        "cannot extract method from resource path '{}'",
-                        resource.path
-                    ))
+                    PaykitError::InvalidData {
+                        context: format!(
+                            "cannot extract method from resource path '{}'",
+                            resource.path
+                        ),
+                        source: None,
+                    }
                 })?
                 .to_string();
 
@@ -213,9 +232,10 @@ impl UnauthenticatedTransportRead for PubkyUnauthenticatedTransport {
         debug!("constructing profile resource");
         let resource = PubkyResource::new(user.clone(), PUBKY_PROFILE_FILE).map_err(|e| {
             error!(error = %e, "failed to construct profile resource");
-            PaykitError::Transport(format!(
-                "failed to construct profile resource for {user}: {e}"
-            ))
+            PaykitError::Transport {
+                context: format!("failed to construct profile resource for {user}"),
+                source: e.into(),
+            }
         })?;
 
         debug!("fetching profile blob from storage");
@@ -225,7 +245,10 @@ impl UnauthenticatedTransportRead for PubkyUnauthenticatedTransport {
                 .await
                 .map_err(|err| {
                     error!(error = %err, "failed to read profile response bytes");
-                    PaykitError::Transport(format!("fetch profile bytes failed: {err}"))
+                    PaykitError::Transport {
+                        context: "fetch profile bytes failed".into(),
+                        source: err.into(),
+                    }
                 })?
                 .to_vec(),
             Err(err) if is_not_found(&err) => {
@@ -234,9 +257,10 @@ impl UnauthenticatedTransportRead for PubkyUnauthenticatedTransport {
             }
             Err(err) => {
                 error!(error = %err, "transport error fetching profile");
-                return Err(PaykitError::Transport(format!(
-                    "fetch profile failed: {err}"
-                )));
+                return Err(PaykitError::Transport {
+                    context: "fetch profile failed".into(),
+                    source: err.into(),
+                });
             }
         };
 


### PR DESCRIPTION
## Pull request overview

https://github.com/pubky/paykit-rs/issues/10

This pull request refactors the `PaykitError` enum to use structured error variants with proper error source chain preservation. The changes introduce `thiserror` and `anyhow` dependencies to modernize error handling, moving from simple string-based error messages to structured errors that preserve the underlying error causes.

**Changes:**
- Refactored `PaykitError` enum to use `thiserror::Error` derive macro and structured variants with `context` and `source` fields
- Updated all error construction sites to use the new structured error format with preserved error sources via `anyhow::Error`
- Removed the unused `Unimplemented` error variant and manual `Display`/`Error` trait implementations

### Reviewed changes

Copilot reviewed 4 out of 5 changed files in this pull request and generated no comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| paykit-lib/src/lib.rs | Refactored `PaykitError` to use `thiserror` derive macro, converted `Transport` and `InvalidData` to struct variants with source preservation, removed manual trait implementations |
| paykit-lib/src/transport/pubky/unauthenticated_transport.rs | Updated all error construction sites to use new structured error format with context and source fields |
| paykit-lib/src/transport/pubky/authenticated_transport.rs | Updated error construction sites to use new structured error format |
| paykit-lib/Cargo.toml | Added `anyhow` and `thiserror` dependencies |
| Cargo.lock | Updated lockfile with new dependencies and version updates for `anyhow` and `thiserror` |