### PR TITLE
add comments on RC in payment endpoint retrieval

### DIFF
--- a/paykit-lib/src/transport/pubky/unauthenticated_transport.rs
+++ b/paykit-lib/src/transport/pubky/unauthenticated_transport.rs
@@ -132,6 +132,18 @@ impl PubkyUnauthenticatedTransport {
 
 #[async_trait]
 impl UnauthenticatedTransportRead for PubkyUnauthenticatedTransport {
+    // NOTE: Race condition — the directory listing and subsequent per-entry
+    // fetches are **not** atomic. Between the `list_entries` call and the
+    // individual `fetch_text` calls the payee may add, remove, or update
+    // endpoints. The returned `SupportedPayments` is therefore a best-effort
+    // snapshot. The underlying Pubky storage layer does not expose
+    // locks or transactional reads, so this cannot be resolved at the
+    // transport level.
+    //
+    // If a payment execution error suggests the endpoint has already been
+    // consumed (evidence of a race), callers should re-fetch the specific
+    // endpoint via `fetch_payment_endpoint`, compare the `EndpointData`, and
+    // retry with the updated value if it differs.
     #[instrument(skip(self), fields(payee = %payee))]
     async fn fetch_supported_payments(&self, payee: &PublicKey) -> Result<SupportedPayments> {
         let addr = format!("{payee}{PAYKIT_PATH_PREFIX}");

--- a/paykit-lib/src/transport/traits.rs
+++ b/paykit-lib/src/transport/traits.rs
@@ -28,6 +28,30 @@ use crate::{EndpointData, MethodId, Profile, PublicKey, Result};
 #[async_trait]
 pub trait UnauthenticatedTransportRead {
     /// Fetches the raw Supported Payments List for the provided `payee`.
+    ///
+    /// # Consistency
+    ///
+    /// This method first lists available payment method entries and then fetches
+    /// each one individually. Because the underlying transport does not support
+    /// atomic/transactional reads, a **race condition** exists: between the
+    /// directory listing and the individual fetches, endpoints may be added,
+    /// removed, or modified by the payee. The returned [`SupportedPayments`] is
+    /// therefore a **best-effort snapshot** and may be inconsistent.
+    ///
+    /// ## Recommended caller strategy
+    ///
+    /// If a payment execution fails with an error that suggests the endpoint
+    /// has already been consumed or is no longer valid (evidence of a race
+    /// condition), callers should:
+    ///
+    /// 1. Re-fetch the specific endpoint via
+    ///    [`fetch_payment_endpoint`](Self::fetch_payment_endpoint).
+    /// 2. Compare the newly retrieved [`EndpointData`] with the value used in
+    ///    the failed attempt.
+    /// 3. If the endpoint data differs, it is safe to retry the payment with
+    ///    the updated value.
+    ///
+    /// [`SupportedPayments`]: crate::SupportedPayments
     async fn fetch_supported_payments(&self, payee: &PublicKey)
         -> Result<crate::SupportedPayments>;
 


### PR DESCRIPTION
https://github.com/pubky/paykit-rs/issues/13



`paykit-lib/src/transport/traits.rs` — Added a # Consistency doc section to the fetch_supported_payments trait method (lines 33–55). It explains:
     - The list-then-fetch pattern is not atomic; endpoints can change between the two steps.
     - The returned SupportedPayments is a best-effort snapshot.
     - Recommended caller strategy: if a payment execution error suggests the endpoint was already consumed, re-fetch via fetch_payment_endpoint, compare the EndpointData,
     and retry if it differs.

`paykit-lib/src/transport/pubky/unauthenticated_transport.rs` — Added an implementation-level // NOTE: comment block above the concrete fetch_supported_payments method (
     lines 136–147). It documents the same race condition from the adapter's perspective, noting that Pubky storage does not expose locks or transactional reads, and repeats
     the retry guidance for maintainers reading the implementation directly.
