### PR TITLE
docs: add payment endpoint identifier spec draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The term "**Payment Method**" refers to the general concept of the medium throug
 To prevent miscommunication between payer and payee which will result in inability to execute payments. The terms used on both ends of the payment are to be decided by the developers community.   
 Given that both the payer and payee may have preferences regarding payment media based on a virtually infinite number of factors—such as market conditions, address types, and interbank settlement times—it is up to social consensus to determine the naming conventions for payment methods and the structure of payment endpoints. Therefore, the examples provided in this document are for illustrative purposes only.
 
+An initial draft convention is available in [specs/payment-endpoint-identifier.md](specs/payment-endpoint-identifier.md). It is recommended but not obligatory, and is intended as the first such proposal rather than a final format.
+
 ## Payment Method Lists
 
 Paykit can support virtually any payment method as long as payer and payee can mutually describe and identify it. Paykit users create the **Supported Payments Lists** \- minimum necessary data related to their supported payment methods and publish them as records on **Paykit routing** network.

--- a/paykit-lib/README.md
+++ b/paykit-lib/README.md
@@ -66,6 +66,8 @@ assert!(MethodId::new("../etc/passwd").is_err());
 
 Read access is available via `as_str()`, `Display`, and `AsRef<str>`.
 
+**Naming convention:** `MethodId` values are opaque to the library, but peers need to agree on them to interoperate. A recommended (non-obligatory) convention for the shape of these identifiers is described in [../specs/payment-endpoint-identifier.md](../specs/payment-endpoint-identifier.md).
+
 ### `EndpointData`
 
 Serialized payload served by a payment endpoint (UTF-8 text such as JSON, lnurl, etc.).

--- a/specs/payment-endpoint-identifier.md
+++ b/specs/payment-endpoint-identifier.md
@@ -1,0 +1,268 @@
+# Paykit Payment Endpoint Identifier Specification
+
+| Field       | Value                                      |
+| ----------- | ------------------------------------------ |
+| Status      | Draft                                      |
+| Version     | 0.1                                        |
+| Last updated| 2026-04-21                                 |
+| Repository  | <https://github.com/pubky/paykit-rs>       |
+
+## Abstract
+
+This document specifies a naming convention for *payment endpoint identifiers*
+in Paykit: short, structured strings that name an unambiguous way for a payee
+to receive value. It also defines the shape of the JSON payload that
+accompanies each identifier.
+
+The intent is to give implementers and downstream bindings (Swift, Kotlin,
+React Native) a single, consistent vocabulary to exchange, so that a payer
+and payee who independently support "`bitcoin-lightning-bolt12`" can recognise
+each other without side-channel coordination.
+
+## 1. Status of this document
+
+This is a *recommended* convention, not a mandatory one. Paykit's routing
+layer does not enforce identifier shape beyond the structural checks performed
+by [`MethodId`](../paykit-lib/src/lib.rs) (ASCII alphanumeric, `-`, `_`, `.`;
+max 64 characters; no path traversal; the value `private` is reserved).
+
+Identifiers that follow this specification are interoperable with Paykit
+clients that follow the same conventions. Identifiers that do not follow it
+may still be valid `MethodId` values, but carry no cross-implementation
+guarantees.
+
+A future revision may introduce a formal registry, additional conformance
+checks, or normative validators. Until then, the grammar and conventions
+below are the working agreement.
+
+## 2. Conformance
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY**
+in this document are to be interpreted as described in [RFC 2119] when, and
+only when, they appear in all capitals.
+
+## 3. Terminology
+
+- **Payment endpoint identifier** (or *identifier*): the three-segment string
+  that names a payment endpoint type, e.g. `bitcoin-onchain-p2tr`. In the
+  Paykit library this is represented by the `MethodId` type.
+- **Payload**: the JSON object stored alongside the identifier, describing
+  the specific payee handle for an endpoint of that type.
+- **Asset**, **rail**, **endpoint**: the three positional segments of an
+  identifier, defined in Section 5.
+- **Segment**: one positional component of an identifier, delimited by `-`.
+
+Paykit's higher-level terms (*Payment Method*, *Payment Endpoint*,
+*Supported Payments List*) are defined in the top-level [README](../README.md);
+this specification does not redefine them.
+
+## 4. Grammar
+
+An identifier is a three-segment string of the form `asset-rail-endpoint`.
+
+```abnf
+identifier   = asset "-" rail "-" endpoint
+asset        = 1*segment-char
+rail         = 1*segment-char
+endpoint     = 1*segment-char
+segment-char = %x61-7A / DIGIT         ; lowercase a-z or 0-9
+```
+
+The following rules apply:
+
+1. All three segments MUST be present and non-empty.
+2. Each segment MUST consist of one or more characters from the lowercase
+   ASCII alphabet (`a`–`z`) and decimal digits (`0`–`9`).
+3. The only separator between segments is the hyphen `-`. A segment MUST NOT
+   itself contain a hyphen, underscore, dot, or any other punctuation.
+4. Identifiers are compared byte-for-byte. Implementations MUST NOT perform
+   case folding, Unicode normalisation, or alias resolution when matching.
+
+## 5. Segments
+
+### 5.1 Asset
+
+The *asset* segment names the unit of value being transferred.
+
+- For cryptoassets, use the lowercased ticker (`bitcoin`, `usdt`, `eth`).
+- For fiat, use the lowercased [ISO 4217] code (`usd`, `eur`, `gbp`).
+- The asset segment MUST NOT encode the chain or token standard; the rail
+  segment disambiguates those.
+
+### 5.2 Rail
+
+The *rail* segment names the settlement system carrying the asset. Examples:
+
+- Base chain: `onchain`, `ethereum`, `solana`, `tron`.
+- Layer-2 or off-chain: `lightning`, `liquid`, `arbitrum`.
+- Fiat network: `sepa`, `ach`, `fps`.
+- Custodial provider: `revolut`, `cashapp`, `wise`.
+
+When a rail is commonly written with an internal space or hyphen (e.g.
+"Faster Payments"), collapse it to a single lowercase token (`fps`) rather
+than introducing intra-segment punctuation.
+
+### 5.3 Endpoint
+
+The *endpoint* segment names the handle format on that rail
+(`p2tr`, `bolt11`, `bolt12`, `address`, `iban`, `tag`).
+
+When a rail currently has a single canonical address format, use `address`
+rather than inventing a more specific name. Reserve distinct endpoint names
+for rails that genuinely expose multiple incompatible formats (for example,
+Bitcoin's `p2wpkh`, `p2tr`, and so on).
+
+Whichever name is used, authors SHOULD still name it explicitly, so that
+future formats on the same rail can be added as new identifiers without
+ambiguity or breaking changes.
+
+## 6. Examples
+
+### 6.1 Valid
+
+```
+bitcoin-onchain-p2tr
+bitcoin-lightning-bolt11
+bitcoin-lightning-bolt12
+usdt-ethereum-address
+usdt-tron-address
+usdc-solana-address
+usd-revolut-tag
+eur-sepa-iban
+gbp-fps-sortcode
+```
+
+### 6.2 Invalid
+
+| Identifier                     | Reason                                  |
+| ------------------------------ | --------------------------------------- |
+| `Bitcoin-onchain-p2tr`         | Uppercase characters are not permitted. |
+| `usdt-ethereum`                | Endpoint segment is missing.            |
+| `gbp-faster-payments-sortcode` | Rail segment contains an internal `-`.  |
+| `usd-revolut-pay_link`         | Underscores are not permitted.          |
+| `-bitcoin-onchain-p2tr`        | Empty leading segment.                  |
+| `bitcoin--p2tr`                | Empty middle segment.                   |
+
+## 7. Payload
+
+Each identifier is paired with a *payload* object that carries the actual
+endpoint details. A payload MUST be a JSON object; bare strings, numbers,
+and arrays are not valid payloads.
+
+### 7.1 Required fields
+
+- `value` *(string, required)*: the primary handle on the rail. This is the
+  address, invoice, offer, IBAN, tag, or equivalent identifier that a payer
+  needs in order to initiate a transfer.
+
+### 7.2 Recommended field names
+
+Beyond `value`, a payload MAY contain any fields the endpoint format
+requires. Unknown fields MUST be ignored by receivers that do not recognise
+them.
+
+The following field names are not required, but SHOULD be used where they
+apply, to keep naming consistent across endpoints:
+
+- `min` *(string)*: minimum amount the endpoint will accept, in the
+  asset's major unit, represented as a decimal string to avoid
+  floating-point rounding.
+- `max` *(string)*: maximum amount the endpoint will accept, in the same
+  form as `min`.
+- Endpoint-specific identifying fields (for example `bic`,
+  `beneficiary_name`, `memo`): named descriptively, in lowercase with
+  underscores separating words.
+
+Authors defining a new endpoint MAY introduce further fields as needed.
+Consistency with existing patterns is encouraged but not enforced.
+
+### 7.3 What does not belong in the payload
+
+Per-payment details (the specific amount being sent, a memo for a single
+transfer, a label attached to one payment) belong in the *payment request*,
+not in the endpoint payload. The payload describes what the payee accepts;
+the request describes a specific transfer.
+
+### 7.4 Examples
+
+```json
+// bitcoin-onchain-p2tr
+{ "value": "bc1p..." }
+```
+
+```json
+// bitcoin-lightning-bolt12
+{
+  "value": "lno1...",
+  "min": "0.0001",
+  "max": "0.01"
+}
+```
+
+```json
+// eur-sepa-iban
+{
+  "value": "DE89370400440532013000",
+  "bic": "COBADEFFXXX",
+  "beneficiary_name": "Jane Doe"
+}
+```
+
+## 8. Extending the format
+
+New identifiers are introduced simply by using them, following the
+conventions in Section 5. Before minting a new identifier, authors SHOULD
+check whether an existing identifier already covers the case. Duplicate
+names for the same semantic endpoint harm interoperability.
+
+Changes to an identifier's *meaning* after it is in use are a breaking
+change for any payer that has already implemented it. Where a new variant
+of a format emerges on the same rail, prefer a new endpoint segment
+(`bolt12` alongside `bolt11`) to redefining an existing one.
+
+## 9. Relation to `paykit-lib`
+
+In the reference implementation, a payment endpoint identifier is stored
+as a [`MethodId`](../paykit-lib/src/lib.rs). The `MethodId` constructor
+performs structural validation (character set, length, reserved values,
+path-traversal rejection) but does not enforce the three-segment shape
+defined here. Callers that want to verify conformance to this
+specification SHOULD apply an additional check on top of `MethodId::new`.
+
+The reserved identifier `private` is used internally by Paykit for
+private-payment storage paths; it is rejected at `MethodId` construction
+and therefore cannot appear as a conforming identifier under this
+specification either.
+
+## 10. Security considerations
+
+- Identifiers are untrusted input when received from a peer. Implementations
+  MUST treat them as opaque tokens and MUST NOT interpret any segment as a
+  filesystem path, URL component, or shell argument without prior
+  validation. `MethodId::new` already rejects path-traversal sequences;
+  callers interpolating identifiers into storage paths MUST continue to
+  route them through that validated constructor rather than using raw
+  strings.
+- Payload values may contain sensitive data (bank account numbers, real
+  names, recovery-style invoices). Public payment lists are visible to any
+  party that knows the payee's public key; authors MUST consider this when
+  deciding which endpoints to publish publicly versus privately. See the
+  "Private Payment Method Lists" section of the [README](../README.md) for
+  the private-list flow.
+- Byte-for-byte comparison (Section 4, rule 4) is a security property as
+  well as a correctness one: case-insensitive or normalising matchers can
+  cause a payer to treat two distinct identifiers as equivalent and select
+  the wrong endpoint.
+
+## 11. References
+
+- [RFC 2119]: Key words for use in RFCs to indicate requirement levels.
+- [RFC 5234]: Augmented BNF for Syntax Specifications: ABNF.
+- [ISO 4217]: Codes for the representation of currencies.
+- Paykit [README](../README.md): protocol overview and vocabulary.
+- Paykit contributor guide [AGENTS.md](../AGENTS.md): repository-level
+  conventions referenced by this document.
+
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119
+[RFC 5234]: https://www.rfc-editor.org/rfc/rfc5234
+[ISO 4217]: https://www.iso.org/iso-4217-currency-codes.html

--- a/specs/payment-endpoint-identifier.md
+++ b/specs/payment-endpoint-identifier.md
@@ -158,8 +158,9 @@ and arrays are not valid payloads.
 ### 7.2 Recommended field names
 
 Beyond `value`, a payload MAY contain any fields the endpoint format
-requires. Unknown fields MUST be ignored by receivers that do not recognise
-them.
+requires. Additional fields MAY be of any JSON type (string, number,
+boolean, array, or object), chosen to fit the data being represented.
+Unknown fields MUST be ignored by receivers that do not recognise them.
 
 The following field names are not required, but SHOULD be used where they
 apply, to keep naming consistent across endpoints:

--- a/specs/payment-endpoint-identifier.md
+++ b/specs/payment-endpoint-identifier.md
@@ -16,7 +16,7 @@ accompanies each identifier.
 
 The intent is to give implementers and downstream bindings (Swift, Kotlin,
 React Native) a single, consistent vocabulary to exchange, so that a payer
-and payee who independently support "`bitcoin-lightning-bolt12`" can recognise
+and payee who independently support "`btc-lightning-bolt12`" can recognise
 each other without side-channel coordination.
 
 ## 1. Status of this document
@@ -44,7 +44,7 @@ only when, they appear in all capitals.
 ## 3. Terminology
 
 - **Payment endpoint identifier** (or *identifier*): the three-segment string
-  that names a payment endpoint type, e.g. `bitcoin-onchain-p2tr`. In the
+  that names a payment endpoint type, e.g. `btc-bitcoin-p2tr`. In the
   Paykit library this is represented by the `MethodId` type.
 - **Payload**: the JSON object stored alongside the identifier, describing
   the specific payee handle for an endpoint of that type.
@@ -84,7 +84,7 @@ The following rules apply:
 
 The *asset* segment names the unit of value being transferred.
 
-- For cryptoassets, use the lowercased ticker (`bitcoin`, `usdt`, `eth`).
+- For cryptoassets, use the lowercased ticker (`btc`, `usdt`, `eth`).
 - For fiat, use the lowercased [ISO 4217] code (`usd`, `eur`, `gbp`).
 - The asset segment MUST NOT encode the chain or token standard; the rail
   segment disambiguates those.
@@ -93,7 +93,7 @@ The *asset* segment names the unit of value being transferred.
 
 The *rail* segment names the settlement system carrying the asset. Examples:
 
-- Base chain: `onchain`, `ethereum`, `solana`, `tron`.
+- Base chain: `bitcoin`, `ethereum`, `solana`, `tron`.
 - Layer-2 or off-chain: `lightning`, `liquid`, `arbitrum`.
 - Fiat network: `sepa`, `ach`, `fps`.
 - Custodial provider: `revolut`, `cashapp`, `wise`.
@@ -121,9 +121,9 @@ ambiguity or breaking changes.
 ### 6.1 Valid
 
 ```
-bitcoin-onchain-p2tr
-bitcoin-lightning-bolt11
-bitcoin-lightning-bolt12
+btc-bitcoin-p2tr
+btc-lightning-bolt11
+btc-lightning-bolt12
 usdt-ethereum-address
 usdt-tron-address
 usdc-solana-address
@@ -136,12 +136,12 @@ gbp-fps-sortcode
 
 | Identifier                     | Reason                                  |
 | ------------------------------ | --------------------------------------- |
-| `Bitcoin-onchain-p2tr`         | Uppercase characters are not permitted. |
+| `Btc-bitcoin-p2tr`             | Uppercase characters are not permitted. |
 | `usdt-ethereum`                | Endpoint segment is missing.            |
 | `gbp-faster-payments-sortcode` | Rail segment contains an internal `-`.  |
 | `usd-revolut-pay_link`         | Underscores are not permitted.          |
-| `-bitcoin-onchain-p2tr`        | Empty leading segment.                  |
-| `bitcoin--p2tr`                | Empty middle segment.                   |
+| `-btc-bitcoin-p2tr`            | Empty leading segment.                  |
+| `btc--p2tr`                    | Empty middle segment.                   |
 
 ## 7. Payload
 
@@ -186,12 +186,12 @@ the request describes a specific transfer.
 ### 7.4 Examples
 
 ```json
-// bitcoin-onchain-p2tr
+// btc-bitcoin-p2tr
 { "value": "bc1p..." }
 ```
 
 ```json
-// bitcoin-lightning-bolt12
+// btc-lightning-bolt12
 {
   "value": "lno1...",
   "min": "0.0001",


### PR DESCRIPTION
## Summary
- Adds `specs/payment-endpoint-identifier.md` (Draft v0.1), a recommended but non-obligatory convention for naming payment endpoints as three-segment `asset-rail-endpoint` strings, and the shape of the JSON payload that accompanies them.
- Explicitly ties the spec to the `MethodId` validation in [paykit-lib/src/lib.rs:129](paykit-lib/src/lib.rs) and notes where the spec is stricter than what the library enforces.
- Includes grammar (ABNF), segment rules, valid/invalid examples, payload conventions (`value` required; `min`/`max` and endpoint-specific fields recommended), extensibility notes, and a security considerations section.

## Notes for reviewers
- The document is marked Draft v0.1 and not normative: the intent is to publish an initial officially recommended convention that downstream bindings (Swift/Kotlin/RN) can align on, not to freeze anything.
- Single-canonical-address rails use `address` (`usdt-ethereum-address`, `usdt-tron-address`, `usdc-solana-address`). Rails with genuinely multiple address formats keep specific names (Bitcoin's `p2tr`, `p2wpkh`, etc.).
- No code changes; `MethodId` behaviour is unchanged.

## Test plan
- [ ] Render `specs/payment-endpoint-identifier.md` on GitHub and confirm tables, ABNF block, and links (README, AGENTS.md, paykit-lib/src/lib.rs) resolve.
- [ ] Confirm the examples in §6.1 all pass `MethodId::new` and the examples in §6.2 would fail structural validation or the conformance rules in §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)