### PR TITLE
[codex] Use GitHub token for package publish

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -47,6 +47,6 @@ jobs:
       working-directory: paykit-ffi/bindings/android
       env:
         GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.ORG_PACKAGES_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
         GITHUB_REPO: ${{ github.repository }}
       run: ./gradlew publish -Pversion=${{ steps.version.outputs.version }}


### PR DESCRIPTION
## What changed
- Use the built-in GitHub Actions token for the Android Gradle publish step instead of the ORG_PACKAGES_TOKEN secret.

## Why
The release publish job only needs to publish GitHub Packages for this repository, and the workflow already grants packages: write. Using github.token avoids failures from an expired org-level PAT.

## Checks
- Parsed .github/workflows/gradle-publish.yml as YAML with Ruby
- git diff --check