### PR TITLE
Add Paykit SDK foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 
@@ -3145,6 +3146,20 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "paykit-sdk"
+version = "0.1.0-rc12"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "paykit-lib",
+ "pubky",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["paykit-lib", "paykit-ffi"]
+members = ["paykit-lib", "paykit-ffi", "paykit-sdk"]

--- a/paykit-sdk/Cargo.toml
+++ b/paykit-sdk/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "paykit-sdk"
+version = "0.1.0-rc12"
+authors = ["denys@synonym.to"]
+description = "Stateful Paykit SDK runtime"
+license = "MIT"
+edition = "2021"
+rust-version = "1.91.1"
+repository = "https://github.com/pubky/paykit-rs"
+homepage = "https://github.com/pubky/paykit-rs#readme"
+documentation = "https://docs.rs/paykit-sdk"
+readme = "../README.md"
+keywords = ["paykit", "payments", "routing", "pubky"]
+categories = ["network-programming", "finance"]
+
+[dependencies]
+anyhow = "1.0.102"
+async-trait = "0.1"
+chrono = { version = "0.4.44", default-features = false, features = ["clock", "serde", "std"] }
+paykit-lib = { path = "../paykit-lib", version = "0.1.0-rc12" }
+pubky = "0.8.0"
+serde = { version = "1", features = ["derive"] }
+thiserror = "2.0.18"
+
+[dev-dependencies]
+tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }

--- a/paykit-sdk/src/adapters.rs
+++ b/paykit-sdk/src/adapters.rs
@@ -1,0 +1,189 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::{identity::PubkyPublicKey, PubkySessionAccess, Result};
+
+/// Provides local Pubky session material to the SDK.
+#[async_trait]
+pub trait PubkySessionProvider: Send + Sync {
+    /// Load live Pubky access for storage and Encrypted Link workflows.
+    async fn load_session_access(&self) -> Result<Option<PubkySessionAccess>>;
+
+    /// Clear local Pubky session access during sign-out.
+    async fn clear_session_access(&self) -> Result<()>;
+}
+
+/// Adapter for payment-method-specific endpoint and execution behavior.
+#[async_trait]
+pub trait PaymentAdapter: Send + Sync {
+    /// Return current receiving details for a scope.
+    async fn current_receiving_details(
+        &self,
+        scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>>;
+
+    /// Check whether the app/payment backend can pay an endpoint.
+    async fn is_endpoint_payable(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<EndpointCompatibility>;
+
+    /// Build a payment target from a compatible endpoint.
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget>;
+
+    /// Execute a Payment Request through the payment backend.
+    async fn execute_payment_request(
+        &self,
+        request: &PaymentRequestExecution,
+    ) -> Result<PaymentExecutionResult>;
+}
+
+/// Optional adapter for contact-scoped or single-use receiving details.
+#[async_trait]
+pub trait EndpointReservationAdapter: Send + Sync {
+    /// Reserve receiving details for a counterparty/method.
+    async fn reserve(
+        &self,
+        counterparty: PubkyPublicKey,
+        method: paykit_lib::PaymentEndpointIdentifier,
+    ) -> Result<ReservedReceivingDetail>;
+
+    /// Rotate reserved receiving details after use.
+    async fn rotate_after_use(
+        &self,
+        reservation_id: ReservationId,
+    ) -> Result<Option<ReservedReceivingDetail>>;
+}
+
+/// Optional adapter for platform/runtime scheduling.
+#[async_trait]
+pub trait SchedulerAdapter: Send + Sync {
+    /// Schedule a recurring payment job.
+    async fn schedule(&self, job: ScheduledPaymentJob) -> Result<()>;
+
+    /// Cancel a scheduled job.
+    async fn cancel(&self, job_id: ScheduledJobId) -> Result<()>;
+}
+
+/// Minimal profile data used by SDK-managed Paykit-facing workflows.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProfileRecord {
+    /// Profile owner public key.
+    pub public_key: PubkyPublicKey,
+    /// Optional display name.
+    pub display_name: Option<String>,
+    /// Optional image pointer.
+    pub image: Option<String>,
+}
+
+/// Minimal contact data used by SDK-managed Paykit-facing workflows.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContactRecord {
+    /// Contact public key.
+    pub public_key: PubkyPublicKey,
+    /// Optional local display snapshot.
+    pub display_name: Option<String>,
+}
+
+/// Paykit-facing profile update requested by the app.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProfileUpdate {
+    /// Optional display name.
+    pub display_name: Option<String>,
+    /// Optional image pointer.
+    pub image: Option<String>,
+}
+
+/// Scope used when asking for receiving details.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReceivingDetailScope {
+    /// Details intended for public Payment Endpoints.
+    Public,
+    /// Details intended for one counterparty's Private Payment List.
+    Private { counterparty: PubkyPublicKey },
+}
+
+/// Payment-method-specific receiving detail returned by an adapter.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceivingDetail {
+    /// Paykit endpoint identifier.
+    pub identifier: String,
+    /// Serialized endpoint payload.
+    pub payload: String,
+}
+
+/// Candidate endpoint to check or pay.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentEndpointCandidate {
+    /// Counterparty that published the endpoint.
+    pub counterparty: PubkyPublicKey,
+    /// Paykit endpoint identifier.
+    pub identifier: String,
+    /// Serialized endpoint payload.
+    pub payload: String,
+}
+
+/// Compatibility result for one endpoint.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EndpointCompatibility {
+    /// The endpoint can be paid by the adapter.
+    Payable,
+    /// The endpoint kind is unsupported.
+    Unsupported { reason: Option<String> },
+    /// The endpoint is recognized but stale/unusable.
+    Stale { reason: Option<String> },
+}
+
+/// Payment target produced by an adapter.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentTarget {
+    /// Method-specific target payload.
+    pub payload: String,
+}
+
+/// Payment Request execution input passed to an adapter.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentRequestExecution {
+    /// Payment Request ID.
+    pub payment_request_id: String,
+    /// Method-specific payment target.
+    pub target: PaymentTarget,
+}
+
+/// Result returned after payment execution.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentExecutionResult {
+    /// Method-specific proof payload, if available.
+    pub proof: Option<String>,
+    /// Whether the payment backend considers the payment settled.
+    pub settled: bool,
+}
+
+/// Identifier for adapter-managed endpoint reservations.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ReservationId(pub String);
+
+/// Reserved receiving detail returned by an adapter.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReservedReceivingDetail {
+    /// Adapter reservation identifier.
+    pub reservation_id: ReservationId,
+    /// Receiving detail bound to the reservation.
+    pub receiving_detail: ReceivingDetail,
+}
+
+/// Identifier for scheduled jobs.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ScheduledJobId(pub String);
+
+/// Recurring payment job passed to the scheduler adapter.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScheduledPaymentJob {
+    /// Job identifier.
+    pub job_id: ScheduledJobId,
+    /// Payment Request ID associated with the job.
+    pub payment_request_id: String,
+}

--- a/paykit-sdk/src/backup.rs
+++ b/paykit-sdk/src/backup.rs
@@ -1,0 +1,10 @@
+//! SDK-managed backup records.
+
+use serde::{Deserialize, Serialize};
+
+/// Metadata for an SDK backup payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SdkBackupMetadata {
+    /// SDK backup schema version.
+    pub version: u32,
+}

--- a/paykit-sdk/src/config.rs
+++ b/paykit-sdk/src/config.rs
@@ -1,0 +1,83 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// Policy for SDK-managed public Payment Endpoint cleanup.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EndpointManagementScope {
+    /// Manage only endpoints previously published by the SDK.
+    ManagedOnly,
+    /// Manage the full local Paykit public namespace.
+    FullPaykitNamespace,
+}
+
+/// Policy for private Payment List sharing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PrivateSharingPolicy {
+    /// Private sharing is enabled when the identity is private-link-capable.
+    Enabled,
+    /// Private sharing is disabled by local policy.
+    Disabled,
+}
+
+/// Policy for falling back to public Payment Endpoints.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PublicFallbackPolicy {
+    /// Never fall back to public endpoints.
+    Disabled,
+    /// Use public endpoints when no private endpoint is available.
+    WhenPrivateUnavailable,
+    /// Try bounded private recovery before falling back to public endpoints.
+    AfterPrivateRecoveryTimeout,
+}
+
+/// Retention limits for unknown Private Application Messages.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnknownMessageRetentionPolicy {
+    /// Maximum unknown messages retained per counterparty.
+    pub max_messages_per_counterparty: usize,
+    /// Maximum unknown message bytes retained per counterparty.
+    pub max_bytes_per_counterparty: usize,
+    /// Maximum retention duration.
+    pub retention_duration: Duration,
+    /// Whether unknown messages may be discarded when limits are reached.
+    pub allow_discard: bool,
+}
+
+impl Default for UnknownMessageRetentionPolicy {
+    fn default() -> Self {
+        Self {
+            max_messages_per_counterparty: 1_000,
+            max_bytes_per_counterparty: 512 * 1024,
+            retention_duration: Duration::from_secs(60 * 60 * 24 * 30),
+            allow_discard: true,
+        }
+    }
+}
+
+/// Runtime configuration for Paykit SDK.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaykitSdkConfig {
+    /// Public endpoint management scope.
+    pub endpoint_management_scope: EndpointManagementScope,
+    /// Private endpoint sharing policy.
+    pub private_sharing: PrivateSharingPolicy,
+    /// Public fallback behavior.
+    pub public_fallback: PublicFallbackPolicy,
+    /// Maximum time to spend on private recovery before returning/falling back.
+    pub private_recovery_timeout: Duration,
+    /// Unknown private message retention limits.
+    pub unknown_message_retention: UnknownMessageRetentionPolicy,
+}
+
+impl Default for PaykitSdkConfig {
+    fn default() -> Self {
+        Self {
+            endpoint_management_scope: EndpointManagementScope::ManagedOnly,
+            private_sharing: PrivateSharingPolicy::Enabled,
+            public_fallback: PublicFallbackPolicy::AfterPrivateRecoveryTimeout,
+            private_recovery_timeout: Duration::from_secs(3),
+            unknown_message_retention: UnknownMessageRetentionPolicy::default(),
+        }
+    }
+}

--- a/paykit-sdk/src/contacts.rs
+++ b/paykit-sdk/src/contacts.rs
@@ -1,0 +1,16 @@
+//! Contact records and contact payment resolution types.
+
+/// Result category for contact payment resolution.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ContactPaymentResolutionStatus {
+    /// A payable endpoint was found.
+    Payable,
+    /// No endpoint was found.
+    NoEndpoint,
+    /// Endpoints exist but are unsupported.
+    UnsupportedEndpoint,
+    /// Private recovery is still in progress.
+    PrivateRecoveryPending,
+    /// The local identity cannot establish private links.
+    PublicOnlySession,
+}

--- a/paykit-sdk/src/endpoints.rs
+++ b/paykit-sdk/src/endpoints.rs
@@ -1,0 +1,18 @@
+//! Public Payment Endpoint sync records.
+
+use serde::{Deserialize, Serialize};
+
+/// Publication status for a SDK-managed Payment Endpoint.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EndpointPublicationStatus {
+    /// The endpoint should be published.
+    Desired,
+    /// The endpoint is confirmed as published.
+    Published,
+    /// The endpoint should be removed.
+    PendingRemoval,
+    /// The endpoint is confirmed removed.
+    Removed,
+    /// The last publication attempt failed.
+    Failed,
+}

--- a/paykit-sdk/src/error.rs
+++ b/paykit-sdk/src/error.rs
@@ -1,0 +1,78 @@
+use thiserror::Error;
+
+/// Error type for stateful Paykit SDK workflows.
+#[derive(Debug, Error)]
+pub enum PaykitSdkError {
+    /// Durable storage failed.
+    #[error("storage error: {context}")]
+    Storage {
+        /// Human-readable failure context.
+        context: String,
+        /// Underlying cause, when available.
+        #[source]
+        source: Option<anyhow::Error>,
+    },
+
+    /// Pubky identity, session, or key capability failed.
+    #[error("identity error: {context}")]
+    Identity {
+        /// Human-readable failure context.
+        context: String,
+        /// Underlying cause, when available.
+        #[source]
+        source: Option<anyhow::Error>,
+    },
+
+    /// Pubky or Encrypted Link transport failed.
+    #[error("transport error: {context}")]
+    Transport {
+        /// Human-readable failure context.
+        context: String,
+        /// Underlying cause, when available.
+        #[source]
+        source: Option<anyhow::Error>,
+    },
+
+    /// Paykit protocol data is invalid, conflicting, or unsupported.
+    #[error("protocol error: {0}")]
+    Protocol(String),
+
+    /// Operation is blocked by configured SDK policy.
+    #[error("policy error: {0}")]
+    Policy(String),
+
+    /// Payment adapter failed.
+    #[error("payment adapter error: {context}")]
+    PaymentAdapter {
+        /// Human-readable failure context.
+        context: String,
+        /// Underlying cause, when available.
+        #[source]
+        source: Option<anyhow::Error>,
+    },
+
+    /// Local state needs explicit recovery before automation can continue.
+    #[error("recovery required: {0}")]
+    RecoveryRequired(String),
+}
+
+impl From<paykit_lib::PaykitError> for PaykitSdkError {
+    fn from(err: paykit_lib::PaykitError) -> Self {
+        match err {
+            paykit_lib::PaykitError::Transport { context, source } => Self::Transport {
+                context,
+                source: Some(source),
+            },
+            paykit_lib::PaykitError::NotFound(msg) => Self::Transport {
+                context: msg,
+                source: None,
+            },
+            paykit_lib::PaykitError::InvalidData { context, source } => Self::Protocol(
+                source
+                    .map(|source| format!("{context}: {source}"))
+                    .unwrap_or(context),
+            ),
+            paykit_lib::PaykitError::Validation(msg) => Self::Protocol(msg),
+        }
+    }
+}

--- a/paykit-sdk/src/identity.rs
+++ b/paykit-sdk/src/identity.rs
@@ -1,0 +1,173 @@
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Pubky public key string used by SDK records.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PubkyPublicKey(String);
+
+impl PubkyPublicKey {
+    /// Create a public key wrapper from a non-empty string.
+    pub fn new(value: impl Into<String>) -> crate::Result<Self> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(crate::PaykitSdkError::Identity {
+                context: "Pubky public key must not be empty".into(),
+                source: None,
+            });
+        }
+        Ok(Self(value))
+    }
+
+    /// Access the inner public key string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PubkyPublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for PubkyPublicKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Pubky capability state visible to Paykit workflows.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PubkyIdentityCapability {
+    /// No local Pubky session is available.
+    SignedOut,
+    /// Public Pubky operations may work, but private links cannot be established.
+    PublicOnly,
+    /// Public operations and Encrypted Links can work.
+    PrivateLinkCapable,
+}
+
+/// Local Pubky secret key used for Encrypted Links.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PubkyLocalSecretKey([u8; 32]);
+
+impl PubkyLocalSecretKey {
+    /// Wrap a 32-byte local secret key.
+    pub fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the secret key bytes.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Consume the wrapper and return the secret key bytes.
+    pub fn into_inner(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl fmt::Debug for PubkyLocalSecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PubkyLocalSecretKey(<redacted>)")
+    }
+}
+
+impl From<[u8; 32]> for PubkyLocalSecretKey {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self::new(bytes)
+    }
+}
+
+/// Live Pubky access used by SDK workflows that touch Pubky storage or links.
+#[derive(Clone)]
+pub struct PubkySessionAccess {
+    /// Authenticated Pubky session for local homeserver writes.
+    pub session: pubky::PubkySession,
+    /// Pubky client used for counterparty homeserver access.
+    pub outbox_client: pubky::Pubky,
+    /// Local secret key required for Encrypted Links, when available.
+    pub local_secret_key: Option<PubkyLocalSecretKey>,
+}
+
+impl PubkySessionAccess {
+    /// Return the local Pubky public key.
+    pub fn public_key(&self) -> crate::Result<PubkyPublicKey> {
+        PubkyPublicKey::new(self.session.info().public_key().to_string())
+    }
+
+    /// Return the Paykit capability implied by this access.
+    pub fn capability(&self) -> PubkyIdentityCapability {
+        if self.private_link_capable() {
+            PubkyIdentityCapability::PrivateLinkCapable
+        } else {
+            PubkyIdentityCapability::PublicOnly
+        }
+    }
+
+    /// Whether this access can establish Encrypted Links.
+    pub fn private_link_capable(&self) -> bool {
+        self.local_secret_key.is_some()
+    }
+}
+
+impl fmt::Debug for PubkySessionAccess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PubkySessionAccess")
+            .field("session", &"<redacted>")
+            .field("outbox_client", &self.outbox_client)
+            .field("local_secret_key", &self.local_secret_key)
+            .finish()
+    }
+}
+
+/// Durable identity state tracked by the SDK.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityState {
+    /// Current local public key, when signed in.
+    pub public_key: Option<PubkyPublicKey>,
+    /// Current Pubky capability.
+    pub capability: PubkyIdentityCapability,
+    /// Whether the local secret key is available to the SDK.
+    pub local_secret_available: bool,
+    /// Last successful initialization time.
+    pub initialized_at: DateTime<Utc>,
+    /// Monotonic generation used to separate state across sign-outs.
+    pub sign_out_generation: u64,
+}
+
+/// Current identity status returned to apps.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityStatus {
+    /// Current local public key, when signed in.
+    pub public_key: Option<PubkyPublicKey>,
+    /// Current Pubky capability.
+    pub capability: PubkyIdentityCapability,
+    /// Whether private Paykit workflows can run.
+    pub private_link_capable: bool,
+}
+
+impl From<&IdentityState> for IdentityStatus {
+    fn from(state: &IdentityState) -> Self {
+        Self {
+            public_key: state.public_key.clone(),
+            capability: state.capability,
+            private_link_capable: state.capability == PubkyIdentityCapability::PrivateLinkCapable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pubky_local_secret_key_debug_is_redacted() {
+        let key = PubkyLocalSecretKey::new([7; 32]);
+
+        assert_eq!(format!("{key:?}"), "PubkyLocalSecretKey(<redacted>)");
+    }
+}

--- a/paykit-sdk/src/lib.rs
+++ b/paykit-sdk/src/lib.rs
@@ -1,0 +1,51 @@
+#![doc = "Stateful runtime layer for Paykit integrations."]
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub mod adapters;
+pub mod backup;
+pub mod config;
+pub mod contacts;
+pub mod endpoints;
+pub mod error;
+pub mod identity;
+pub mod linked_peers;
+pub mod payment_requests;
+pub mod private_lists;
+pub mod private_stream;
+pub mod receipts;
+pub mod reservations;
+pub mod runtime;
+pub mod scheduler;
+pub mod storage;
+pub mod telemetry;
+
+#[doc(inline)]
+pub use adapters::{
+    ContactRecord, EndpointCompatibility, EndpointReservationAdapter, PaymentAdapter,
+    PaymentEndpointCandidate, PaymentExecutionResult, PaymentRequestExecution, PaymentTarget,
+    ProfileRecord, ProfileUpdate, PubkySessionProvider, ReceivingDetail, ReceivingDetailScope,
+    ReservedReceivingDetail, SchedulerAdapter,
+};
+#[doc(inline)]
+pub use config::{
+    EndpointManagementScope, PaykitSdkConfig, PrivateSharingPolicy, PublicFallbackPolicy,
+    UnknownMessageRetentionPolicy,
+};
+#[doc(inline)]
+pub use error::PaykitSdkError;
+#[doc(inline)]
+pub use identity::{
+    IdentityState, IdentityStatus, PubkyIdentityCapability, PubkyLocalSecretKey, PubkyPublicKey,
+    PubkySessionAccess,
+};
+#[doc(inline)]
+pub use runtime::{Clock, InitializationReport, PaykitSdk, SystemClock};
+#[doc(inline)]
+pub use storage::{
+    EncryptedLinkStateRecord, EventDedupRecord, InMemoryStorage, LinkedPeerRecord,
+    NewPrivateStreamItem, PrivateStreamItemRecord, StorageAdapter, StorageState,
+    StorageTransaction,
+};
+
+/// Common result alias for Paykit SDK operations.
+pub type Result<T> = std::result::Result<T, PaykitSdkError>;

--- a/paykit-sdk/src/linked_peers.rs
+++ b/paykit-sdk/src/linked_peers.rs
@@ -1,0 +1,18 @@
+//! Linked Peer state records.
+
+use serde::{Deserialize, Serialize};
+
+/// Local relationship state for a counterparty.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LinkedPeerState {
+    /// The counterparty is not known locally.
+    Unknown,
+    /// The counterparty is known but no active Encrypted Link exists.
+    Known,
+    /// An Encrypted Link is established.
+    Linked,
+    /// Local state cannot safely continue without recovery.
+    RecoveryRequired,
+    /// Local policy blocks this peer.
+    Blocked,
+}

--- a/paykit-sdk/src/payment_requests.rs
+++ b/paykit-sdk/src/payment_requests.rs
@@ -1,0 +1,28 @@
+//! Payment Request lifecycle records.
+
+use serde::{Deserialize, Serialize};
+
+/// Local SDK lifecycle state for a Payment Request.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PaymentRequestLifecycleState {
+    /// Proposal has been received or sent.
+    Proposed,
+    /// Proposal expired before acceptance.
+    ProposalExpired,
+    /// Payer accepted the request.
+    Accepted,
+    /// Payer rejected the request.
+    Rejected,
+    /// Request was canceled.
+    Canceled,
+    /// Payment Proof was submitted.
+    ProofSubmitted,
+    /// Recurring request is active.
+    ActiveRecurring,
+    /// Automatic execution is paused.
+    Paused,
+    /// Local state requires recovery.
+    RecoveryRequired,
+    /// Conflicting events made local state invalid.
+    InvalidConflict,
+}

--- a/paykit-sdk/src/private_lists.rs
+++ b/paykit-sdk/src/private_lists.rs
@@ -1,0 +1,14 @@
+//! Private Payment List latest-state records.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Derived latest-state view of a counterparty's Private Payment List.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrivatePaymentListView {
+    /// Stream item id of the latest valid list.
+    pub latest_stream_item_id: Option<u64>,
+    /// Current endpoint payloads keyed by identifier string.
+    pub payment_endpoints: HashMap<String, String>,
+}

--- a/paykit-sdk/src/private_stream.rs
+++ b/paykit-sdk/src/private_stream.rs
@@ -1,0 +1,16 @@
+//! Durable private stream records.
+
+use serde::{Deserialize, Serialize};
+
+/// Parse status for one received Private Application Message.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PrivateStreamParseStatus {
+    /// Message parsed as a valid recognized Paykit message.
+    Valid,
+    /// Message kind is recognized, but payload is malformed.
+    MalformedRecognized,
+    /// Message has a valid private header but unknown kind.
+    UnknownKind,
+    /// Message is not valid JSON or does not have a usable private header.
+    InvalidJson,
+}

--- a/paykit-sdk/src/receipts.rs
+++ b/paykit-sdk/src/receipts.rs
@@ -1,0 +1,14 @@
+//! Receipt Access and Receipt indexing records.
+
+use serde::{Deserialize, Serialize};
+
+/// Retrieval status for an Encrypted Receipt.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReceiptRetrievalState {
+    /// Receipt Access was received, but the receipt has not been fetched.
+    Pending,
+    /// Receipt was fetched and decrypted.
+    Retrieved,
+    /// Retrieval or decryption failed.
+    Failed,
+}

--- a/paykit-sdk/src/reservations.rs
+++ b/paykit-sdk/src/reservations.rs
@@ -1,0 +1,16 @@
+//! Endpoint reservation records.
+
+use serde::{Deserialize, Serialize};
+
+/// SDK state for an endpoint reservation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EndpointReservationState {
+    /// Reservation can still be used.
+    Active,
+    /// Reservation was used.
+    Used,
+    /// Reservation was rotated after use.
+    Rotated,
+    /// Reservation was retired.
+    Retired,
+}

--- a/paykit-sdk/src/runtime.rs
+++ b/paykit-sdk/src/runtime.rs
@@ -1,0 +1,224 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::PaykitSdkConfig,
+    identity::{IdentityState, IdentityStatus, PubkyIdentityCapability},
+    storage::StorageAdapter,
+    PaymentAdapter, PubkySessionProvider, Result,
+};
+
+/// Clock abstraction used by SDK workflows and tests.
+pub trait Clock: Clone + Send + Sync + 'static {
+    /// Return the current UTC time.
+    fn now(&self) -> DateTime<Utc>;
+}
+
+/// System UTC clock.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+/// Initialization report returned after SDK startup.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InitializationReport {
+    /// Current identity status.
+    pub identity: IdentityStatus,
+}
+
+/// Stateful Paykit SDK runtime for one local Pubky identity.
+pub struct PaykitSdk<S, K, P, C = SystemClock> {
+    storage: S,
+    pubky: K,
+    payment: P,
+    config: PaykitSdkConfig,
+    clock: C,
+}
+
+impl<S, K, P> PaykitSdk<S, K, P, SystemClock>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+{
+    /// Create an SDK runtime with the system clock.
+    pub fn new(storage: S, pubky: K, payment: P, config: PaykitSdkConfig) -> Self {
+        Self::with_clock(storage, pubky, payment, config, SystemClock)
+    }
+}
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Create an SDK runtime with an explicit clock.
+    pub fn with_clock(storage: S, pubky: K, payment: P, config: PaykitSdkConfig, clock: C) -> Self {
+        Self {
+            storage,
+            pubky,
+            payment,
+            config,
+            clock,
+        }
+    }
+
+    /// Initialize durable SDK identity state.
+    pub async fn initialize(&self) -> Result<InitializationReport> {
+        let session = self.pubky.load_session_access().await?;
+        let (public_key, capability) = match session.as_ref() {
+            Some(session) => (Some(session.public_key()?), session.capability()),
+            None => (None, PubkyIdentityCapability::SignedOut),
+        };
+        let state = IdentityState {
+            public_key,
+            local_secret_available: capability == PubkyIdentityCapability::PrivateLinkCapable,
+            capability,
+            initialized_at: self.clock.now(),
+            sign_out_generation: self
+                .storage
+                .load_identity_state()
+                .await?
+                .map(|state| state.sign_out_generation)
+                .unwrap_or_default(),
+        };
+
+        self.storage.save_identity_state(state.clone()).await?;
+
+        Ok(InitializationReport {
+            identity: IdentityStatus::from(&state),
+        })
+    }
+
+    /// Return the last persisted identity status, if initialized.
+    pub async fn identity_status(&self) -> Result<Option<IdentityStatus>> {
+        Ok(self
+            .storage
+            .load_identity_state()
+            .await?
+            .as_ref()
+            .map(IdentityStatus::from))
+    }
+
+    /// Access SDK configuration.
+    pub fn config(&self) -> &PaykitSdkConfig {
+        &self.config
+    }
+
+    /// Access the payment adapter.
+    pub fn payment_adapter(&self) -> &P {
+        &self.payment
+    }
+
+    /// Access the Pubky session provider.
+    pub fn pubky_session_provider(&self) -> &K {
+        &self.pubky
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+    use crate::{
+        adapters::{
+            EndpointCompatibility, PaymentEndpointCandidate, PaymentExecutionResult,
+            PaymentRequestExecution, PaymentTarget, ReceivingDetail, ReceivingDetailScope,
+        },
+        storage::InMemoryStorage,
+        PubkySessionAccess,
+    };
+
+    #[derive(Clone)]
+    struct FixedClock;
+
+    impl Clock for FixedClock {
+        fn now(&self) -> DateTime<Utc> {
+            Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+        }
+    }
+
+    struct TestPubkySessionProvider {
+        session: Option<PubkySessionAccess>,
+    }
+
+    #[async_trait]
+    impl PubkySessionProvider for TestPubkySessionProvider {
+        async fn load_session_access(&self) -> Result<Option<PubkySessionAccess>> {
+            Ok(self.session.clone())
+        }
+
+        async fn clear_session_access(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    struct TestPaymentAdapter;
+
+    #[async_trait]
+    impl PaymentAdapter for TestPaymentAdapter {
+        async fn current_receiving_details(
+            &self,
+            _scope: ReceivingDetailScope,
+        ) -> Result<Vec<ReceivingDetail>> {
+            Ok(Vec::new())
+        }
+
+        async fn is_endpoint_payable(
+            &self,
+            _endpoint: &PaymentEndpointCandidate,
+        ) -> Result<EndpointCompatibility> {
+            Ok(EndpointCompatibility::Unsupported { reason: None })
+        }
+
+        async fn build_payment_target(
+            &self,
+            endpoint: &PaymentEndpointCandidate,
+        ) -> Result<PaymentTarget> {
+            Ok(PaymentTarget {
+                payload: endpoint.payload.clone(),
+            })
+        }
+
+        async fn execute_payment_request(
+            &self,
+            _request: &PaymentRequestExecution,
+        ) -> Result<PaymentExecutionResult> {
+            Ok(PaymentExecutionResult {
+                proof: None,
+                settled: false,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_initialize_persists_signed_out_identity() {
+        let storage = InMemoryStorage::new();
+        let pubky = TestPubkySessionProvider { session: None };
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            pubky,
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let report = sdk.initialize().await.unwrap();
+
+        assert!(!report.identity.private_link_capable);
+        let stored = storage.snapshot().unwrap().identity_state.unwrap();
+        assert!(stored.public_key.is_none());
+        assert_eq!(stored.capability, PubkyIdentityCapability::SignedOut);
+        assert!(!stored.local_secret_available);
+        assert_eq!(stored.initialized_at, FixedClock.now());
+    }
+}

--- a/paykit-sdk/src/scheduler.rs
+++ b/paykit-sdk/src/scheduler.rs
@@ -1,0 +1,14 @@
+//! Recurring Payment Request scheduling records.
+
+use serde::{Deserialize, Serialize};
+
+/// Local scheduling state for a recurring Payment Request.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SchedulingState {
+    /// No scheduled job exists.
+    NotScheduled,
+    /// A scheduled job exists.
+    Scheduled,
+    /// Scheduling is paused.
+    Paused,
+}

--- a/paykit-sdk/src/storage.rs
+++ b/paykit-sdk/src/storage.rs
@@ -1,0 +1,417 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    identity::{IdentityState, PubkyPublicKey},
+    linked_peers::LinkedPeerState,
+    private_stream::PrivateStreamParseStatus,
+    PaykitSdkError, Result,
+};
+
+/// Durable storage boundary for Paykit SDK.
+#[async_trait]
+pub trait StorageAdapter: Send + Sync {
+    /// Run an atomic storage transaction.
+    async fn transaction<T, F>(&self, f: F) -> Result<T>
+    where
+        T: Send,
+        F: FnOnce(&mut dyn StorageTransaction) -> Result<T> + Send;
+
+    /// Load the current identity state.
+    async fn load_identity_state(&self) -> Result<Option<IdentityState>> {
+        self.transaction(|tx| Ok(tx.load_identity_state())).await
+    }
+
+    /// Save the current identity state atomically.
+    async fn save_identity_state(&self, state: IdentityState) -> Result<()> {
+        self.transaction(move |tx| {
+            tx.save_identity_state(state);
+            Ok(())
+        })
+        .await
+    }
+}
+
+/// Mutable operations available inside one storage transaction.
+pub trait StorageTransaction {
+    /// Load the current identity state.
+    fn load_identity_state(&self) -> Option<IdentityState>;
+
+    /// Save the current identity state.
+    fn save_identity_state(&mut self, state: IdentityState);
+
+    /// Load one Linked Peer record.
+    fn linked_peer(&self, counterparty: &PubkyPublicKey) -> Option<LinkedPeerRecord>;
+
+    /// Save one Linked Peer record.
+    fn save_linked_peer(&mut self, record: LinkedPeerRecord);
+
+    /// Load one Encrypted Link state record.
+    fn encrypted_link_state(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Option<EncryptedLinkStateRecord>;
+
+    /// Save one Encrypted Link state record.
+    fn save_encrypted_link_state(&mut self, record: EncryptedLinkStateRecord);
+
+    /// Insert one private stream item and return its assigned id.
+    fn insert_private_stream_item(&mut self, item: NewPrivateStreamItem) -> u64;
+
+    /// List private stream items for a counterparty.
+    fn private_stream_items(&self, counterparty: &PubkyPublicKey) -> Vec<PrivateStreamItemRecord>;
+
+    /// Load an Event Message dedupe record.
+    fn event_dedup_record(&self, event_id: &str) -> Option<EventDedupRecord>;
+
+    /// Save an Event Message dedupe record.
+    fn save_event_dedup_record(&mut self, record: EventDedupRecord);
+}
+
+/// Durable Linked Peer state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinkedPeerRecord {
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Current local relationship/link state.
+    pub state: LinkedPeerState,
+    /// Last successful sync time.
+    pub last_sync_at: Option<DateTime<Utc>>,
+    /// Last private receive time.
+    pub last_private_receive_at: Option<DateTime<Utc>>,
+    /// Consecutive failure count for recovery/retry policy.
+    pub failure_count: u32,
+}
+
+/// Durable Encrypted Link snapshot state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EncryptedLinkStateRecord {
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Serialized active link snapshot.
+    pub link_snapshot: Option<Vec<u8>>,
+    /// Serialized in-progress handshake snapshot.
+    pub handshake_snapshot: Option<Vec<u8>>,
+    /// Local snapshot generation.
+    pub generation: u64,
+    /// Last checkpoint time.
+    pub checkpointed_at: DateTime<Utc>,
+}
+
+/// New private stream item before storage assigns an id.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NewPrivateStreamItem {
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Receive batch id assigned by the SDK runtime.
+    pub receive_batch_id: u64,
+    /// Raw JSON payload.
+    pub raw_json: String,
+    /// Parsed Private Application Message version.
+    pub parsed_version: Option<u32>,
+    /// Parsed Private Application Message kind.
+    pub parsed_kind: Option<String>,
+    /// Whether the kind is a known Paykit kind.
+    pub known_paykit_kind: Option<String>,
+    /// Parse status.
+    pub parse_status: PrivateStreamParseStatus,
+    /// Parse error, when available.
+    pub parse_error: Option<String>,
+    /// Receive time.
+    pub received_at: DateTime<Utc>,
+}
+
+/// Durable private stream item.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrivateStreamItemRecord {
+    /// Assigned stream item id.
+    pub stream_item_id: u64,
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Receive batch id assigned by the SDK runtime.
+    pub receive_batch_id: u64,
+    /// Raw JSON payload.
+    pub raw_json: String,
+    /// Parsed Private Application Message version.
+    pub parsed_version: Option<u32>,
+    /// Parsed Private Application Message kind.
+    pub parsed_kind: Option<String>,
+    /// Whether the kind is a known Paykit kind.
+    pub known_paykit_kind: Option<String>,
+    /// Parse status.
+    pub parse_status: PrivateStreamParseStatus,
+    /// Parse error, when available.
+    pub parse_error: Option<String>,
+    /// Receive time.
+    pub received_at: DateTime<Utc>,
+}
+
+impl PrivateStreamItemRecord {
+    fn from_new(stream_item_id: u64, item: NewPrivateStreamItem) -> Self {
+        Self {
+            stream_item_id,
+            counterparty: item.counterparty,
+            receive_batch_id: item.receive_batch_id,
+            raw_json: item.raw_json,
+            parsed_version: item.parsed_version,
+            parsed_kind: item.parsed_kind,
+            known_paykit_kind: item.known_paykit_kind,
+            parse_status: item.parse_status,
+            parse_error: item.parse_error,
+            received_at: item.received_at,
+        }
+    }
+}
+
+/// Event Message dedupe/conflict record.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventDedupRecord {
+    /// Event ID.
+    pub event_id: String,
+    /// Event kind.
+    pub event_kind: String,
+    /// Canonical payload hash.
+    pub canonical_payload_hash: String,
+    /// First stream item that carried the event.
+    pub first_stream_item_id: u64,
+    /// Duplicate stream items with the same payload.
+    pub duplicate_stream_item_ids: Vec<u64>,
+    /// Conflicting stream items that reused the Event ID with a different payload.
+    pub conflicting_stream_item_ids: Vec<u64>,
+}
+
+/// In-memory storage state used for tests and examples.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct StorageState {
+    /// Current identity state.
+    pub identity_state: Option<IdentityState>,
+    /// Linked Peer records by counterparty.
+    pub linked_peers: HashMap<PubkyPublicKey, LinkedPeerRecord>,
+    /// Encrypted Link state records by counterparty.
+    pub encrypted_link_states: HashMap<PubkyPublicKey, EncryptedLinkStateRecord>,
+    /// Append-only private stream items.
+    pub private_stream_items: Vec<PrivateStreamItemRecord>,
+    /// Next private stream item id.
+    pub next_private_stream_item_id: u64,
+    /// Event dedupe records by Event ID.
+    pub event_dedup_records: HashMap<String, EventDedupRecord>,
+}
+
+/// In-memory SDK storage implementation for tests and examples.
+///
+/// This storage is not durable and must not be used for production SDK state.
+#[derive(Clone, Debug, Default)]
+pub struct InMemoryStorage {
+    state: Arc<Mutex<StorageState>>,
+}
+
+impl InMemoryStorage {
+    /// Create empty in-memory storage.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return a copy of the current storage state.
+    pub fn snapshot(&self) -> Result<StorageState> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|err| PaykitSdkError::Storage {
+                context: "in-memory storage lock poisoned".into(),
+                source: Some(anyhow::anyhow!(err.to_string())),
+            })?
+            .clone())
+    }
+}
+
+#[async_trait]
+impl StorageAdapter for InMemoryStorage {
+    async fn transaction<T, F>(&self, f: F) -> Result<T>
+    where
+        T: Send,
+        F: FnOnce(&mut dyn StorageTransaction) -> Result<T> + Send,
+    {
+        let mut guard = self.state.lock().map_err(|err| PaykitSdkError::Storage {
+            context: "in-memory storage lock poisoned".into(),
+            source: Some(anyhow::anyhow!(err.to_string())),
+        })?;
+        let mut transaction = InMemoryStorageTransaction {
+            state: guard.clone(),
+        };
+
+        let value = f(&mut transaction)?;
+        *guard = transaction.state;
+        Ok(value)
+    }
+}
+
+struct InMemoryStorageTransaction {
+    state: StorageState,
+}
+
+impl StorageTransaction for InMemoryStorageTransaction {
+    fn load_identity_state(&self) -> Option<IdentityState> {
+        self.state.identity_state.clone()
+    }
+
+    fn save_identity_state(&mut self, state: IdentityState) {
+        self.state.identity_state = Some(state);
+    }
+
+    fn linked_peer(&self, counterparty: &PubkyPublicKey) -> Option<LinkedPeerRecord> {
+        self.state.linked_peers.get(counterparty).cloned()
+    }
+
+    fn save_linked_peer(&mut self, record: LinkedPeerRecord) {
+        self.state
+            .linked_peers
+            .insert(record.counterparty.clone(), record);
+    }
+
+    fn encrypted_link_state(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Option<EncryptedLinkStateRecord> {
+        self.state.encrypted_link_states.get(counterparty).cloned()
+    }
+
+    fn save_encrypted_link_state(&mut self, record: EncryptedLinkStateRecord) {
+        self.state
+            .encrypted_link_states
+            .insert(record.counterparty.clone(), record);
+    }
+
+    fn insert_private_stream_item(&mut self, item: NewPrivateStreamItem) -> u64 {
+        let stream_item_id = self.state.next_private_stream_item_id;
+        self.state.next_private_stream_item_id += 1;
+        self.state
+            .private_stream_items
+            .push(PrivateStreamItemRecord::from_new(stream_item_id, item));
+        stream_item_id
+    }
+
+    fn private_stream_items(&self, counterparty: &PubkyPublicKey) -> Vec<PrivateStreamItemRecord> {
+        self.state
+            .private_stream_items
+            .iter()
+            .filter(|item| &item.counterparty == counterparty)
+            .cloned()
+            .collect()
+    }
+
+    fn event_dedup_record(&self, event_id: &str) -> Option<EventDedupRecord> {
+        self.state.event_dedup_records.get(event_id).cloned()
+    }
+
+    fn save_event_dedup_record(&mut self, record: EventDedupRecord) {
+        self.state
+            .event_dedup_records
+            .insert(record.event_id.clone(), record);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+
+    fn timestamp() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+    }
+
+    fn counterparty() -> PubkyPublicKey {
+        PubkyPublicKey::new("pk-peer").unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_transaction_commits_records() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+
+        let stream_item_id = storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| {
+                    tx.save_linked_peer(LinkedPeerRecord {
+                        counterparty: counterparty.clone(),
+                        state: LinkedPeerState::Linked,
+                        last_sync_at: Some(timestamp()),
+                        last_private_receive_at: Some(timestamp()),
+                        failure_count: 0,
+                    });
+
+                    let stream_item_id = tx.insert_private_stream_item(NewPrivateStreamItem {
+                        counterparty: counterparty.clone(),
+                        receive_batch_id: 7,
+                        raw_json: r#"{"version":1,"kind":"paykit.test"}"#.into(),
+                        parsed_version: Some(1),
+                        parsed_kind: Some("paykit.test".into()),
+                        known_paykit_kind: None,
+                        parse_status: PrivateStreamParseStatus::UnknownKind,
+                        parse_error: None,
+                        received_at: timestamp(),
+                    });
+
+                    tx.save_event_dedup_record(EventDedupRecord {
+                        event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+                        event_kind: "paykit.test".into(),
+                        canonical_payload_hash: "hash".into(),
+                        first_stream_item_id: stream_item_id,
+                        duplicate_stream_item_ids: Vec::new(),
+                        conflicting_stream_item_ids: Vec::new(),
+                    });
+
+                    Ok(stream_item_id)
+                }
+            })
+            .await
+            .unwrap();
+
+        let snapshot = storage.snapshot().unwrap();
+        assert_eq!(stream_item_id, 0);
+        assert_eq!(
+            snapshot.linked_peers[&counterparty].state,
+            LinkedPeerState::Linked
+        );
+        assert_eq!(snapshot.private_stream_items.len(), 1);
+        assert_eq!(snapshot.event_dedup_records.len(), 1);
+        assert_eq!(snapshot.next_private_stream_item_id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_transaction_rolls_back_on_error() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+
+        let result: Result<()> = storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| {
+                    tx.save_linked_peer(LinkedPeerRecord {
+                        counterparty: counterparty.clone(),
+                        state: LinkedPeerState::Linked,
+                        last_sync_at: Some(timestamp()),
+                        last_private_receive_at: None,
+                        failure_count: 0,
+                    });
+
+                    Err(PaykitSdkError::Storage {
+                        context: "forced rollback".into(),
+                        source: None,
+                    })
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+        let snapshot = storage.snapshot().unwrap();
+        assert!(snapshot.linked_peers.is_empty());
+    }
+}

--- a/paykit-sdk/src/telemetry.rs
+++ b/paykit-sdk/src/telemetry.rs
@@ -1,0 +1,12 @@
+//! Telemetry and redaction settings.
+
+use serde::{Deserialize, Serialize};
+
+/// Log redaction level for SDK telemetry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RedactionLevel {
+    /// Redact secrets and sensitive private payloads.
+    Standard,
+    /// Redact all private payload details.
+    Strict,
+}

--- a/specs/paykit-sdk.md
+++ b/specs/paykit-sdk.md
@@ -1,7 +1,7 @@
 # Paykit SDK Plan
 
-Status: planning / discussion only
-Date: 2026-06-02
+Status: planning / implementation design
+Date: 2026-06-03
 
 ## Goal
 
@@ -9,620 +9,1013 @@ Define the future Paykit SDK layer that sits above Paykit Library.
 
 Paykit Library remains the stateless Rust implementation of Paykit Protocol
 wire formats, Pubky storage helpers, Encrypted Link transport helpers, and
-structural validation. Paykit SDK is the higher-level integration layer that
-wallets, payment processors, and apps can use when they need durable local
-state, stream routing, recovery behavior, contact/payment workflows, and
-ergonomic platform APIs.
-
-The SDK should be product-neutral. This plan was informed by existing mobile
-and core app integrations that already duplicate higher-level Pubky and Paykit
-runtime behavior, but those integrations are examples rather than scope owners.
-
-## Integration Inputs
-
-The repeated integration patterns are:
-
-- Pubky session import/export and restore
-- Pubky profile and contact fetch/cache workflows
-- public Payment Endpoint publishing and discovery
-- private Payment List publication and resolution
-- Encrypted Link snapshot storage and recovery
-- receipt access indexing and receipt retrieval
-- contact payment resolution across private and public Paykit data
-
-Those reusable behaviors are good candidates for a shared SDK/runtime instead
-of remaining duplicated in each app.
-
-## Why This Layer Exists
-
-Private Application Messages share one ordered Encrypted Link stream. The
-low-level library should expose that stream without hiding messages in internal
-buffers or making lifecycle decisions. A wallet or processor still needs a
-durable runtime that can:
-
-- persist received Private Application Messages before advancing its local checkpoint
-- route messages into protocol lanes
-- derive local Payment Request state
-- dedupe replays
-- recover after crashes or missing snapshots
-- manage Encrypted Link snapshots and recovery attempts
-- publish and refresh public and private Payment Lists
-- resolve contact Payment Endpoints
-- expose convenient app-facing getters without losing unrelated message kinds
-
-Those responsibilities are stateful and belong above Paykit Library.
-
-## Relationship To Paykit Components
-
-### Paykit Library
-
-Paykit Library should provide:
-
-- Pubky Routing reads and writes
-- Payment Endpoint validation and storage helpers
-- Private Payment List serialization and parsing
-- Payment Request, Receipt Access, Receipt, and Payment Proof wire types
-- Encrypted Link handshake, restore, send, receive, and snapshot helpers
-- full Private Application Message stream receive API
-- stateless parsers for known Private Application Message kinds
-- stateless structural validation
-- send helpers for known protocol messages
-
-Paykit Library should not own:
-
-- durable event history
-- local database schema
-- payer/payee lifecycle state
-- contact address books
-- profile storage schemas
-- payment-provider balances
-- payment execution
-- recurring payment scheduling
-- UI state
-- notification policy
-- retry queues beyond narrow transport helper behavior
-
-### Paykit SDK
-
-Paykit SDK should provide:
-
-- durable Encrypted Link state storage
-- durable Private Application Message event log
-- crash-safe receive/checkpoint flow
-- typed lane routing over the raw Private Application Message stream
-- SDK-level typed getters that preserve unrelated message lanes
-- Payment Request lifecycle state
-- outbound Event Message preparation, persistence, and retry
-- receipt access indexing and receipt retrieval helpers
-- public Payment Endpoint publishing and cleanup workflows
-- Private Payment List publishing, refresh, and latest-state indexing
-- contact payment resolution across private and public Paykit data
-- Pubky identity/profile/contact adapter integration needed for Paykit workflows
-- recovery behavior for stale or lost Encrypted Link state
-- optional scheduling hooks for recurring Payment Requests
-- payment adapter interfaces
-- platform bindings for app integrations
-
-## Layering
-
-The SDK plan should keep three layers separate:
-
-- Pubky identity layer: generic Pubky session, Ring auth, profile/contact/follow,
-  file fetch, and key helpers. These may come from a Pubky SDK or from the app.
-  Paykit SDK should use this layer for Paykit workflows, but should not own the
-  full Pubky profile/contact product model.
-- Paykit SDK runtime: Payment Endpoint publication, Private Payment Lists,
-  Encrypted Link state, private stream routing, contact payment resolution,
-  backup records, Receipts, and Payment Requests.
-- Payment adapter: receiving-detail generation, method/provider state,
-  payment execution, activity records, feature flags, and UI.
-
-## Candidate SDK Scope
-
-### Pubky Session And Auth Runtime
-
-Existing platform integrations wrap Paykit session management and Pubky auth
-helpers in app services. The SDK should consume a Pubky identity layer or
-caller-provided identity adapter, then expose the Paykit-facing runtime shape:
-
-- initialize Paykit and Pubky-backed runtime state
-- import/export Pubky session secrets
-- sign out and force local sign out
-- report current Pubky public key and auth state
-- report whether the session is public-only or private-link-capable
-- expose whether a local Pubky secret key is available for Encrypted Links
-- restore a saved session on app start
-- refresh a session when a locally managed Pubky secret key is available
-- avoid persisting stale session secrets until import succeeds
-- provide a serial execution boundary around stateful FFI calls where platform
-  bindings require it
-
-The SDK may provide optional Pubky Ring auth helpers:
-
-- start/cancel/complete a `pubkyauth://` relay flow
-- parse auth URLs for display
-- approve auth URLs when the app has the local Pubky secret key
-- expose nonce/callback correlation helpers for apps that use callback URLs
-
-The SDK should not force a specific identity provider. Apps should be able to
-bring a session secret, a Pubky keypair, or an external authenticator.
-
-A Ring-authenticated session may be valid for public Paykit operations while
-lacking the local secret key needed for Encrypted Links. That capability
-distinction should be first-class so apps can report "public Paykit only"
-instead of retrying private flows that cannot succeed.
-
-### Pubky Key Material
-
-Some integrations derive Pubky Ed25519 secret keys from seed material. This can
-be useful, but it is sensitive and product-specific.
-
-The SDK should define the identity input boundary:
-
-- accept an imported Pubky session secret
-- accept a caller-managed Pubky secret key when needed for Encrypted Links
-- validate that a stored secret key matches the active Pubky public key
-- expose backup/restore metadata for locally managed versus externally managed
-  sessions
-
-The SDK should not silently derive identity keys from seed material by default.
-Identity key derivation policy belongs to the integrating app unless Paykit
-explicitly standardizes it as a protocol/product requirement. If the helper
-remains useful, it should be an opt-in identity adapter, not the default SDK
-behavior.
-
-### Pubky Profiles
-
-Existing app integrations duplicate profile fetch, profile write, cached
-display metadata, avatar upload, and fallback behavior. The SDK should provide
-adapter-backed helpers for the Paykit workflows that need profile context:
-
-- fetch a Pubky profile by public key
-- normalize and validate Pubky public keys
-- support profile cache records for display name and image URI
-- resolve an app profile first and fall back to `pubky.app` profile data when
-  configured
-- write a caller-provided profile payload to a configured Pubky path
-- upload/fetch public profile blobs when configured with a storage path policy
-- clear profile cache on sign out
-
-Core Pubky profile behavior may belong in a Pubky SDK. Paykit SDK should keep
-profile paths and profile schema configurable. Product profile paths, staging
-paths, avatar compression, and signup flows stay product policy unless Paykit
-adopts them explicitly.
-
-### Pubky Contacts
-
-App contact systems can combine public Pubky follows, app-owned contact
-storage, profile snapshots, and Paykit private sharing state. The SDK should
-provide adapter-backed helpers for Paykit workflows that need contact context:
-
-- normalize, validate, compare, and redact Pubky public keys
-- reject self-contact and duplicate contact additions
-- list contacts from a configured Pubky contacts path
-- discover remote `pubky.app` follows for import
-- fetch contact profiles concurrently with placeholder fallback policy
-- save, update, and remove contact profile snapshots at a configured path
-- expose contact import candidates and merge decisions
-- notify Paykit private state when saved contacts are added, removed, or pruned
-
-Core Pubky follow/contact behavior may belong in a Pubky SDK. Paykit SDK should
-not own contact UI, grouping/sorting presentation, localized validation
-messages, route decisions, or onboarding screens.
-
-### Pubky File And Image Resolution
-
-Platform integrations often fetch `pubky://` resources and follow simple image
-descriptor indirection. The SDK may provide reusable file helpers when Paykit
-workflows need them:
-
-- resolve or fetch `pubky://` resources
-- fetch UTF-8 text or raw bytes
-- optionally follow profile/image descriptor JSON with a `src` field
-- expose cache keys or cache invalidation signals for profile media
-
-General `pubky://` file fetching may also live in a Pubky SDK. Paykit SDK
-should not own platform image rendering, Coil/SwiftUI image loaders,
-memory/disk cache sizing, image clipping, or loading/error UI.
-
-### Public Payment Endpoint Runtime
-
-Apps, wallets, and payment processors build and publish public Payment
-Endpoints from payment-adapter state. The SDK should own the reusable Paykit
-workflow:
-
-- parse Payment Endpoint payloads
-- serialize endpoint payloads from adapter-provided receiving details
-- validate Payment Endpoint Identifiers and configured supported methods
-- determine the current desired public Payment List from adapter capabilities
-- publish desired endpoints and remove stale managed endpoints
-- remove all managed endpoints when public sharing is disabled
-- fetch a counterparty's public Payment List
-- filter endpoints through an adapter-provided compatibility checker
-- build a contact payment launch target from compatible endpoints
-- build method-specific payment launch data when the payment adapter supports it
-- refresh expiring Payment Endpoint Payloads before publication
-- clear cached endpoint metadata after a payment settles
-
-The SDK should not generate payment receiving details directly. It should ask a
-payment adapter for receiving details, network or method metadata,
-payment-method availability, and endpoint usability.
-
-### Contact Payment Resolution
-
-Apps often need to answer questions like "can this contact be paid?" and
-"start a payment to this contact" by trying counterparty-specific private
-Payment Lists first and then public Payment Lists. The SDK should provide this
-as a shared workflow:
-
-- resolve a contact's current private Payment List when a Linked Peer exists
-- use cached private endpoints when a link is stale but cached data is still
-  acceptable under configured policy
-- wait for private recovery only for a configured bounded recovery window
-- fall back to public Payment Endpoints when a counterparty-specific private
-  Payment List is unavailable or disabled
-- return a structured result: opened payment target, no endpoint, unsupported
-  endpoint, stale/recovery pending, or error
-- expose "has payable endpoint" checks for contact lists and previews
-
-The SDK should let apps configure fallback policy. Some products may prefer
-private-only behavior for saved contacts; others may allow public fallback.
-When private recovery does not complete inside the configured window, the SDK
-should return either public fallback or a structured stale/recovery result
-instead of blocking payment resolution indefinitely.
-
-### Encrypted Link Runtime
-
-App integrations currently have to manage Encrypted Link handles, snapshots,
-handshake snapshots, restore/retry behavior, and recovery markers. The SDK
-should own this runtime:
-
-- decide deterministic initiator/responder role from the two public keys
-- establish or restore Encrypted Links for Linked Peers
-- persist Encrypted Link snapshots after successful receive/send progress
-- persist handshake snapshots while a handshake is incomplete
-- validate snapshot recipient before restore
-- close/drop stale active handles
-- count stale link failures and fail closed after a configured threshold
-- restart handshakes only when link/session context is truly lost
-- keep link recovery state per counterparty
-- publish and read recovery markers when recovery is needed
-- avoid broad private storage purge unless the policy proves it is safe for the
-  current contact set
-
-This should be implemented above Paykit Library because it is stateful and
-requires local durable storage.
-
-### Durable Private Stream Intake
-
-The SDK should use `EncryptedLink::receive_private_application_messages` as the
-durable receive path.
-
-This requires a `StorageAdapter` with transaction semantics, or an explicit
-crash-recovery contract that provides equivalent checkpoint safety.
-
-For each receive cycle:
-
-1. Receive the full Private Application Message batch from Paykit Library.
-2. Persist each received private stream item whose plaintext is syntactically
-   valid JSON, with stream order, raw JSON payload, parsed kind when available,
-   parse result, and current link identity.
-3. Persist dedupe/index updates derived from those messages.
-4. Persist the advanced Encrypted Link snapshot only after the messages and
-   derived state are durable, preferably in the same transaction/checkpoint
-   boundary.
-5. Expose typed views/getters from the SDK's own durable store.
-
-If the SDK persists messages but crashes before persisting the advanced
-snapshot, replay is acceptable and should be deduped. If the SDK persists the
-snapshot without persisting messages, it may lose events, so this order is not
-allowed.
-
-### Stream Routing
-
-The SDK should route Private Application Messages by Private Message Kind.
-
-Initial lanes:
-
-- `paykit.private_payment_list`: Latest-State Message lane
-- `paykit.receipt_access`: Event Message lane
-- `paykit.payment_request`: Payment Request Event Message lane
-- `paykit.payment_request_acceptance`: Payment Request Event Message lane
-- `paykit.payment_request_rejection`: Payment Request Event Message lane
-- `paykit.payment_request_cancellation`: Payment Request Event Message lane
-- `paykit.payment_proof`: Payment Request Event Message lane
-
-Unknown private stream items with valid Private Application Message headers but
-unsupported kinds should be retained in the durable log unless a caller
-explicitly configures a discard policy. This keeps future protocol messages
-recoverable after an SDK upgrade.
-
-### Private Payment List Runtime
-
-Apps that support private sharing publish private endpoint maps per saved
-contact and keep the newest remote endpoint map cached. The SDK should own:
-
-- building a complete Private Payment List from adapter-provided endpoints
-- enforcing pubky-noise message size limits before send
-- dropping lower-priority endpoints under a configured policy when the payload
-  is too large
-- hashing the local payload to skip redundant sends
-- publishing removal tombstones or empty lists when private sharing is disabled
-  or a contact is removed
-- caching the latest valid remote Private Payment List per Linked Peer
-- preserving older raw messages in the durable log for audit/debug
-- making clear that Private Payment Lists publish endpoints only; Payment
-  References come from Payment Requests, Payment Proofs, and Receipts
-
-The SDK should not reintroduce the removed `reference` field or any
-product-specific Private Payment List payload shape.
-
-### Single-Use Endpoint Reservation
-
-Some payment methods use contact-scoped or single-use receiving details. This
-can be reusable, but it must be adapter-driven.
-
-The SDK should provide an optional endpoint reservation subsystem:
-
-- reserve an adapter-provided receiving detail for a contact
-- remember current and historical contact assignments for attribution
-- prevent reserved receiving details from being reused as general receive
-  details
-- restore reservation ceilings from backup so restored integrations do not
-  reuse old reserved identifiers
-- rotate contact-specific receiving details after use
-- reconcile reserved identifier ceilings with the payment adapter
-- map method-specific settlement identifiers back to a contact when possible
-
-The SDK should not own receiving-detail generation, payment-provider state,
-method-specific routing or quote policy, or settlement detection directly.
-Those are payment adapter responsibilities.
-
-### Payment Request Runtime
-
-The SDK should derive Payment Request state from persisted Event Messages.
-
-For outbound Payment Request events, the SDK should serialize and persist the
-exact event payload before sending so retries can reuse the same Event ID and
-payload.
-
-It should handle:
-
-- request proposal storage
-- explicit acceptance
-- rejection
-- unilateral cancellation
-- Payment Proof indexing
-- dedupe by Event ID
-- detection of conflicting reused Event IDs
-- detection of conflicting repeated Payment Request terms
-- proof/request correlation validation
-- sender role validation
-- proposal expiry handling before acceptance
-- recurring request schedule eligibility
-- pause of automatic execution when local history is missing or inconsistent
-
-Paykit Library can validate event shape and stateless proof/request correlation,
-but the SDK decides whether an event is allowed in the current lifecycle state.
-
-### Receipt Runtime
-
-The SDK should treat Receipt Access as an Event Message lane.
-
-It should:
-
-- persist every valid Receipt Access message in send order
-- reconcile repeated Receipt IDs
-- fetch Encrypted Receipts from Receipt Location, paired with the Receipt Access
-  sender/issuer context, when requested or configured
-- decrypt Receipts with Receipt Decryption Key
-- index Receipts by Receipt ID, Payment Reference, counterparty,
-  Payment Request ID, and Billing Period when available
-- retry sending Receipt Access when storing the Receipt succeeded but sending
-  the access message failed
-- avoid logging raw Receipt Decryption Keys
-
-### Backup And Restore
-
-Apps may need to back up Pubky session state, private link snapshots, private
-contact endpoint cache, recovery markers, and reserved endpoint metadata. The
-SDK should make this first-class:
-
-- export SDK-managed non-payment-provider state in versioned backup records
-- restore SDK state without assuming the active payment-provider session is
-  already valid
-- validate restored Encrypted Link and handshake snapshots against the expected
-  counterparty before use
-- separate secret state from non-secret cache state where platform storage
-  requires it
-- emit "backup state changed" notifications for app backup systems
-- fail closed when restored state is inconsistent
-
-The SDK should not own the app's backup transport, cloud provider, encryption
-container, or seed/secret backup policy.
-
-### Activity And Contact Attribution
-
-Integrations may annotate activity with Pubky contact keys and use private
-endpoint reservations to map incoming payments back to contacts. The SDK should
-own only the reusable correlation helpers:
-
-- normalize contact public keys for activity metadata
-- map known private settlement identifiers to contacts
-- map reserved private receiving details to contacts
-- expose correlation metadata that an app can store on activity records
-
-The SDK should not own the app activity database, transaction replacement
-policy, activity screens, or display copy.
-
-## Clearly Out Of Scope
-
-The following should stay in a payment adapter, product app, or integrating app:
-
-- payment execution and settlement detection
-- payment-provider lifecycle, balances, fee/quote policy, route policy, and
-  method-specific state
-- method-specific payment payload or URI parsing beyond adapter-provided
-  compatibility checks
-- receiving-detail generation and identifier ownership
-- reusable receiving-detail caching outside Paykit contact reservations
-- selected payment-method UI policy
-- fiat display, exchange-rate handling, and amount-entry UX
-- product feature flags and onboarding screens
-- settings screens and localized error messages
-- navigation, QR scanning, clipboard handling, share sheets, and toasts
-- profile/contact list presentation, grouping, sorting UI, and search UI
-- avatar compression, platform image rendering, and cache sizing
-- signup policy unless Paykit standardizes it
-- identity key derivation policy unless Paykit standardizes it
-- app backup transport, cloud sync, and encrypted backup containers
-- destructive storage purge policy that is not proven safe for all current
-  Linked Peers
-
-## Suggested SDK Adapter Boundary
-
-The first SDK should be usable by wallets, payment processors, and apps without
-importing product-specific types. It should depend on small interfaces supplied
-by the integrating app.
-
-Suggested adapters:
-
-- `StorageAdapter`: durable local storage with transaction/checkpoint semantics
-- `Clock`: current time for expiry, retry, and schedule decisions
-- `PubkyIdentityAdapter`: active session, public key, local secret key
-  availability, public-only/private-link-capable state, session
-  import/export/sign-out
-- `PubkyProfileAdapter`: optional app profile paths and profile serialization
-- `PaymentEndpointProvider`: current public/private receiving details
-- `EndpointCompatibilityChecker`: validates whether an endpoint is payable by
-  the payment adapter on the current network or method
-- `EndpointReservationAdapter`: reserves, rotates, and checks single-use
-  receiving details
-- `PaymentExecutor`: optional execution hook for Payment Requests
-- `Scheduler`: optional recurring Payment Request scheduling hook
-- `Logger`: structured logging with redaction
-
-## Suggested API Shape
-
-This is illustrative only.
+structural validation. Paykit SDK is the durable runtime that wallets, payment
+processors, and apps can use when they need local state, recovery behavior,
+contact/payment workflows, and ergonomic platform APIs.
+
+The SDK should be product-neutral and payment-method-neutral. It should support
+payment methods through adapters without baking any one method into the SDK.
+
+## Design Principles
+
+- Keep `paykit-lib` stateless. It validates and sends protocol objects, but it
+  does not own local history, lifecycle state, scheduling, retries, or contact
+  policy.
+- Make the SDK stateful and crash-safe. It owns durable event logs, derived
+  views, snapshots, retries, recovery state, and app-facing getters.
+- Preserve the private stream. Receive all Private Application Messages in
+  order and persist them before advancing the Encrypted Link checkpoint.
+- Own the Pubky integration needed by Paykit. Since Pubky is Paykit's only
+  transport/storage backend, apps should not need a separate Pubky integration
+  just to use Paykit SDK.
+- Keep product profile/contact UX separate. The SDK can own small Paykit-facing
+  profile/contact records and shared paths, but it should not own app screens,
+  social graph semantics, or product-specific profile schemas.
+- Keep payment execution separate. Payment adapters provide receiving details,
+  endpoint compatibility, payment execution, settlement detection, and
+  method-specific state.
+- Prefer typed records at the SDK boundary. Apps should not have to parse raw
+  JSON or reason about Encrypted Link snapshots directly for normal workflows.
+- Expose low-level escape hatches where useful, but make the safe durable path
+  the default.
+
+## Architecture
+
+The system should have three main layers:
+
+- Paykit Protocol / `paykit-lib`: stateless wire types, Pubky path helpers,
+  Encrypted Link send/receive helpers, parsers, serializers, and structural
+  validation.
+- Paykit SDK runtime: durable state, private stream routing, lifecycle
+  derivation, endpoint publication, contact payment resolution, retries,
+  recovery, Pubky session/capability handling, Pubky-backed Paykit
+  profile/contact metadata, and app-facing APIs.
+- Payment adapter layer: receiving-detail generation, endpoint compatibility,
+  payment execution, settlement detection, method/provider state, and activity
+  records.
+
+The SDK may still accept narrow platform hooks for secure session persistence,
+auth UI/Ring session handoff, custom profile/contact storage, scheduling, and
+logging. Those hooks should not require each app to reimplement Pubky Paykit
+logic.
+
+The SDK should depend on `paykit-lib`, not replace it. Platform apps should
+prefer SDK bindings for normal product workflows and use `paykit-lib` bindings
+only for low-level protocol operations.
+
+## Crate Layout
+
+The first implementation should add a new Rust crate:
+
+```text
+paykit-sdk/
+  Cargo.toml
+  src/
+    lib.rs
+    config.rs
+    error.rs
+    runtime.rs
+    adapters.rs
+    storage.rs
+    identity.rs
+    endpoints.rs
+    contacts.rs
+    linked_peers.rs
+    private_stream.rs
+    private_lists.rs
+    payment_requests.rs
+    receipts.rs
+    reservations.rs
+    backup.rs
+    scheduler.rs
+    telemetry.rs
+```
+
+Suggested module responsibilities:
+
+- `runtime`: owns `PaykitSdk`, coordinates adapters, storage, and workflow
+  modules.
+- `config`: product-neutral policy knobs such as fallback behavior, retry
+  limits, stale cache rules, and message retention limits.
+- `adapters`: payment-method adapters plus narrow platform hooks for session
+  persistence, scheduling, reservations, and logging.
+- `storage`: durable records, transaction interface, migrations, and in-memory
+  test storage.
+- `identity`: SDK-owned Pubky session capability state and identity
+  refresh/import/export workflows.
+- `endpoints`: public Payment Endpoint publication, cleanup, and remote public
+  Payment List reads.
+- `contacts`: SDK-owned Paykit-facing contact/profile records, shared namespace
+  handling, and optional custom path/schema hooks.
+- `linked_peers`: Encrypted Link establishment, restore, recovery, and
+  per-counterparty runtime state.
+- `private_stream`: ordered Private Application Message intake, persistence,
+  routing, dedupe, and derived view rebuild.
+- `private_lists`: local and remote Private Payment List publication, caching,
+  latest-state derivation, and size policy.
+- `payment_requests`: Payment Request event state machine, outbound event
+  queueing, proof correlation, and scheduling hooks.
+- `receipts`: Receipt Access event indexing, Encrypted Receipt retrieval,
+  decryption, and retry of access messages.
+- `reservations`: optional contact-scoped or single-use receiving-detail
+  reservation records.
+- `backup`: versioned export/import of SDK-managed state.
+- `scheduler`: optional recurring Payment Request scheduling integration.
+- `telemetry`: structured logs and redaction helpers.
+
+If platform bindings become large, add separate crates:
+
+```text
+paykit-sdk-ffi/
+paykit-sdk-react-native/
+```
+
+Those should expose SDK workflows directly. They can eventually replace most
+app usage of low-level `paykit-ffi`, while keeping `paykit-ffi` available for
+protocol-level integrations.
+
+## Core Runtime Object
+
+The SDK should expose a single runtime object per local Pubky identity:
 
 ```rust
-struct PaykitSdk {
-    // storage, Pubky session access, clock, and payment adapter hooks
-}
-
-impl PaykitSdk {
-    async fn initialize(&mut self) -> Result<InitializationReport>;
-    async fn restore_session(&mut self, session_secret: String) -> Result<PublicKey>;
-    async fn sign_out(&mut self) -> Result<()>;
-
-    async fn load_own_profile(&mut self) -> Result<Option<ProfileRecord>>;
-    async fn load_contacts(&mut self) -> Result<Vec<ContactRecord>>;
-    async fn add_contact(&mut self, public_key: PublicKey) -> Result<ContactRecord>;
-    async fn remove_contact(&mut self, public_key: PublicKey) -> Result<()>;
-
-    async fn publish_public_payment_endpoints(&mut self) -> Result<EndpointSyncReport>;
-    async fn clear_public_payment_endpoints(&mut self) -> Result<EndpointSyncReport>;
-
-    async fn sync_counterparty(&mut self, counterparty: PublicKey) -> Result<SyncReport>;
-    async fn prepare_saved_contacts(&mut self, contacts: Vec<PublicKey>) -> Result<SyncReport>;
-
-    async fn resolve_contact_payment(
-        &mut self,
-        counterparty: PublicKey,
-    ) -> Result<ContactPaymentResolution>;
-
-    async fn get_current_private_payment_list(
-        &self,
-        counterparty: PublicKey,
-    ) -> Result<Option<PrivatePaymentList>>;
-
-    async fn list_receipt_access(
-        &self,
-        counterparty: PublicKey,
-    ) -> Result<Vec<ReceiptAccessRecord>>;
-
-    async fn list_payment_requests(
-        &self,
-        counterparty: PublicKey,
-        filter: PaymentRequestFilter,
-    ) -> Result<Vec<PaymentRequestRecord>>;
-
-    async fn accept_payment_request(
-        &mut self,
-        payment_request_id: PaymentRequestId,
-    ) -> Result<()>;
-
-    async fn reject_payment_request(
-        &mut self,
-        payment_request_id: PaymentRequestId,
-        reason: Option<String>,
-    ) -> Result<()>;
-
-    async fn cancel_payment_request(
-        &mut self,
-        payment_request_id: PaymentRequestId,
-        reason: Option<String>,
-    ) -> Result<()>;
-
-    async fn record_payment_proof(
-        &mut self,
-        payment_request_id: PaymentRequestId,
-        proof: PaymentProofInput,
-    ) -> Result<()>;
-
-    async fn export_backup_state(&self) -> Result<Option<SdkBackupState>>;
-    async fn restore_backup_state(&mut self, backup: Option<SdkBackupState>) -> Result<()>;
+pub struct PaykitSdk<S, K, P, C> {
+    storage: S,
+    pubky: K,
+    payment: P,
+    config: PaykitSdkConfig,
+    clock: C,
 }
 ```
 
+The runtime should be cheap to construct but stateful in behavior. It should not
+hide durable state in memory only. Any operation that changes link progress,
+outbound queues, derived state, or publication status must persist through the
+storage adapter.
+
+The SDK should also provide a boxed/dynamic adapter mode for FFI:
+
+```rust
+pub struct PaykitSdkHandle {
+    // boxed adapters, storage, and runtime locks for platform bindings
+}
+```
+
+## Integration Interfaces
+
+The SDK should own Pubky-backed Paykit behavior. Integration interfaces are for
+state, platform auth/session persistence, and payment-method-specific behavior
+that the SDK cannot provide generically.
+
+### StorageAdapter
+
+`StorageAdapter` is required. It must support atomic updates or an equivalent
+crash-recovery contract.
+
+```rust
+#[async_trait]
+pub trait StorageAdapter {
+    async fn transaction<T>(
+        &self,
+        f: impl FnOnce(&mut dyn StorageTransaction) -> Result<T> + Send,
+    ) -> Result<T>;
+}
+```
+
+`StorageTransaction` should support records for:
+
+- identity/session state
+- linked peer state
+- Encrypted Link snapshots and handshake snapshots
+- raw private stream items
+- parsed event records
+- dedupe indexes
+- derived current views
+- outbound messages and retry state
+- endpoint publication records
+- endpoint reservations
+- receipt records
+- backup metadata
+- recovery/fail-closed markers
+
+The SDK should ship an in-memory storage implementation for tests and examples.
+Production apps should provide a durable implementation.
+
+### PubkySessionProvider
+
+Required for loading and storing local Pubky session material.
+
+```rust
+pub trait PubkySessionProvider {
+    async fn load_session_access(&self) -> Result<Option<PubkySessionAccess>>;
+    async fn clear_session_access(&self) -> Result<()>;
+}
+```
+
+`PubkySessionAccess` provides the live authenticated `PubkySession`, Pubky
+client for counterparty homeserver access, and optional `PubkyLocalSecretKey`
+needed for Encrypted Links. The SDK derives and persists public `IdentityState`
+from that access during initialization.
+
+The SDK derives Paykit capability from the session access:
+
+- `SignedOut`
+- `PublicOnly`: public Pubky operations may work, but Encrypted Links cannot be
+  established because the local secret key is unavailable.
+- `PrivateLinkCapable`: public operations and Encrypted Links can work.
+
+Ring-authenticated sessions often produce the `PublicOnly` case. The SDK should
+surface this as a clear state instead of retrying private operations that cannot
+succeed.
+
+The SDK should provide high-level import/export/sign-out APIs itself. The
+provider is the narrow platform hook for secure storage and auth-session handoff,
+not a separate Pubky SDK that integrators must use.
+
+### Paykit Profile And Contact Namespace
+
+The SDK should provide default Pubky-backed Paykit-facing profile and contact
+metadata so different Paykit apps can interoperate. This belongs in the SDK, not
+in `paykit-lib` core protocol validation.
+
+The default namespace must not pollute the public Payment Endpoint root. Public
+Payment Endpoints currently live directly under `/pub/paykit/v0/`, so SDK
+profile/contact records should use a reserved Paykit path such as:
+
+- a reserved subdirectory under `/pub/paykit/v0/`, or
+- an unversioned Paykit-level path under `/pub/paykit/`.
+
+The versioned option keeps SDK metadata beside the current protocol version.
+The unversioned option may be better if profile/contact records should remain
+stable across Paykit protocol versions. Either way, the chosen path must be
+reserved so it cannot collide with Payment Endpoint Identifier files.
+
+The exact path policy should be configurable:
+
+- default shared Paykit SDK profile/contact paths for apps that want
+  cross-Paykit interoperability
+- custom app paths for products that already have profile/contact storage
+- adapter-only mode for apps that want Paykit SDK to consume profile/contact
+  data without writing any Pubky profile/contact records
+
+Custom profile/contact hooks are optional escape hatches. The default path for
+most integrators should be: configure Paykit SDK, provide secure storage and a
+payment adapter, and let the SDK handle Pubky-backed Paykit profile/contact
+reads and writes.
+
+Default profile records can be public because they are display metadata. Contact
+records need more care because they can reveal a social/payment graph. The SDK
+should support shared Paykit contacts, but should also allow apps to keep saved
+contacts local, encrypted, or app-specific when privacy policy requires it.
+
+Schemas should be small, versioned, and Paykit-facing:
+
+- profile display name and image pointer
+- normalized Pubky public key
+- optional app/profile source metadata
+- contact public key
+- optional local display snapshot
+- optional Paykit capability summary
+
+The SDK should not standardize product profile pages, social graph semantics,
+contact grouping, or UI behavior.
+
+### PaymentAdapter
+
+Required for endpoint publication and payment execution workflows.
+
+```rust
+pub trait PaymentAdapter {
+    async fn current_receiving_details(
+        &self,
+        scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>>;
+
+    async fn is_endpoint_payable(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<EndpointCompatibility>;
+
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget>;
+
+    async fn execute_payment_request(
+        &self,
+        request: &PaymentRequestExecution,
+    ) -> Result<PaymentExecutionResult>;
+}
+```
+
+The adapter owns payment-method-specific details:
+
+- receiving-detail generation
+- network or method metadata
+- balances, quote policy, fees, and route policy
+- payment execution
+- settlement detection
+- method-specific payload parsing beyond basic Paykit compatibility
+
+### EndpointReservationAdapter
+
+Optional. Used when payment methods need contact-scoped or single-use receiving
+details.
+
+```rust
+pub trait EndpointReservationAdapter {
+    async fn reserve(
+        &self,
+        contact: PubkyPublicKey,
+        method: PaymentEndpointIdentifier,
+    ) -> Result<ReservedReceivingDetail>;
+
+    async fn rotate_after_use(
+        &self,
+        reservation_id: ReservationId,
+    ) -> Result<Option<ReservedReceivingDetail>>;
+}
+```
+
+### SchedulerAdapter
+
+Optional. Used for recurring Payment Requests.
+
+```rust
+pub trait SchedulerAdapter {
+    async fn schedule(&self, job: ScheduledPaymentJob) -> Result<()>;
+    async fn cancel(&self, job_id: ScheduledJobId) -> Result<()>;
+}
+```
+
+The SDK derives scheduling eligibility, but the integrating app/runtime may own
+the actual timer service.
+
+### Logger And Clock
+
+The SDK should accept:
+
+- `Clock`: deterministic current-time source for expiry, retries, and tests.
+- `Logger`: structured logging with redaction for secrets, Receipt Decryption
+  Keys, raw private payloads, and session material.
+
 ## Storage Model
 
-The SDK storage model should be implementation-specific, but it should be able
-to represent:
+The SDK storage model can be implemented by each platform, but the logical
+records should be stable.
 
-- local Pubky identity state
-- session backup state
-- profile cache records
-- contact records and contact profile snapshots
-- imported-contact candidates
-- public endpoint publication records
-- counterparties / Linked Peers
-- Encrypted Link snapshots
-- Encrypted Link handshake snapshots
-- recovery markers and recovery attempts
-- raw Private Application Messages
-- parsed private event records
-- current Private Payment List view
-- private endpoint publication records and payload hashes
-- endpoint reservation records and historical assignments
-- outbound message queue and retry state
-- Payment Request records
-- Payment Proof records
-- Receipt Access records
-- Receipt retrieval/decryption status
+### IdentityState
+
+Tracks local Pubky identity state:
+
+- local public key
+- capability state
+- session backup metadata
+- whether local secret key is available
+- last successful initialization time
+- sign-out generation
+
+### LinkedPeerRecord
+
+One record per counterparty:
+
+- counterparty public key
+- relationship state: unknown, known, linked, recovery required, blocked
+- initiator/responder role
+- last sync time
+- last private receive time
+- current recovery marker state
+- failure counters
+- policy overrides
+
+### EncryptedLinkState
+
+One record per linked peer:
+
+- active link snapshot
+- handshake snapshot
+- snapshot recipient public key
+- read/write progress metadata
+- last persisted checkpoint time
+- snapshot generation
+
+Snapshots are opaque `paykit-lib` snapshots. The SDK validates the expected
+counterparty before restoring them.
+
+### PrivateStreamItem
+
+Append-only raw private stream item:
+
+- local identity
+- counterparty
+- stream sequence number assigned by the SDK
+- receive batch id
+- raw JSON payload
+- parsed `version`
+- parsed `kind`
+- known Paykit kind, when recognized
+- parse status: valid, malformed recognized message, unknown kind, invalid JSON
+- parse error, when available
+- received time
+
+This is the source of truth for private protocol-derived state.
+
+### EventDedupRecord
+
+Tracks Event Message idempotency:
+
+- event id
+- event kind
+- canonical payload hash
+- first stream item id
+- duplicate stream item ids
+- conflict status
+
+Conflicting reused Event IDs must fail closed for the affected derived state.
+
+### PrivatePaymentListView
+
+Latest-state view per counterparty:
+
+- latest valid stream item id
+- latest payload hash
+- current Payment Endpoint map
+- stale/recovery status
+- last refresh time
+
+Malformed newer Private Payment List messages do not replace the last valid
+view. They remain in the raw log.
+
+### EndpointPublicationRecord
+
+Tracks local public and private endpoint publication:
+
+- scope: public or counterparty-private
+- Payment Endpoint Identifier
+- payload hash
+- publication status: desired, published, pending removal, removed, failed
+- last attempted time
+- last confirmed time
+- retry count
+
+### EndpointReservationRecord
+
+Tracks optional contact-scoped receiving details:
+
+- reservation id
+- counterparty public key
+- Payment Endpoint Identifier
+- adapter-provided receiving detail id
+- payload hash
+- state: active, used, rotated, retired
+- attribution metadata
+- backup generation
+
+### PaymentRequestRecord
+
+Derived record per Payment Request:
+
+- payment request id
+- proposer/payee counterparty
+- current local role: payer or payee
+- immutable terms
+- proposal event id
+- proposal expiry state
+- lifecycle state
+- accepted/rejected/canceled event ids
+- latest Payment Proof records
+- recurrence schedule metadata
+- automatic execution status
 - recovery/fail-closed status
 
-The raw Private Application Message table/log is the source of truth for
-derived protocol state. Derived views can be rebuilt from it.
+SDK lifecycle states should be explicit and local:
 
-Storage implementations should be able to commit raw messages, derived
-indexes/dedupe state, and advanced Encrypted Link snapshots atomically, or
-provide recovery semantics that prevent the snapshot from advancing durably
-ahead of persisted messages.
+- `proposed`
+- `proposal_expired`
+- `accepted`
+- `rejected`
+- `canceled`
+- `proof_submitted`
+- `active_recurring`
+- `paused`
+- `recovery_required`
+- `invalid_conflict`
+
+The SDK may expose product-friendly summaries, but it should not claim generic
+settlement finality unless the payment adapter confirms it.
+
+### ReceiptAccessRecord And ReceiptRecord
+
+Receipt Access records:
+
+- event id
+- receipt id
+- sender/issuer counterparty
+- Receipt Location path
+- Receipt Decryption Key
+- optional Payment Request ID
+- optional Billing Period
+- retrieval state
+
+Receipt records:
+
+- receipt id
+- decrypted receipt payload
+- payment reference
+- optional Payment Request ID
+- optional Billing Period
+- issuer context
+- retrieval/decryption time
+
+Receipt Decryption Keys must be redacted in logs and debug output.
+
+### OutboundMessageRecord
+
+Durable outbound queue:
+
+- outbound id
+- counterparty
+- message kind
+- event id, when applicable
+- exact serialized payload
+- payload hash
+- send status
+- retry count
+- next retry time
+- last error
+
+Event Message retries must reuse the same Event ID and exact payload.
+
+### UnknownPrivateMessageRetention
+
+Unknown valid Private Application Messages should be retained by default. The
+SDK config should define:
+
+- maximum retained unknown messages per counterparty
+- maximum retained bytes per counterparty
+- retention duration
+- whether discard is allowed
+
+Discard policy should never apply to recognized Paykit Event Messages unless
+the app explicitly purges all SDK state.
+
+## Storage And Checkpoint Invariant
+
+The most important SDK invariant is:
+
+```text
+Persist raw received messages and derived indexes before durably saving the
+advanced Encrypted Link snapshot.
+```
+
+For each receive cycle:
+
+1. Acquire the per-counterparty private-stream lock.
+2. Restore or establish the Encrypted Link.
+3. Receive the full batch from `paykit-lib`.
+4. Parse every syntactically valid JSON Private Application Message enough to
+   identify version/kind.
+5. In one transaction, insert raw stream items, update dedupe records, update
+   derived views, and then save the advanced link snapshot.
+6. Release the lock.
+
+If the app crashes after messages are stored but before the snapshot is stored,
+replay is acceptable and must be deduped. If the snapshot is stored without the
+messages, events may be lost; the SDK must not allow that.
+
+## Runtime Locks
+
+The SDK needs local runtime locks to prevent concurrent operations from racing
+the same durable state.
+
+Recommended locks:
+
+- identity lock: serializes import/export/sign-out and capability refresh.
+- public endpoint lock: serializes publication and cleanup of local public
+  Payment Endpoints.
+- peer link lock: serializes Encrypted Link restore, handshake, send, receive,
+  and snapshot updates per counterparty.
+- private stream lock: serializes receive/checkpoint work per counterparty.
+- outbound queue lock: serializes retry workers per counterparty.
+- reservation lock: serializes contact-scoped receiving-detail reservation and
+  rotation per counterparty/method.
+
+These are local SDK/runtime locks, not protocol messages. They can be in-memory
+with durable recovery markers where needed. If a platform can run multiple
+processes against the same storage, lock ownership must be storage-backed.
+
+## Workflows
+
+### Initialize SDK
+
+1. Load SDK config.
+2. Load identity state from storage.
+3. Load Pubky session access through `PubkySessionProvider`.
+4. Derive signed-out, public-only, or private-link-capable state.
+5. Load peer records and recovery markers.
+6. Start optional retry workers only after storage is ready.
+7. Return an initialization report with capability and recovery state.
+
+### Import Or Restore Pubky Session
+
+1. Acquire identity lock.
+2. Import or restore the Pubky session through SDK-owned Pubky logic.
+3. Persist resulting session access through SDK storage/session hooks.
+4. Detect capability: public-only or private-link-capable.
+5. Persist identity state and capability.
+6. If identity changed, mark old peer/link state inactive instead of silently
+   reusing it.
+7. Return current identity status.
+
+### Publish Public Payment Endpoints
+
+1. Ask `PaymentAdapter` for current public receiving details.
+2. Convert receiving details into Payment Endpoint payloads.
+3. Validate identifiers and payloads through `paykit-lib`.
+4. Compare desired payload hashes with `EndpointPublicationRecord`.
+5. Publish changed endpoints.
+6. Remove stale managed endpoints.
+7. Persist confirmed/pending/failed state.
+8. Return an `EndpointSyncReport`.
+
+The SDK should not remove endpoints it did not create unless explicitly
+configured to manage the whole Paykit public namespace.
+
+### Publish Private Payment List
+
+1. Ensure the identity is private-link-capable.
+2. Ensure or restore Linked Peer.
+3. Ask `PaymentAdapter` for private receiving details scoped to the counterparty.
+4. Apply reservation policy if enabled.
+5. Build a complete Private Payment List.
+6. Enforce the pubky-noise message size limit.
+7. Skip send when payload hash matches the last published payload.
+8. Persist outbound record and exact payload.
+9. Send through Encrypted Link.
+10. Persist send result and updated link snapshot.
+
+Private Payment Lists publish endpoints only. Payment References come from
+Payment Requests, Payment Proofs, and Receipts.
+
+### Receive Private Stream
+
+1. Acquire peer link/private stream locks.
+2. Restore or establish Encrypted Link.
+3. Receive ordered Private Application Messages through `paykit-lib`.
+4. Persist raw messages and parse results.
+5. Route recognized messages:
+   - Private Payment List updates latest-state view.
+   - Receipt Access appends event records.
+   - Payment Request messages update lifecycle state.
+   - Payment Proof messages update proof records.
+6. Detect duplicate Event IDs and conflicting payloads.
+7. Persist updated snapshot after messages and derived state.
+8. Return a receive report.
+
+### Resolve Contact Payment
+
+Input:
+
+- counterparty public key
+- desired amount/asset, if known
+- supported endpoint policy
+- fallback policy
+
+Flow:
+
+1. Load contact/profile display metadata if configured.
+2. Check Linked Peer and cached private Payment List.
+3. If private state is stale and recovery is possible, run bounded recovery.
+4. If private endpoints are available, ask `PaymentAdapter` for compatibility.
+5. If no private endpoint is payable and public fallback is allowed, fetch
+   public Payment List and check compatibility.
+6. Return a structured result:
+   - `Payable`
+   - `NoEndpoint`
+   - `UnsupportedEndpoint`
+   - `PrivateRecoveryPending`
+   - `PublicOnlySession`
+   - `Error`
+
+The SDK should not block indefinitely waiting for private recovery.
+
+### Send Payment Request
+
+Payee flow:
+
+1. Build immutable Payment Request terms.
+2. Validate terms structurally.
+3. Generate Event ID and Payment Request ID.
+4. Serialize exact event payload through `paykit-lib`.
+5. Persist outbound event and local derived request state.
+6. Send over Encrypted Link.
+7. Persist send status.
+
+Payer receive flow:
+
+1. Receive and persist raw event.
+2. Validate structural shape.
+3. Check sender role.
+4. Check duplicate/conflicting Event ID.
+5. Check duplicate/conflicting Payment Request ID terms.
+6. Check proposal expiry.
+7. Derive local state and expose it to the app.
+
+### Accept, Reject, Or Cancel Payment Request
+
+For outbound lifecycle events:
+
+1. Load local Payment Request state.
+2. Check whether the local role may send this event.
+3. Check current lifecycle state.
+4. Serialize and persist exact outbound payload.
+5. Send and retry using the same Event ID and payload.
+
+Cancellation is unilateral. Acceptance and rejection are payer-only in v0.2.
+
+### Record Payment Proof
+
+1. Load accepted Payment Request.
+2. Ask `PaymentAdapter` for execution result or caller-supplied proof data.
+3. Validate stateless proof/request correlation through `paykit-lib`.
+4. Persist proof event before sending.
+5. Send Payment Proof.
+6. Update local state to `proof_submitted`.
+
+The SDK should not mark a payment as settled unless the payment adapter provides
+settlement confirmation.
+
+### Retrieve Receipts
+
+1. Receive Receipt Access event.
+2. Persist event and dedupe by Event ID.
+3. Pair Receipt Location path with sender/issuer context.
+4. Fetch Encrypted Receipt when requested or configured.
+5. Decrypt with Receipt Decryption Key.
+6. Verify Receipt ID/location correlation through `paykit-lib`.
+7. Index by Receipt ID, Payment Reference, Payment Request ID, Billing Period,
+   counterparty, and issuer.
+
+### Backup And Restore
+
+Backup should include SDK-managed state:
+
+- identity backup metadata, when safe
+- peer records
+- Encrypted Link snapshots
+- handshake snapshots
+- Private Payment List cache
+- endpoint publication records
+- endpoint reservations
+- raw private stream log or checkpointed subset
+- outbound queue
+- recovery markers
+
+Backup should not include:
+
+- app cloud transport details
+- product-specific profile/contact schema beyond adapter-owned records
+- payment-provider secrets unless explicitly provided by the payment adapter
+- seed material unless Paykit standardizes that policy
+
+Restore flow:
+
+1. Load backup into storage under a restore transaction.
+2. Validate local identity compatibility.
+3. Validate every link snapshot recipient.
+4. Mark peers requiring resync.
+5. Do not execute automatic payments until private stream and request state are
+   consistent.
+
+## Public SDK API Shape
+
+The exact API will evolve, but the SDK should expose operations like:
+
+```rust
+impl PaykitSdk {
+    async fn initialize(&mut self) -> Result<InitializationReport>;
+    async fn identity_status(&self) -> Result<IdentityStatus>;
+    async fn import_session(&mut self, session_secret: String) -> Result<IdentityStatus>;
+    async fn sign_out(&mut self) -> Result<()>;
+
+    async fn sync_public_endpoints(&mut self) -> Result<EndpointSyncReport>;
+    async fn clear_public_endpoints(&mut self) -> Result<EndpointSyncReport>;
+
+    async fn sync_contact(&mut self, counterparty: PubkyPublicKey) -> Result<ContactSyncReport>;
+    async fn sync_saved_contacts(&mut self, contacts: Vec<PubkyPublicKey>) -> Result<SyncReport>;
+
+    async fn receive_private_messages(
+        &mut self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<PrivateReceiveReport>;
+
+    async fn current_private_payment_list(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<Option<PrivatePaymentListView>>;
+
+    async fn resolve_contact_payment(
+        &mut self,
+        request: ContactPaymentResolutionRequest,
+    ) -> Result<ContactPaymentResolution>;
+
+    async fn propose_payment_request(
+        &mut self,
+        counterparty: PubkyPublicKey,
+        terms: PaymentRequestTermsInput,
+    ) -> Result<PaymentRequestRecord>;
+
+    async fn accept_payment_request(
+        &mut self,
+        id: PaymentRequestId,
+    ) -> Result<PaymentRequestRecord>;
+
+    async fn reject_payment_request(
+        &mut self,
+        id: PaymentRequestId,
+        reason: Option<String>,
+    ) -> Result<PaymentRequestRecord>;
+
+    async fn cancel_payment_request(
+        &mut self,
+        id: PaymentRequestId,
+        reason: Option<String>,
+    ) -> Result<PaymentRequestRecord>;
+
+    async fn record_payment_proof(
+        &mut self,
+        id: PaymentRequestId,
+        proof: PaymentProofInput,
+    ) -> Result<PaymentRequestRecord>;
+
+    async fn list_payment_requests(
+        &self,
+        filter: PaymentRequestFilter,
+    ) -> Result<Vec<PaymentRequestRecord>>;
+
+    async fn list_receipt_access(
+        &self,
+        filter: ReceiptAccessFilter,
+    ) -> Result<Vec<ReceiptAccessRecord>>;
+
+    async fn retrieve_receipt(
+        &mut self,
+        receipt_id: ReceiptId,
+    ) -> Result<ReceiptRecord>;
+
+    async fn export_backup_state(&self) -> Result<SdkBackupState>;
+    async fn restore_backup_state(&mut self, backup: SdkBackupState) -> Result<RestoreReport>;
+}
+```
+
+## Platform Binding Shape
+
+The SDK should have first-class bindings for mobile and app integrations.
+
+Recommended approach:
+
+- Rust SDK crate owns the runtime and core state machine.
+- FFI crate exposes an opaque SDK handle.
+- Platform wrappers provide ergonomic Swift/Kotlin/React Native APIs.
+- Apps provide adapter implementations through platform callbacks or through
+  small platform-side adapter objects.
+
+Platform bindings should expose:
+
+- initialization and identity status
+- endpoint sync
+- contact sync and payment resolution
+- private stream receive/sync
+- Payment Request lifecycle APIs
+- Receipt retrieval APIs
+- backup/export/restore APIs
+- structured reports and errors
+
+Bindings should not expose:
+
+- raw Receipt Decryption Keys in debug output
+- unredacted raw private messages in logs
+- implicit event-loss-prone typed getters that bypass durable storage
+
+## Error Model
+
+SDK errors should be structured:
+
+- `Storage`: durable storage failure
+- `Identity`: Pubky session/key/capability failure
+- `Transport`: Pubky or Encrypted Link transport failure
+- `Protocol`: invalid Paykit message, conflict, or unsupported version
+- `Policy`: operation blocked by configured fallback or privacy policy
+- `PaymentAdapter`: payment adapter failure
+- `RecoveryRequired`: local state is inconsistent and automatic execution is
+  paused
+
+Errors should include machine-readable codes and short redacted context. UI copy
+belongs to the app.
+
+## Policy Configuration
+
+`PaykitSdkConfig` should include:
+
+- public endpoint management scope
+- private sharing enabled/disabled
+- public fallback policy
+- private recovery wait duration and retry limits
+- stale private cache policy
+- outbound retry policy
+- unknown message retention policy
+- receipt auto-retrieval policy
+- recurring Payment Request scheduling policy
+- endpoint reservation policy
+- log redaction level
+
+## What Moves From Existing App/Core Integrations
+
+These are good candidates to move into Paykit SDK:
+
+- Pubky session capability tracking for Paykit workflows
+- public-only versus private-link-capable state
+- public Payment Endpoint sync and stale endpoint cleanup
+- Private Payment List publish/fetch/cache
+- Encrypted Link snapshot and handshake runtime
+- stale link recovery markers and bounded recovery policy
+- ordered private stream receive/persist/route
+- contact payment resolution and payable endpoint checks
+- endpoint reservation records and attribution helpers
+- SDK-managed backup records
+- Receipt Access indexing and retrieval helpers
+- Payment Request lifecycle state
+
+These should stay outside Paykit SDK:
+
+- payment-provider node/runtime state
+- receiving-detail generation internals
+- payment execution and settlement detection
+- balances, fees, quotes, and route policy
+- product profile/contact UI
+- localized copy and navigation
+- app backup transport and cloud sync
+- seed/secret derivation policy unless standardized
+
+## Implementation Build Order
+
+1. Add `paykit-sdk` crate skeleton, error type, config, adapter traits, and
+   in-memory test storage.
+2. Implement durable storage records and transaction/checkpoint contract.
+3. Implement identity capability state and public endpoint sync.
+4. Implement Encrypted Link runtime, peer records, private stream intake, and
+   checkpoint-safe persistence.
+5. Implement Private Payment List latest-state derivation and contact payment
+   resolution.
+6. Implement outbound queue and retry model for private messages.
+7. Implement Receipt Access indexing and Receipt retrieval.
+8. Implement Payment Request lifecycle derivation and outbound lifecycle APIs.
+9. Implement optional endpoint reservation subsystem.
+10. Implement backup/export/restore for SDK-managed state.
+11. Add FFI and platform wrappers.
+12. Migrate one existing app integration behind the SDK and use that to refine
+    adapters.
+
+Each step should include unit tests for storage invariants and at least one
+integration-style test using an in-memory adapter setup.
+
+## Test Plan
+
+Core tests:
+
+- storage transaction commits and rollbacks
+- receive persists raw messages before snapshot
+- replay after crash dedupes events
+- conflicting Event IDs fail closed
+- malformed recognized messages remain auditable
+- unknown valid Private Application Messages are retained
+- Private Payment List latest valid message wins
+- stale private link falls back according to policy
+- public-only identity blocks private link operations clearly
+- outbound retries reuse exact Event ID and payload
+- Payment Request role/lifecycle checks
+- Receipt Access dedupe and receipt retrieval
+- backup/restore validates snapshot recipient and pauses unsafe automation
+
+Platform tests:
+
+- SDK handle lifecycle
+- adapter callback errors
+- redaction in debug/log output
+- serialization parity for records and errors
+- no nullable/optional protocol ambiguity in wrappers
 
 ## Open Questions
 
-1. Which storage interface should the first SDK target: embedded database,
-   caller-provided trait, or both?
-2. Should Paykit standardize seed-derived Pubky keys, or should that remain
-   entirely app policy?
-3. Which profile/contact paths should be default versus caller-configured?
-4. Should contact payment resolution default to private-first with bounded
-   recovery and public fallback, or should fallback be app-configured?
-5. How much of endpoint reservation should be generalized now versus left as a
-   payment adapter feature until more integrations need it?
-6. How should the SDK limit stored unknown Private Application Messages, so
-   future protocol messages are not lost but local storage cannot grow forever?
-7. How much scheduling should the SDK own for recurring Payment Requests versus
+1. Should the first storage implementation be caller-provided only, or should
+   Paykit ship a SQLite-backed storage adapter?
+2. Should the default Paykit SDK profile/contact namespace use a reserved
+   subdirectory under `/pub/paykit/v0/`, or an unversioned Paykit-level path
+   under `/pub/paykit/`?
+3. What is the default public fallback policy for saved contacts?
+4. How much endpoint reservation should be generalized in the first SDK version?
+5. How much recurring Payment Request scheduling should the SDK own versus
    delegating to app/runtime schedulers?
+6. What are the unknown Private Application Message retention defaults?
+7. Should SDK bindings become the primary mobile API while `paykit-ffi` remains
+   low-level protocol API?


### PR DESCRIPTION
## Summary

Stack PR 1/6 for the Paykit SDK split.

Adds the SDK foundation: the crate skeleton, core configuration/error/identity types, adapter traits, the storage transaction contract, basic runtime facade shape, and the SDK architecture spec.

This establishes the Rust SDK boundary above the stateless `paykit-lib` crate without adding the main runtime workflows yet.

## Review Notes

- Base: `master`
- Head: `codex/sdk-stack-foundation`
- This stack replaces the large draft reference PR #55 with smaller reviewable layers.
- The final stack branch was verified to have the same tree as #55's head.

## Verification

The final stacked branch matches #55's final tree exactly.
