### PR TITLE
Add SDK Payment Requests and Receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ before executing a payment through their existing infrastructure.
 
 ### Current Boundaries
 
-Paykit currently does not:
+`paykit-lib` and the current platform bindings do not:
 
 - execute payments
 - choose the final Payment Endpoint for a payer
@@ -199,13 +199,18 @@ Paykit currently does not:
 - manage Pubky session creation, authorization scope, key rotation, or account
   recovery
 
-These responsibilities remain with the integrating application, the Pubky SDK,
-or future higher-level Paykit components.
+`paykit-sdk` is the Rust runtime layer for SDK-managed local
+state such as endpoint sync, Encrypted Link snapshots, private stream intake,
+Private Payment Lists, and contact payment resolution. Payment execution,
+settlement detection, product UI, and platform session storage remain with the
+integrating application and its adapters.
 
 ## Library Crates
 
 - [`paykit-lib`](paykit-lib/) is the canonical Rust Paykit Library. It consumes
   concrete Pubky SDK handles and keeps no global application state.
+- [`paykit-sdk`](paykit-sdk/) is the Rust SDK runtime for stateful Paykit
+  workflows. SDK platform bindings are planned separately.
 - [`paykit-ffi`](paykit-ffi/) exposes UniFFI bindings for Swift and Kotlin.
 - [`paykit-react-native`](paykit-react-native/) wraps the generated bindings for
   React Native.
@@ -256,8 +261,8 @@ message.
 available Private Application Message batch in send order. SDK/runtime code should persist
 and route that raw stream, then use stateless parsers such as
 `parse_private_payment_list_json`, `parse_payment_request_event_message`,
-and `parse_receipt_access_event_message`. The raw JSON is preserved even when
-parsed `version`/`kind` header fields are missing or malformed.
+and `parse_receipt_access_event_message`. The raw payload is preserved even
+when parsed `version`/`kind` header fields are missing or malformed.
 
 #### Exchange Payment Requests
 
@@ -265,9 +270,9 @@ Payment Request protocol messages are Event Messages. Use
 `EncryptedLink::receive_private_application_messages` when deriving durable
 state across multiple Private Message Kinds. Payment Request events can
 then be parsed with `parse_payment_request_event_message`, which keeps the
-canonical kind, raw JSON payload, and parse result so malformed recognized
-messages can be persisted before the app persists an advanced Encrypted Link
-snapshot or treats them as handled.
+canonical kind, raw payload, and parse result so malformed recognized messages
+can be persisted before the app persists an advanced Encrypted Link snapshot or
+treats them as handled.
 
 For outbound idempotency, SDK/runtime code can call
 `serialize_payment_request_event` and persist the exact JSON payload before
@@ -289,8 +294,9 @@ it with the Receipt Access sender/issuer context when retrieving the Encrypted
 Receipt.
 
 Private Application Messages share one ordered encrypted stream. The raw stream
-API returns every syntactically valid Private Application Message in send order. Callers
-that trigger side effects from Event Messages must persist and reconcile their
+API returns every received Private Application Message plaintext payload in
+send order, including malformed JSON payloads. Callers that trigger side
+effects from Event Messages must persist and reconcile their
 own handled/unhandled event state before persisting a snapshot whose read
 counter has advanced past those messages. If event state is persisted but the
 snapshot is not, replay is expected; Event Messages should be deduped by

--- a/THESAURUS.md
+++ b/THESAURUS.md
@@ -7,7 +7,7 @@
 ## Bounded Contexts
 
 ### Paykit
-- **Definition**: The whole Paykit system/product, including Paykit Protocol, Paykit Library, future Paykit SDK/runtime work, private payments, receipts, Payment Requests, and related components.
+- **Definition**: The whole Paykit system/product, including Paykit Protocol, Paykit Library, Paykit SDK/runtime work, private payments, receipts, Payment Requests, and related components.
 - **NOT**: Only the protocol layer or only the Rust library.
 - **Synonyms to AVOID**: Paykit SDK when referring to the whole product or current stateless library
 - **Related terms**: Paykit Protocol, Paykit Library, Paykit SDK, Payment Request
@@ -25,8 +25,8 @@
 - **Related terms**: Paykit Protocol, Paykit SDK, Language Bindings
 
 ### Paykit SDK
-- **Definition**: A planned/future stateful integration layer above Paykit Library for durable Encrypted Link state, private stream routing, event logs, recovery behavior, Payment Request lifecycle state, receipt indexing, and ergonomic wallet/payment-processor workflows.
-- **NOT**: A current core component of Paykit architecture.
+- **Definition**: The stateful integration layer above Paykit Library for durable Encrypted Link state, private stream routing, event logs, recovery behavior, Payment Request lifecycle state, receipt indexing, and ergonomic wallet/payment-processor workflows. Current implementation starts as a Rust SDK runtime foundation.
+- **NOT**: Paykit Library, Paykit Protocol, or payment execution/settlement logic.
 - **Synonyms to AVOID**: Paykit core, Paykit runtime core, Pubky SDK
 - **Related terms**: Paykit, Paykit Library, Language Bindings
 
@@ -300,6 +300,7 @@ Current/core:
 - Paykit
 - Paykit Protocol
 - Paykit Library
+- Paykit SDK
 - Pubky Routing
 
 Protocol concepts:
@@ -334,7 +335,7 @@ Protocol concepts:
 - Encrypted Link Handshake
 
 Future/planned:
-- Paykit SDK
+- Paykit SDK platform bindings
 
 Implementation/legacy details:
 - Paykit FFI

--- a/paykit-ffi/README.md
+++ b/paykit-ffi/README.md
@@ -2,6 +2,10 @@
 
 UniFFI bindings for [paykit-lib](../paykit-lib/), exposing Paykit's payment routing functionality to iOS (Swift) and Android (Kotlin).
 
+These bindings expose the low-level, stateless Paykit Library API. The
+stateful `paykit-sdk` runtime is a separate Rust crate and does not have
+platform bindings yet.
+
 ## Exported API
 
 ### Initialization
@@ -84,7 +88,7 @@ Private Paykit APIs require an active session and an established Encrypted Link 
 
 #### Private Application Message and receipt handling
 
-- `FfiPrivateApplicationMessage` is one received Private Application Message with optional parsed `version`, optional parsed `kind`, and raw JSON payload. Platform SDK/runtime code should persist the raw JSON and route messages with recognized `kind` values.
+- `FfiPrivateApplicationMessage` is one received Private Application Message with optional parsed `version`, optional parsed `kind`, and raw payload text. Platform SDK/runtime code should persist the raw payload and route messages with recognized `kind` values.
 - Payment Request bindings expose the same stateless protocol tools as `paykit-lib`: typed records, send helpers, raw event parsing, canonical event serialization, and proof/request correlation validation. They do not derive lifecycle state, enforce roles, schedule recurring payments, or validate method-specific proofs.
 - `FfiPaymentRequestEventMessage` preserves `kind`, optional parsed IDs, `raw_json`, parsed event data when valid, and `validation_error` when a recognized event is malformed.
 - `FfiReceiptDraft` is caller input for `paykit_prepare_receipt`: optional `receipt_id`, `payment_reference`, optional `payment_request_id` and `billing_period` for Payment Request correlation, optional `payment_endpoint_identifier`, optional `amount` (`value` plus `asset`), and `metadata_json`, which must serialize to a JSON object.
@@ -107,20 +111,20 @@ Private Paykit APIs require an active session and an established Encrypted Link 
 ./build.sh all
 ```
 
-### Platform-Specific Builds
-```
-./build.sh ios      # iOS only
-./build.sh android  # Android only
-```
-
 ### Release Builds (with version bump)
-The `-r/--release` flag bumps versions in `Cargo.toml`, the root `Package.swift`, and `gradle.properties`, then builds.
-Defaults to patch version bump; use `--major`/`-M` or `--minor`/`-m` for other increments.
+Always build all platform bindings together so Swift and Kotlin stay in sync.
+The `-r/--release` flag bumps versions in the crate `Cargo.toml` files, the
+SDK's `paykit-lib` dependency, the root `Package.swift`, and
+`gradle.properties`, then builds.
+When the current version is an RC, `-r` without `--rc` finalizes that RC
+version. When the current version is not an RC, `-r` defaults to a patch bump.
+Use `--rc` to create or increment an RC version.
 
 ```
-./build.sh -r ios              # Bump patch (default) and build iOS
-./build.sh -r --minor android  # Bump minor and build Android
-./build.sh -r -M all           # Bump major and build all platforms
+./build.sh -r all           # Finalize current RC, or bump patch if not on an RC
+./build.sh -r --rc all      # Create/increment an RC and build all platforms
+./build.sh -r --minor all   # Bump minor and build all platforms
+./build.sh -r -M all        # Bump major and build all platforms
 ```
 
 ### Run Tests
@@ -228,12 +232,12 @@ paykit-ffi/
 │       └── uniffi-bindgen.rs
 ├── uniffi.toml             # Swift binding config
 ├── uniffi-android.toml     # Kotlin binding config
-├── build.sh                # Unified build script (ios|android|all + version bump)
-├── build_ios.sh            # iOS build + XCFramework generation
-├── build_android.sh        # Android build + Gradle publish
+├── build.sh                # Unified all-platform build script + version bump
+├── build_ios.sh            # Internal iOS sub-build script
+├── build_android.sh        # Internal Android sub-build script
 ├── update_package.py       # Auto-update root Package.swift checksum/tag
 ├── bindings/
-│   ├── ios/                # Generated: Swift bindings + XCFramework (after build_ios.sh)
+│   ├── ios/                # Generated: Swift bindings + XCFramework
 │   └── android/            # Gradle project for Maven publishing
 │       ├── build.gradle.kts
 │       ├── settings.gradle.kts
@@ -243,7 +247,7 @@ paykit-ffi/
 │           ├── build.gradle.kts
 │           └── src/main/
 │               ├── AndroidManifest.xml
-│               ├── jniLibs/    # Generated: .so files (after build_android.sh)
-│               └── kotlin/     # Generated: Kotlin bindings (after build_android.sh)
+│               ├── jniLibs/    # Generated: .so files
+│               └── kotlin/     # Generated: Kotlin bindings
 └── README.md
 ```

--- a/paykit-ffi/RELEASE.md
+++ b/paykit-ffi/RELEASE.md
@@ -11,9 +11,14 @@ From `paykit-ffi/`:
 ./build.sh -r --patch all        # Patch: 0.1.0 → 0.1.1
 ```
 
-This bumps the version consistently in `paykit-ffi/Cargo.toml`, `paykit-lib/Cargo.toml`, the root `Package.swift`, and `gradle.properties`, then builds both platforms and updates the `Package.swift` checksum.
+This bumps the version consistently in `paykit-ffi/Cargo.toml`,
+`paykit-lib/Cargo.toml`, `paykit-sdk/Cargo.toml`, the SDK's `paykit-lib`
+dependency, the root `Package.swift`, and `gradle.properties`, then builds both
+platforms and updates the `Package.swift` checksum.
 
-Build a single platform with `ios` or `android` instead of `all`.
+Always build all platform bindings together with `all` so Swift and Kotlin stay
+in sync. The internal `build_ios.sh` and `build_android.sh` scripts are only for
+local sub-build debugging.
 
 ## 2. Commit
 

--- a/paykit-ffi/build.sh
+++ b/paykit-ffi/build.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+usage() {
+    echo "Usage: $0 [-r|--release] [--major|-M|--minor|-m|--patch|-p] [--rc] all"
+}
+
 set_version() {
     local new_version="$1"
 
@@ -13,6 +17,8 @@ set_version() {
 
     "${SED_INPLACE[@]}" "s/^version = \".*\"/version = \"$new_version\"/" Cargo.toml
     "${SED_INPLACE[@]}" "s/^version = \".*\"/version = \"$new_version\"/" ../paykit-lib/Cargo.toml
+    "${SED_INPLACE[@]}" "s/^version = \".*\"/version = \"$new_version\"/" ../paykit-sdk/Cargo.toml
+    "${SED_INPLACE[@]}" "s/paykit-lib = { path = \"..\\/paykit-lib\", version = \".*\" }/paykit-lib = { path = \"..\\/paykit-lib\", version = \"$new_version\" }/" ../paykit-sdk/Cargo.toml
     "${SED_INPLACE[@]}" "s/let tag = \"v.*\"/let tag = \"v$new_version\"/" ../Package.swift
     "${SED_INPLACE[@]}" "s/^version=.*/version=$new_version/" bindings/android/gradle.properties
 }
@@ -103,33 +109,30 @@ while [[ $# -gt 0 ]]; do
             USE_RC=true
             shift
             ;;
-        ios|android|all)
+        all)
             BUILD_TARGET="$1"
             shift
             ;;
+        ios|android)
+            echo "Error: build all platform bindings together with './build.sh all'."
+            echo "Use build_ios.sh or build_android.sh directly only for local sub-build debugging."
+            usage
+            exit 1
+            ;;
         *)
-            echo "Usage: $0 [-r|--release] [--major|-M|--minor|-m|--patch|-p] [--rc] {ios|android|all}"
+            usage
             exit 1
             ;;
     esac
 done
 
+if [ "$BUILD_TARGET" != "all" ]; then
+    usage
+    exit 1
+fi
+
 if [ "$DO_RELEASE" = true ]; then
     bump_version "$BUMP_TYPE" "$USE_RC"
 fi
 
-case "$BUILD_TARGET" in
-  "ios")
-    ./build_ios.sh
-    ;;
-  "android")
-    ./build_android.sh
-    ;;
-  "all")
-    ./build_ios.sh && ./build_android.sh
-    ;;
-  *)
-    echo "Usage: $0 [-r|--release] [--major|-M|--minor|-m|--patch|-p] [--rc] {ios|android|all}"
-    exit 1
-    ;;
-esac
+./build_ios.sh && ./build_android.sh

--- a/paykit-sdk/README.md
+++ b/paykit-sdk/README.md
@@ -5,7 +5,8 @@ Stateful Rust runtime for Paykit integrations.
 `paykit-sdk` builds on `paykit-lib` and owns SDK-level local state for Pubky
 identity status, public Payment Endpoint sync, Encrypted Link state, private
 stream intake, Private Payment List derivation, contact payment resolution, and
-outbound Private Application Message delivery.
+outbound Private Application Message delivery. It also indexes Receipt Access
+events and retrieves/decrypts Encrypted Receipts into private SDK state.
 
 The crate is currently Rust-only. Existing Swift, Kotlin, and React Native
 bindings continue to expose low-level `paykit-lib` APIs until SDK bindings are

--- a/paykit-sdk/src/config.rs
+++ b/paykit-sdk/src/config.rs
@@ -10,12 +10,12 @@ pub enum EndpointManagementScope {
     FullPaykitNamespace,
 }
 
-/// Policy for private Payment List sharing.
+/// Policy for private Paykit message sharing.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PrivateSharingPolicy {
-    /// Private sharing is enabled when the identity is private-link-capable.
+    /// Private Paykit messages are enabled when the identity is private-link-capable.
     Enabled,
-    /// Private sharing is disabled by local policy.
+    /// Private Paykit messages are disabled by local policy.
     Disabled,
 }
 
@@ -35,7 +35,7 @@ pub enum PublicFallbackPolicy {
 pub struct PaykitSdkConfig {
     /// Public endpoint management scope.
     pub endpoint_management_scope: EndpointManagementScope,
-    /// Private endpoint sharing policy.
+    /// Private Paykit message sharing policy.
     pub private_sharing: PrivateSharingPolicy,
     /// Public fallback behavior.
     pub public_fallback: PublicFallbackPolicy,

--- a/paykit-sdk/src/lib.rs
+++ b/paykit-sdk/src/lib.rs
@@ -13,8 +13,10 @@ pub mod error;
 pub mod identity;
 pub mod linked_peers;
 pub mod outbound_private;
+pub mod payment_requests;
 pub mod private_lists;
 pub mod private_stream;
+pub mod receipts;
 /// SDK runtime facade.
 pub mod runtime;
 /// Durable storage traits and in-memory test storage.
@@ -57,11 +59,24 @@ pub use outbound_private::{
     OutboundPrivateSendReport,
 };
 #[doc(inline)]
+pub use payment_requests::{
+    payment_request_records, received_payment_request_records, PaymentProofRecord,
+    PaymentRequestAmountRecord, PaymentRequestBillingPeriodRecord, PaymentRequestLifecycleState,
+    PaymentRequestLocalRole, PaymentRequestRecord, PaymentRequestRecurrenceRecord,
+    PaymentRequestTermsRecord,
+};
+#[doc(inline)]
 pub use private_lists::{
     current_private_payment_list, derive_private_payment_list_view, PrivatePaymentListView,
 };
 #[doc(inline)]
 pub use private_stream::{EventIdConflict, PrivateStreamIntakeReport, PrivateStreamParseStatus};
+#[doc(inline)]
+pub use receipts::{
+    receipt_access_record_by_receipt_id, receipt_access_records, receipt_record,
+    ReceiptAccessRecord, ReceiptAmountRecord, ReceiptBillingPeriodRecord, ReceiptRecord,
+    ReceiptRetrievalStatus,
+};
 #[doc(inline)]
 pub use runtime::{Clock, InitializationReport, PaykitSdk, SystemClock};
 #[doc(inline)]

--- a/paykit-sdk/src/payment_requests.rs
+++ b/paykit-sdk/src/payment_requests.rs
@@ -1,0 +1,2511 @@
+//! Payment Request lifecycle derivation.
+//!
+//! Derived records can include Payment Request metadata. Treat them as private
+//! SDK state.
+
+use std::{
+    cmp::{Ordering, Reverse},
+    collections::{HashMap, HashSet},
+    fmt,
+};
+
+use chrono::{DateTime, Utc};
+use paykit_lib::{
+    parse_payment_request_event_message, serialize_payment_request_event, PaymentProof,
+    PaymentRequest, PaymentRequestAcceptance, PaymentRequestCancellation, PaymentRequestEvent,
+    PaymentRequestRejection, PrivateApplicationMessage,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+use crate::{
+    outbound_private::enqueue_private_message,
+    outbound_private::OutboundPrivateMessageStatus,
+    private_stream::payload_hash,
+    storage::{
+        EventDedupRecord, OutboundPrivateMessageRecord, PrivateStreamItemRecord, StorageAdapter,
+    },
+    PubkyPublicKey, Result,
+};
+
+/// Local role for one Payment Request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PaymentRequestLocalRole {
+    /// Local identity is expected to pay.
+    Payer,
+    /// Local identity expects to receive payment.
+    Payee,
+}
+
+/// SDK-derived Payment Request lifecycle state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PaymentRequestLifecycleState {
+    /// Proposal is known locally and remains actionable.
+    Proposed,
+    /// Proposal is past its expiry.
+    ProposalExpired,
+    /// Request was accepted.
+    Accepted,
+    /// Request was rejected.
+    Rejected,
+    /// Request was canceled.
+    Canceled,
+    /// A one-time Payment Proof was submitted.
+    ProofSubmitted,
+    /// Recurring request is accepted and active.
+    ActiveRecurring,
+    /// Event ordering, dedupe, or lifecycle validation found an invalid state.
+    InvalidConflict,
+}
+
+/// Durable Payment Amount fields copied from Payment Request terms.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentRequestAmountRecord {
+    /// Decimal amount text.
+    pub value: String,
+    /// Asset code or unit.
+    pub asset: String,
+}
+
+/// Recurrence fields copied from Payment Request terms.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentRequestRecurrenceRecord {
+    /// Positive interval count.
+    pub every: u32,
+    /// Recurrence unit string.
+    pub unit: String,
+    /// RFC3339 UTC timestamp using `Z`.
+    pub starts_at: String,
+    /// RFC3339 UTC timestamp using `Z`.
+    pub anchor: String,
+    /// Optional RFC3339 UTC timestamp using `Z`.
+    pub ends_at: Option<String>,
+}
+
+/// Immutable Payment Request terms copied into an SDK record.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct PaymentRequestTermsRecord {
+    /// Requested amount.
+    pub amount: PaymentRequestAmountRecord,
+    /// Payee-provided payment correlation value.
+    pub payment_reference: String,
+    /// Proposal expiry before acceptance.
+    pub proposal_expires_at: Option<String>,
+    /// Optional recurrence.
+    pub recurrence: Option<PaymentRequestRecurrenceRecord>,
+    /// Accepted Payment Endpoint Identifiers.
+    pub accepted_payment_endpoint_identifiers: Vec<String>,
+    /// Application-specific metadata.
+    pub metadata: JsonMap<String, JsonValue>,
+}
+
+impl fmt::Debug for PaymentRequestTermsRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentRequestTermsRecord")
+            .field("amount", &"<redacted>")
+            .field("payment_reference", &self.payment_reference)
+            .field("proposal_expires_at", &self.proposal_expires_at)
+            .field("recurrence", &self.recurrence)
+            .field(
+                "accepted_payment_endpoint_identifiers",
+                &self.accepted_payment_endpoint_identifiers,
+            )
+            .field(
+                "metadata",
+                &format_args!("<redacted:{} fields>", self.metadata.len()),
+            )
+            .finish()
+    }
+}
+
+impl From<&paykit_lib::PaymentRequestTerms> for PaymentRequestTermsRecord {
+    fn from(terms: &paykit_lib::PaymentRequestTerms) -> Self {
+        Self {
+            amount: PaymentRequestAmountRecord {
+                value: terms.amount.value.clone(),
+                asset: terms.amount.asset.clone(),
+            },
+            payment_reference: terms.payment_reference.as_str().to_owned(),
+            proposal_expires_at: terms.proposal_expires_at.clone(),
+            recurrence: terms.recurrence.as_ref().map(|recurrence| {
+                PaymentRequestRecurrenceRecord {
+                    every: recurrence.every,
+                    unit: recurrence_unit_to_str(recurrence.unit).to_owned(),
+                    starts_at: recurrence.starts_at.clone(),
+                    anchor: recurrence.anchor.clone(),
+                    ends_at: recurrence.ends_at.clone(),
+                }
+            }),
+            accepted_payment_endpoint_identifiers: terms
+                .accepted_payment_endpoint_identifiers
+                .iter()
+                .map(|identifier| identifier.as_str().to_owned())
+                .collect(),
+            metadata: terms.metadata.clone(),
+        }
+    }
+}
+
+/// Billing Period fields copied from a Payment Proof.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentRequestBillingPeriodRecord {
+    /// RFC3339 UTC timestamp using `Z`.
+    pub starts_at: String,
+    /// RFC3339 UTC timestamp using `Z`.
+    pub ends_at: String,
+}
+
+impl From<&paykit_lib::BillingPeriod> for PaymentRequestBillingPeriodRecord {
+    fn from(period: &paykit_lib::BillingPeriod) -> Self {
+        Self {
+            starts_at: period.starts_at.clone(),
+            ends_at: period.ends_at.clone(),
+        }
+    }
+}
+
+/// Payment Proof captured in a derived Payment Request record.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct PaymentProofRecord {
+    /// Event ID.
+    pub event_id: String,
+    /// Outbound message id, when proof was sent locally.
+    pub outbound_message_id: Option<u64>,
+    /// Stream item id, when proof was received from the counterparty.
+    pub stream_item_id: Option<u64>,
+    /// Payment Reference copied from the proof.
+    pub payment_reference: String,
+    /// Optional Billing Period copied from the proof.
+    pub billing_period: Option<PaymentRequestBillingPeriodRecord>,
+    /// Payment Endpoint Identifier used for payment.
+    pub payment_endpoint_identifier: String,
+    /// Method-specific proof object.
+    pub proof: JsonMap<String, JsonValue>,
+    /// Local record time for this proof.
+    pub recorded_at: DateTime<Utc>,
+}
+
+impl fmt::Debug for PaymentProofRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentProofRecord")
+            .field("event_id", &self.event_id)
+            .field("outbound_message_id", &self.outbound_message_id)
+            .field("stream_item_id", &self.stream_item_id)
+            .field("payment_reference", &self.payment_reference)
+            .field("billing_period", &self.billing_period)
+            .field(
+                "payment_endpoint_identifier",
+                &self.payment_endpoint_identifier,
+            )
+            .field(
+                "proof",
+                &format_args!("<redacted:{} fields>", self.proof.len()),
+            )
+            .field("recorded_at", &self.recorded_at)
+            .finish()
+    }
+}
+
+/// SDK-derived Payment Request lifecycle record.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct PaymentRequestRecord {
+    /// Counterparty associated with the private stream.
+    pub counterparty: PubkyPublicKey,
+    /// Stable Payment Request ID.
+    pub payment_request_id: String,
+    /// Local role, when known.
+    pub local_role: Option<PaymentRequestLocalRole>,
+    /// Derived lifecycle state.
+    pub state: PaymentRequestLifecycleState,
+    /// Stream item id of the proposal event.
+    pub proposal_stream_item_id: Option<u64>,
+    /// Outbound message id of the proposal event.
+    pub proposal_outbound_message_id: Option<u64>,
+    /// Proposal Event ID.
+    pub proposal_event_id: Option<String>,
+    /// Immutable terms from the proposal.
+    pub terms: Option<PaymentRequestTermsRecord>,
+    /// Acceptance Event ID.
+    pub accepted_event_id: Option<String>,
+    /// Rejection Event ID.
+    pub rejected_event_id: Option<String>,
+    /// Cancellation Event ID.
+    pub canceled_event_id: Option<String>,
+    /// Payment Proof records in local record order.
+    pub payment_proofs: Vec<PaymentProofRecord>,
+    /// Last inbound stream item applied to this record.
+    pub last_stream_item_id: Option<u64>,
+    /// Last outbound message applied to this record.
+    pub last_outbound_message_id: Option<u64>,
+    /// Last event local record time.
+    pub last_event_at: Option<DateTime<Utc>>,
+    /// Invalid state reason, when available.
+    pub invalid_reason: Option<String>,
+}
+
+impl fmt::Debug for PaymentRequestRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentRequestRecord")
+            .field("counterparty", &self.counterparty)
+            .field("payment_request_id", &self.payment_request_id)
+            .field("local_role", &self.local_role)
+            .field("state", &self.state)
+            .field("proposal_stream_item_id", &self.proposal_stream_item_id)
+            .field(
+                "proposal_outbound_message_id",
+                &self.proposal_outbound_message_id,
+            )
+            .field("proposal_event_id", &self.proposal_event_id)
+            .field("accepted_event_id", &self.accepted_event_id)
+            .field("rejected_event_id", &self.rejected_event_id)
+            .field("canceled_event_id", &self.canceled_event_id)
+            .field("payment_proof_count", &self.payment_proofs.len())
+            .field("last_stream_item_id", &self.last_stream_item_id)
+            .field("last_outbound_message_id", &self.last_outbound_message_id)
+            .field("last_event_at", &self.last_event_at)
+            .field("invalid_reason", &self.invalid_reason)
+            .finish()
+    }
+}
+
+impl PaymentRequestRecord {
+    fn new(counterparty: PubkyPublicKey, payment_request_id: String) -> Self {
+        Self {
+            counterparty,
+            payment_request_id,
+            local_role: None,
+            state: PaymentRequestLifecycleState::InvalidConflict,
+            proposal_stream_item_id: None,
+            proposal_outbound_message_id: None,
+            proposal_event_id: None,
+            terms: None,
+            accepted_event_id: None,
+            rejected_event_id: None,
+            canceled_event_id: None,
+            payment_proofs: Vec::new(),
+            last_stream_item_id: None,
+            last_outbound_message_id: None,
+            last_event_at: None,
+            invalid_reason: None,
+        }
+    }
+
+    fn touch(&mut self, item: &PrivateStreamItemRecord) {
+        self.last_stream_item_id = Some(item.stream_item_id);
+        self.last_event_at = Some(item.received_at);
+    }
+
+    fn touch_outbound(&mut self, message: &OutboundPrivateMessageRecord) {
+        self.last_outbound_message_id = Some(message.outbound_message_id);
+        self.last_event_at = Some(message.created_at);
+    }
+
+    fn mark_invalid(&mut self, item: &PrivateStreamItemRecord, reason: impl Into<String>) {
+        self.state = PaymentRequestLifecycleState::InvalidConflict;
+        if self.invalid_reason.is_none() {
+            self.invalid_reason = Some(reason.into());
+        }
+        self.touch(item);
+    }
+}
+
+/// Derive received Payment Request lifecycle records for one counterparty.
+///
+/// Records are derived from the persisted inbound private stream and returned
+/// newest-first by the last applied stream item. Malformed recognized Payment
+/// Request events without a valid `payment_request_id` remain available in the
+/// raw private stream log but cannot be attached to a request-scoped record.
+pub async fn received_payment_request_records<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    now: DateTime<Utc>,
+) -> Result<Vec<PaymentRequestRecord>>
+where
+    S: StorageAdapter,
+{
+    let (items, dedupe_records) = storage
+        .transaction(|tx| {
+            let items = tx.private_stream_items(counterparty);
+            let mut dedupe_records = HashMap::new();
+            for item in &items {
+                let Some(message) = payment_request_message_from_item(item) else {
+                    continue;
+                };
+                let Some(parsed) = parse_payment_request_event_message(&message) else {
+                    continue;
+                };
+                let Some(event_id) = parsed.event_id() else {
+                    continue;
+                };
+                if let Some(record) = tx.event_dedup_record(counterparty, event_id.as_str()) {
+                    dedupe_records.insert(event_id.as_str().to_owned(), record);
+                }
+            }
+            Ok((items, dedupe_records))
+        })
+        .await?;
+    derive_received_payment_request_records(counterparty.clone(), items, dedupe_records, now)
+}
+
+/// Derive local Payment Request records for one counterparty.
+///
+/// Records merge received Payment Request events from the private stream with
+/// local outbound Payment Request events from the outbound private-message log.
+/// Returned records are newest-first by local record time.
+pub async fn payment_request_records<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    now: DateTime<Utc>,
+) -> Result<Vec<PaymentRequestRecord>>
+where
+    S: StorageAdapter,
+{
+    let (items, outbound, dedupe_records) = storage
+        .transaction(|tx| {
+            let items = tx.private_stream_items(counterparty);
+            let outbound = tx.outbound_private_messages(counterparty);
+            let mut dedupe_records = HashMap::new();
+            for item in &items {
+                let Some(message) = payment_request_message_from_item(item) else {
+                    continue;
+                };
+                let Some(parsed) = parse_payment_request_event_message(&message) else {
+                    continue;
+                };
+                let Some(event_id) = parsed.event_id() else {
+                    continue;
+                };
+                if let Some(record) = tx.event_dedup_record(counterparty, event_id.as_str()) {
+                    dedupe_records.insert(event_id.as_str().to_owned(), record);
+                }
+            }
+            Ok((items, outbound, dedupe_records))
+        })
+        .await?;
+    derive_payment_request_records(counterparty.clone(), items, outbound, dedupe_records, now)
+}
+
+/// Queue one raw Payment Request protocol event for outbound delivery.
+///
+/// The exact canonical JSON payload is serialized before it is stored, so retry
+/// workers can resend the same Event ID and payload.
+pub(crate) async fn enqueue_payment_request_event<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentRequestEvent,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let raw_json = serialize_payment_request_event(event)?;
+    enqueue_private_message(storage, counterparty, raw_json, now).await
+}
+
+/// Queue a raw Payment Request proposal for outbound delivery.
+pub(crate) async fn enqueue_payment_request<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentRequest,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let event = PaymentRequestEvent::Request(event.clone());
+    enqueue_payment_request_event(storage, counterparty, &event, now).await
+}
+
+/// Queue a raw Payment Request acceptance for outbound delivery.
+pub(crate) async fn enqueue_payment_request_acceptance<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentRequestAcceptance,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let event = PaymentRequestEvent::Acceptance(event.clone());
+    enqueue_payment_request_event(storage, counterparty, &event, now).await
+}
+
+/// Queue a raw Payment Request rejection for outbound delivery.
+pub(crate) async fn enqueue_payment_request_rejection<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentRequestRejection,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let event = PaymentRequestEvent::Rejection(event.clone());
+    enqueue_payment_request_event(storage, counterparty, &event, now).await
+}
+
+/// Queue a raw Payment Request cancellation for outbound delivery.
+pub(crate) async fn enqueue_payment_request_cancellation<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentRequestCancellation,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let event = PaymentRequestEvent::Cancellation(event.clone());
+    enqueue_payment_request_event(storage, counterparty, &event, now).await
+}
+
+/// Queue a raw Payment Proof for outbound delivery.
+pub(crate) async fn enqueue_payment_proof<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentProof,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let event = PaymentRequestEvent::Proof(event.clone());
+    enqueue_payment_request_event(storage, counterparty, &event, now).await
+}
+
+fn derive_received_payment_request_records(
+    counterparty: PubkyPublicKey,
+    mut items: Vec<PrivateStreamItemRecord>,
+    dedupe_records: HashMap<String, EventDedupRecord>,
+    now: DateTime<Utc>,
+) -> Result<Vec<PaymentRequestRecord>> {
+    items.sort_by_key(|item| item.stream_item_id);
+    let mut records = HashMap::<String, PaymentRequestRecord>::new();
+
+    for item in items {
+        let Some(message) = payment_request_message_from_item(&item) else {
+            continue;
+        };
+        let Some(parsed) = parse_payment_request_event_message(&message) else {
+            continue;
+        };
+        let payment_request_id = parsed.payment_request_id().map(|id| id.as_str().to_owned());
+        let event_id = parsed.event_id().map(|id| id.as_str().to_owned());
+
+        if let Some(event_id) = event_id.as_deref() {
+            if let Some(dedupe) = dedupe_records.get(event_id) {
+                if dedupe
+                    .duplicate_stream_item_ids
+                    .contains(&item.stream_item_id)
+                {
+                    continue;
+                }
+                if dedupe
+                    .conflicting_stream_item_ids
+                    .contains(&item.stream_item_id)
+                    || (dedupe.first_stream_item_id == item.stream_item_id
+                        && !dedupe.conflicting_stream_item_ids.is_empty())
+                {
+                    if let Some(payment_request_id) = payment_request_id {
+                        record_for(&mut records, &counterparty, payment_request_id)
+                            .mark_invalid(&item, "Event ID reused with different payload");
+                    }
+                    continue;
+                }
+            }
+        }
+
+        let Some(payment_request_id) = payment_request_id else {
+            continue;
+        };
+        let record = record_for(&mut records, &counterparty, payment_request_id);
+        if !parsed.is_valid() {
+            record.mark_invalid(
+                &item,
+                parsed
+                    .validation_error()
+                    .unwrap_or("malformed Payment Request event"),
+            );
+            continue;
+        }
+        let event = parsed.parsed_event().expect("valid event");
+        apply_event(record, event, &item, now);
+    }
+
+    for record in records.values_mut() {
+        if record.state == PaymentRequestLifecycleState::Proposed && proposal_expired(record, now) {
+            record.state = PaymentRequestLifecycleState::ProposalExpired;
+        }
+    }
+
+    let mut records = records.into_values().collect::<Vec<_>>();
+    records.sort_by_key(|record| {
+        Reverse(
+            record
+                .last_stream_item_id
+                .or(record.proposal_stream_item_id),
+        )
+    });
+    Ok(records)
+}
+
+#[derive(Clone)]
+enum StoredPaymentRequestEvent {
+    Received {
+        item: PrivateStreamItemRecord,
+        event: PaymentRequestEvent,
+    },
+    Outbound {
+        message: OutboundPrivateMessageRecord,
+        event: PaymentRequestEvent,
+    },
+}
+
+impl StoredPaymentRequestEvent {
+    fn record_time(&self) -> DateTime<Utc> {
+        match self {
+            Self::Received { item, .. } => item.received_at,
+            Self::Outbound { message, .. } => message.created_at,
+        }
+    }
+
+    fn kind_order(&self) -> u8 {
+        match self.event() {
+            PaymentRequestEvent::Request(_) => 0,
+            PaymentRequestEvent::Acceptance(_) | PaymentRequestEvent::Rejection(_) => 1,
+            PaymentRequestEvent::Cancellation(_) => 2,
+            PaymentRequestEvent::Proof(_) => 3,
+        }
+    }
+
+    fn source_order(&self) -> u64 {
+        match self {
+            Self::Received { item, .. } => item.stream_item_id,
+            Self::Outbound { message, .. } => message.outbound_message_id,
+        }
+    }
+
+    fn source_rank(&self) -> u8 {
+        match self {
+            Self::Received { .. } => 0,
+            Self::Outbound { .. } => 1,
+        }
+    }
+
+    fn payload_hash(&self) -> String {
+        match self {
+            Self::Received { item, .. } => payload_hash(&item.raw_json),
+            Self::Outbound { message, .. } => payload_hash(&message.raw_json),
+        }
+    }
+
+    fn event(&self) -> &PaymentRequestEvent {
+        match self {
+            Self::Received { event, .. } | Self::Outbound { event, .. } => event,
+        }
+    }
+
+    fn payment_request_id(&self) -> String {
+        self.event().payment_request_id().as_str().to_owned()
+    }
+
+    fn event_id(&self) -> String {
+        self.event().event_id().as_str().to_owned()
+    }
+}
+
+fn derive_payment_request_records(
+    counterparty: PubkyPublicKey,
+    mut items: Vec<PrivateStreamItemRecord>,
+    outbound: Vec<OutboundPrivateMessageRecord>,
+    dedupe_records: HashMap<String, EventDedupRecord>,
+    now: DateTime<Utc>,
+) -> Result<Vec<PaymentRequestRecord>> {
+    let mut records = HashMap::<String, PaymentRequestRecord>::new();
+    let mut events = Vec::<StoredPaymentRequestEvent>::new();
+    let mut pre_invalid_request_ids = HashSet::<String>::new();
+    let mut tainted_event_seeds = Vec::<TaintedEventSeed>::new();
+
+    items.sort_by_key(|item| item.stream_item_id);
+    for item in items {
+        let Some(message) = payment_request_message_from_item(&item) else {
+            continue;
+        };
+        let Some(parsed) = parse_payment_request_event_message(&message) else {
+            continue;
+        };
+        let payment_request_id = parsed.payment_request_id().map(|id| id.as_str().to_owned());
+        let event_id = parsed.event_id().map(|id| id.as_str().to_owned());
+
+        if let Some(event_id) = event_id.as_deref() {
+            if let Some(dedupe) = dedupe_records.get(event_id) {
+                if dedupe
+                    .duplicate_stream_item_ids
+                    .contains(&item.stream_item_id)
+                {
+                    continue;
+                }
+                if dedupe
+                    .conflicting_stream_item_ids
+                    .contains(&item.stream_item_id)
+                    || (dedupe.first_stream_item_id == item.stream_item_id
+                        && !dedupe.conflicting_stream_item_ids.is_empty())
+                {
+                    if let Some(payment_request_id) = payment_request_id {
+                        tainted_event_seeds.push(TaintedEventSeed {
+                            event_id: event_id.to_owned(),
+                            payment_request_id: payment_request_id.clone(),
+                            payload_hash: payload_hash(&item.raw_json),
+                            source_rank: 0,
+                        });
+                        pre_invalid_request_ids.insert(payment_request_id.clone());
+                        record_for(&mut records, &counterparty, payment_request_id)
+                            .mark_invalid(&item, "Event ID reused with different payload");
+                    } else {
+                        tainted_event_seeds.push(TaintedEventSeed {
+                            event_id: event_id.to_owned(),
+                            payment_request_id: String::new(),
+                            payload_hash: payload_hash(&item.raw_json),
+                            source_rank: 0,
+                        });
+                    }
+                    continue;
+                }
+            }
+        }
+
+        let Some(payment_request_id) = payment_request_id else {
+            if let Some(event_id) = event_id {
+                tainted_event_seeds.push(TaintedEventSeed {
+                    event_id,
+                    payment_request_id: String::new(),
+                    payload_hash: payload_hash(&item.raw_json),
+                    source_rank: 0,
+                });
+            }
+            continue;
+        };
+        if !parsed.is_valid() {
+            if let Some(event_id) = event_id {
+                tainted_event_seeds.push(TaintedEventSeed {
+                    event_id,
+                    payment_request_id: payment_request_id.clone(),
+                    payload_hash: payload_hash(&item.raw_json),
+                    source_rank: 0,
+                });
+            }
+            pre_invalid_request_ids.insert(payment_request_id.clone());
+            record_for(&mut records, &counterparty, payment_request_id).mark_invalid(
+                &item,
+                parsed
+                    .validation_error()
+                    .unwrap_or("malformed Payment Request event"),
+            );
+            continue;
+        }
+        events.push(StoredPaymentRequestEvent::Received {
+            item,
+            event: parsed.parsed_event().expect("valid event").clone(),
+        });
+    }
+
+    for message in outbound {
+        if message.status == OutboundPrivateMessageStatus::Invalid {
+            continue;
+        }
+        let Some(parsed) = parse_payment_request_event_message(&PrivateApplicationMessage {
+            version: Some(1),
+            kind: Some(message.kind.clone()),
+            raw_json: message.raw_json.clone(),
+        }) else {
+            continue;
+        };
+        let Some(event) = parsed.parsed_event() else {
+            continue;
+        };
+        let stored = StoredPaymentRequestEvent::Outbound {
+            message,
+            event: event.clone(),
+        };
+        if dedupe_records
+            .get(event.event_id().as_str())
+            .is_some_and(|dedupe| !dedupe.conflicting_stream_item_ids.is_empty())
+        {
+            let record = record_for(&mut records, &counterparty, stored.payment_request_id());
+            mark_invalid_stored(record, &stored, "Event ID reused with different payload");
+            continue;
+        }
+        events.push(stored);
+    }
+
+    events.sort_by(compare_stored_events);
+    let tainted_events = events
+        .iter()
+        .filter(|event| pre_invalid_request_ids.contains(&event.payment_request_id()))
+        .cloned()
+        .collect::<Vec<_>>();
+    events.retain(|event| !pre_invalid_request_ids.contains(&event.payment_request_id()));
+    events = dedupe_stored_events(
+        &counterparty,
+        &mut records,
+        events,
+        tainted_events,
+        tainted_event_seeds,
+    );
+    for event in events {
+        let payment_request_id = event.payment_request_id();
+        let record = record_for(&mut records, &counterparty, payment_request_id);
+        apply_stored_event(record, &event);
+    }
+
+    for record in records.values_mut() {
+        if record.state == PaymentRequestLifecycleState::Proposed && proposal_expired(record, now) {
+            record.state = PaymentRequestLifecycleState::ProposalExpired;
+        }
+    }
+
+    let mut records = records.into_values().collect::<Vec<_>>();
+    records.sort_by_key(|record| {
+        Reverse((
+            record.last_event_at,
+            record
+                .last_outbound_message_id
+                .or(record.last_stream_item_id),
+        ))
+    });
+    Ok(records)
+}
+
+fn compare_stored_events(a: &StoredPaymentRequestEvent, b: &StoredPaymentRequestEvent) -> Ordering {
+    a.record_time().cmp(&b.record_time()).then_with(|| {
+        if a.source_rank() == b.source_rank() {
+            a.source_order().cmp(&b.source_order())
+        } else {
+            a.kind_order()
+                .cmp(&b.kind_order())
+                .then_with(|| a.source_rank().cmp(&b.source_rank()))
+        }
+    })
+}
+
+#[derive(Clone)]
+struct StoredEventDedupeEntry {
+    payload_hash: String,
+    event: Option<StoredPaymentRequestEvent>,
+    payment_request_id: String,
+    source_rank: u8,
+    tainted: bool,
+}
+
+struct TaintedEventSeed {
+    event_id: String,
+    payment_request_id: String,
+    payload_hash: String,
+    source_rank: u8,
+}
+
+fn dedupe_stored_events(
+    counterparty: &PubkyPublicKey,
+    records: &mut HashMap<String, PaymentRequestRecord>,
+    events: Vec<StoredPaymentRequestEvent>,
+    tainted_events: Vec<StoredPaymentRequestEvent>,
+    tainted_event_seeds: Vec<TaintedEventSeed>,
+) -> Vec<StoredPaymentRequestEvent> {
+    let mut first_by_event_id = HashMap::<String, StoredEventDedupeEntry>::new();
+    let mut conflicted_event_ids = HashSet::<String>::new();
+    let mut conflicted_request_ids = HashSet::<String>::new();
+    let mut deduped = Vec::new();
+
+    for event in tainted_events {
+        first_by_event_id
+            .entry(event.event_id())
+            .or_insert_with(|| {
+                let payload_hash = event.payload_hash();
+                let payment_request_id = event.payment_request_id();
+                let source_rank = event.source_rank();
+                StoredEventDedupeEntry {
+                    payload_hash,
+                    event: Some(event),
+                    payment_request_id,
+                    source_rank,
+                    tainted: true,
+                }
+            });
+    }
+    for seed in tainted_event_seeds {
+        first_by_event_id
+            .entry(seed.event_id)
+            .or_insert_with(|| StoredEventDedupeEntry {
+                payload_hash: seed.payload_hash,
+                event: None,
+                payment_request_id: seed.payment_request_id,
+                source_rank: seed.source_rank,
+                tainted: true,
+            });
+    }
+
+    for event in events {
+        let event_id = event.event_id();
+        let current_hash = event.payload_hash();
+        if let Some(first) = first_by_event_id.get(&event_id) {
+            if first.payload_hash == current_hash
+                && !first.tainted
+                && first.source_rank == event.source_rank()
+            {
+                continue;
+            }
+            if !first.tainted {
+                let first_event = first.event.as_ref().expect("valid stored event");
+                let first_record =
+                    record_for(records, counterparty, first.payment_request_id.clone());
+                mark_invalid_stored(
+                    first_record,
+                    first_event,
+                    "Event ID reused with different payload",
+                );
+                conflicted_request_ids.insert(first.payment_request_id.clone());
+            }
+            let current_record = record_for(records, counterparty, event.payment_request_id());
+            mark_invalid_stored(
+                current_record,
+                &event,
+                "Event ID reused with different payload",
+            );
+            conflicted_event_ids.insert(event_id);
+            conflicted_request_ids.insert(event.payment_request_id());
+            continue;
+        }
+
+        first_by_event_id.insert(
+            event_id,
+            StoredEventDedupeEntry {
+                payload_hash: current_hash,
+                payment_request_id: event.payment_request_id(),
+                source_rank: event.source_rank(),
+                event: Some(event.clone()),
+                tainted: false,
+            },
+        );
+        deduped.push(event);
+    }
+
+    deduped.retain(|event| {
+        !conflicted_event_ids.contains(&event.event_id())
+            && !conflicted_request_ids.contains(&event.payment_request_id())
+    });
+    deduped
+}
+
+fn record_for<'a>(
+    records: &'a mut HashMap<String, PaymentRequestRecord>,
+    counterparty: &PubkyPublicKey,
+    payment_request_id: String,
+) -> &'a mut PaymentRequestRecord {
+    records
+        .entry(payment_request_id.clone())
+        .or_insert_with(|| PaymentRequestRecord::new(counterparty.clone(), payment_request_id))
+}
+
+fn payment_request_message_from_item(
+    item: &PrivateStreamItemRecord,
+) -> Option<PrivateApplicationMessage> {
+    let kind = item.known_paykit_kind.as_deref()?;
+    if !is_payment_request_kind(kind) {
+        return None;
+    }
+    Some(PrivateApplicationMessage {
+        version: item
+            .parsed_version
+            .and_then(|version| u8::try_from(version).ok()),
+        kind: item.parsed_kind.clone(),
+        raw_json: item.raw_json.clone(),
+    })
+}
+
+fn is_payment_request_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "paykit.payment_request"
+            | "paykit.payment_request_acceptance"
+            | "paykit.payment_request_rejection"
+            | "paykit.payment_request_cancellation"
+            | "paykit.payment_proof"
+    )
+}
+
+fn apply_event(
+    record: &mut PaymentRequestRecord,
+    event: &PaymentRequestEvent,
+    item: &PrivateStreamItemRecord,
+    now: DateTime<Utc>,
+) {
+    if record.state == PaymentRequestLifecycleState::InvalidConflict
+        && record.last_stream_item_id.is_some()
+    {
+        record.touch(item);
+        return;
+    }
+
+    match event {
+        PaymentRequestEvent::Request(request) => apply_request(record, request, item),
+        PaymentRequestEvent::Acceptance(_) => {
+            if record.terms.is_none() {
+                record.mark_invalid(item, "Payment Request acceptance arrived before proposal");
+                return;
+            }
+            record.mark_invalid(
+                item,
+                "Payment Request acceptance is an outbound payer event for a received proposal",
+            );
+        }
+        PaymentRequestEvent::Rejection(_) => {
+            if record.terms.is_none() {
+                record.mark_invalid(item, "Payment Request rejection arrived before proposal");
+                return;
+            }
+            record.mark_invalid(
+                item,
+                "Payment Request rejection is an outbound payer event for a received proposal",
+            );
+        }
+        PaymentRequestEvent::Cancellation(cancellation) => {
+            if record.terms.is_none() {
+                record.mark_invalid(item, "Payment Request cancellation arrived before proposal");
+                return;
+            }
+            if matches!(
+                record.state,
+                PaymentRequestLifecycleState::Canceled
+                    | PaymentRequestLifecycleState::InvalidConflict
+            ) {
+                record.mark_invalid(
+                    item,
+                    "Payment Request cancellation arrived after terminal state",
+                );
+                return;
+            }
+            record.canceled_event_id = Some(cancellation.event_id.as_str().to_owned());
+            record.state = PaymentRequestLifecycleState::Canceled;
+            record.touch(item);
+        }
+        PaymentRequestEvent::Proof(_) => {
+            if record.terms.is_none() {
+                record.mark_invalid(item, "Payment Proof arrived before acceptance");
+                return;
+            }
+            record.mark_invalid(
+                item,
+                "Payment Proof is an outbound payer event for a received proposal",
+            );
+        }
+    }
+
+    if record.state == PaymentRequestLifecycleState::Proposed && proposal_expired(record, now) {
+        record.state = PaymentRequestLifecycleState::ProposalExpired;
+    }
+}
+
+fn apply_request(
+    record: &mut PaymentRequestRecord,
+    request: &PaymentRequest,
+    item: &PrivateStreamItemRecord,
+) {
+    if record.state == PaymentRequestLifecycleState::InvalidConflict
+        && record.last_stream_item_id.is_some()
+    {
+        record.touch(item);
+        return;
+    }
+    if record.terms.is_some() {
+        record.mark_invalid(
+            item,
+            "multiple Payment Request proposals used the same Payment Request ID",
+        );
+        return;
+    }
+    record.local_role = Some(PaymentRequestLocalRole::Payer);
+    record.state = PaymentRequestLifecycleState::Proposed;
+    record.proposal_stream_item_id = Some(item.stream_item_id);
+    record.proposal_event_id = Some(request.event_id.as_str().to_owned());
+    record.terms = Some(PaymentRequestTermsRecord::from(&request.request));
+    record.touch(item);
+}
+
+fn apply_stored_event(record: &mut PaymentRequestRecord, stored: &StoredPaymentRequestEvent) {
+    if record.state == PaymentRequestLifecycleState::InvalidConflict
+        && (record.last_stream_item_id.is_some() || record.last_outbound_message_id.is_some())
+    {
+        touch_stored(record, stored);
+        return;
+    }
+
+    match stored.event() {
+        PaymentRequestEvent::Request(request) => apply_stored_request(record, stored, request),
+        PaymentRequestEvent::Acceptance(acceptance) => {
+            if !payer_action_source_allowed(record, stored) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request acceptance came from the wrong side",
+                );
+                return;
+            }
+            if !has_terms(
+                record,
+                stored,
+                "Payment Request acceptance arrived before proposal",
+            ) {
+                return;
+            }
+            if proposal_expired(record, stored.record_time()) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request acceptance arrived after proposal expiry",
+                );
+                return;
+            }
+            if !matches!(record.state, PaymentRequestLifecycleState::Proposed) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request acceptance arrived after transition",
+                );
+                return;
+            }
+            record.accepted_event_id = Some(acceptance.event_id.as_str().to_owned());
+            record.state = if record
+                .terms
+                .as_ref()
+                .and_then(|terms| terms.recurrence.as_ref())
+                .is_some()
+            {
+                PaymentRequestLifecycleState::ActiveRecurring
+            } else {
+                PaymentRequestLifecycleState::Accepted
+            };
+            touch_stored(record, stored);
+        }
+        PaymentRequestEvent::Rejection(rejection) => {
+            if !payer_action_source_allowed(record, stored) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request rejection came from the wrong side",
+                );
+                return;
+            }
+            if !has_terms(
+                record,
+                stored,
+                "Payment Request rejection arrived before proposal",
+            ) {
+                return;
+            }
+            if proposal_expired(record, stored.record_time()) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request rejection arrived after proposal expiry",
+                );
+                return;
+            }
+            if !matches!(record.state, PaymentRequestLifecycleState::Proposed) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request rejection arrived after transition",
+                );
+                return;
+            }
+            record.rejected_event_id = Some(rejection.event_id.as_str().to_owned());
+            record.state = PaymentRequestLifecycleState::Rejected;
+            touch_stored(record, stored);
+        }
+        PaymentRequestEvent::Cancellation(cancellation) => {
+            if !has_terms(
+                record,
+                stored,
+                "Payment Request cancellation arrived before proposal",
+            ) {
+                return;
+            }
+            if matches!(
+                record.state,
+                PaymentRequestLifecycleState::Rejected
+                    | PaymentRequestLifecycleState::Canceled
+                    | PaymentRequestLifecycleState::InvalidConflict
+            ) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request cancellation arrived after terminal state",
+                );
+                return;
+            }
+            record.canceled_event_id = Some(cancellation.event_id.as_str().to_owned());
+            record.state = PaymentRequestLifecycleState::Canceled;
+            touch_stored(record, stored);
+        }
+        PaymentRequestEvent::Proof(proof) => {
+            if !payer_action_source_allowed(record, stored) {
+                mark_invalid_stored(record, stored, "Payment Proof came from the wrong side");
+                return;
+            }
+            if !matches!(
+                record.state,
+                PaymentRequestLifecycleState::Accepted
+                    | PaymentRequestLifecycleState::ActiveRecurring
+            ) {
+                mark_invalid_stored(record, stored, "Payment Proof arrived before acceptance");
+                return;
+            }
+            let Some(request) = request_from_record(record) else {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Proof cannot be correlated without proposal",
+                );
+                return;
+            };
+            if let Err(err) = proof.validate_for_request(&request) {
+                mark_invalid_stored(record, stored, err.to_string());
+                return;
+            }
+            record.payment_proofs.push(PaymentProofRecord {
+                event_id: proof.event_id.as_str().to_owned(),
+                outbound_message_id: match stored {
+                    StoredPaymentRequestEvent::Outbound { message, .. } => {
+                        Some(message.outbound_message_id)
+                    }
+                    StoredPaymentRequestEvent::Received { .. } => None,
+                },
+                stream_item_id: match stored {
+                    StoredPaymentRequestEvent::Received { item, .. } => Some(item.stream_item_id),
+                    StoredPaymentRequestEvent::Outbound { .. } => None,
+                },
+                payment_reference: proof.payment_reference.as_str().to_owned(),
+                billing_period: proof
+                    .billing_period
+                    .as_ref()
+                    .map(PaymentRequestBillingPeriodRecord::from),
+                payment_endpoint_identifier: proof.payment_endpoint_identifier.as_str().to_owned(),
+                proof: proof.proof.clone(),
+                recorded_at: stored.record_time(),
+            });
+            record.state = if record
+                .terms
+                .as_ref()
+                .and_then(|terms| terms.recurrence.as_ref())
+                .is_some()
+            {
+                PaymentRequestLifecycleState::ActiveRecurring
+            } else {
+                PaymentRequestLifecycleState::ProofSubmitted
+            };
+            touch_stored(record, stored);
+        }
+    }
+}
+
+fn apply_stored_request(
+    record: &mut PaymentRequestRecord,
+    stored: &StoredPaymentRequestEvent,
+    request: &PaymentRequest,
+) {
+    if record.state == PaymentRequestLifecycleState::InvalidConflict
+        && (record.last_stream_item_id.is_some() || record.last_outbound_message_id.is_some())
+    {
+        touch_stored(record, stored);
+        return;
+    }
+    if record.terms.is_some() {
+        mark_invalid_stored(
+            record,
+            stored,
+            "multiple Payment Request proposals used the same Payment Request ID",
+        );
+        return;
+    }
+    record.local_role = Some(match stored {
+        StoredPaymentRequestEvent::Received { .. } => PaymentRequestLocalRole::Payer,
+        StoredPaymentRequestEvent::Outbound { .. } => PaymentRequestLocalRole::Payee,
+    });
+    record.state = PaymentRequestLifecycleState::Proposed;
+    match stored {
+        StoredPaymentRequestEvent::Received { item, .. } => {
+            record.proposal_stream_item_id = Some(item.stream_item_id);
+        }
+        StoredPaymentRequestEvent::Outbound { message, .. } => {
+            record.proposal_outbound_message_id = Some(message.outbound_message_id);
+        }
+    }
+    record.proposal_event_id = Some(request.event_id.as_str().to_owned());
+    record.terms = Some(PaymentRequestTermsRecord::from(&request.request));
+    touch_stored(record, stored);
+}
+
+fn has_terms(
+    record: &mut PaymentRequestRecord,
+    stored: &StoredPaymentRequestEvent,
+    reason: &str,
+) -> bool {
+    if record.terms.is_some() {
+        true
+    } else {
+        mark_invalid_stored(record, stored, reason);
+        false
+    }
+}
+
+fn payer_action_source_allowed(
+    record: &PaymentRequestRecord,
+    stored: &StoredPaymentRequestEvent,
+) -> bool {
+    matches!(
+        (record.local_role, stored),
+        (
+            Some(PaymentRequestLocalRole::Payer),
+            StoredPaymentRequestEvent::Outbound { .. }
+        ) | (
+            Some(PaymentRequestLocalRole::Payee),
+            StoredPaymentRequestEvent::Received { .. }
+        )
+    )
+}
+
+fn touch_stored(record: &mut PaymentRequestRecord, stored: &StoredPaymentRequestEvent) {
+    match stored {
+        StoredPaymentRequestEvent::Received { item, .. } => record.touch(item),
+        StoredPaymentRequestEvent::Outbound { message, .. } => record.touch_outbound(message),
+    }
+}
+
+fn mark_invalid_stored(
+    record: &mut PaymentRequestRecord,
+    stored: &StoredPaymentRequestEvent,
+    reason: impl Into<String>,
+) {
+    record.state = PaymentRequestLifecycleState::InvalidConflict;
+    if record.invalid_reason.is_none() {
+        record.invalid_reason = Some(reason.into());
+    }
+    touch_stored(record, stored);
+}
+
+pub(crate) fn request_from_record(record: &PaymentRequestRecord) -> Option<PaymentRequest> {
+    let terms = record.terms.as_ref()?;
+    let proposal_event_id = record.proposal_event_id.as_ref()?;
+    let recurrence = if let Some(recurrence) = &terms.recurrence {
+        Some(paykit_lib::Recurrence {
+            every: recurrence.every,
+            unit: parse_recurrence_unit(&recurrence.unit)?,
+            starts_at: recurrence.starts_at.clone(),
+            anchor: recurrence.anchor.clone(),
+            ends_at: recurrence.ends_at.clone(),
+        })
+    } else {
+        None
+    };
+    Some(PaymentRequest::new(
+        paykit_lib::EventId::new(proposal_event_id).ok()?,
+        paykit_lib::PaymentRequestId::new(record.payment_request_id.clone()).ok()?,
+        paykit_lib::PaymentRequestTerms {
+            amount: paykit_lib::PaymentAmount::new(
+                terms.amount.value.clone(),
+                terms.amount.asset.clone(),
+            )
+            .ok()?,
+            payment_reference: paykit_lib::PaymentReference::new(terms.payment_reference.clone())
+                .ok()?,
+            proposal_expires_at: terms.proposal_expires_at.clone(),
+            recurrence,
+            accepted_payment_endpoint_identifiers: terms
+                .accepted_payment_endpoint_identifiers
+                .iter()
+                .map(|identifier| paykit_lib::PaymentEndpointIdentifier::new(identifier).ok())
+                .collect::<Option<Vec<_>>>()?,
+            metadata: terms.metadata.clone(),
+        },
+    ))
+}
+
+fn proposal_expired(record: &PaymentRequestRecord, now: DateTime<Utc>) -> bool {
+    record
+        .terms
+        .as_ref()
+        .and_then(|terms| terms.proposal_expires_at.as_ref())
+        .and_then(|expires_at| DateTime::parse_from_rfc3339(expires_at).ok())
+        .map(|expires_at| now >= expires_at.with_timezone(&Utc))
+        .unwrap_or(false)
+}
+
+fn recurrence_unit_to_str(unit: paykit_lib::RecurrenceUnit) -> &'static str {
+    match unit {
+        paykit_lib::RecurrenceUnit::Minute => "minute",
+        paykit_lib::RecurrenceUnit::Hour => "hour",
+        paykit_lib::RecurrenceUnit::Day => "day",
+        paykit_lib::RecurrenceUnit::Week => "week",
+        paykit_lib::RecurrenceUnit::Month => "month",
+        paykit_lib::RecurrenceUnit::Year => "year",
+    }
+}
+
+fn parse_recurrence_unit(unit: &str) -> Option<paykit_lib::RecurrenceUnit> {
+    match unit {
+        "minute" => Some(paykit_lib::RecurrenceUnit::Minute),
+        "hour" => Some(paykit_lib::RecurrenceUnit::Hour),
+        "day" => Some(paykit_lib::RecurrenceUnit::Day),
+        "week" => Some(paykit_lib::RecurrenceUnit::Week),
+        "month" => Some(paykit_lib::RecurrenceUnit::Month),
+        "year" => Some(paykit_lib::RecurrenceUnit::Year),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+    use crate::{
+        outbound_private::{
+            enqueue_private_message as enqueue_untyped_private_message,
+            queued_outbound_private_messages,
+        },
+        private_stream::persist_private_stream_batch,
+        storage::InMemoryStorage,
+    };
+
+    fn timestamp() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+    }
+
+    fn counterparty() -> PubkyPublicKey {
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+    }
+
+    fn private_message(raw_json: String) -> PrivateApplicationMessage {
+        let value: serde_json::Value = serde_json::from_str(&raw_json).unwrap();
+        PrivateApplicationMessage {
+            version: value
+                .get("version")
+                .and_then(serde_json::Value::as_u64)
+                .and_then(|version| u8::try_from(version).ok()),
+            kind: value
+                .get("kind")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
+            raw_json,
+        }
+    }
+
+    fn parsed_event(raw_json: String) -> PaymentRequestEvent {
+        parse_payment_request_event_message(&private_message(raw_json))
+            .unwrap()
+            .parsed_event()
+            .unwrap()
+            .clone()
+    }
+
+    fn request_raw(
+        event_id: &str,
+        request_id: &str,
+        reference: &str,
+        expires_at: Option<&str>,
+        recurrence: Option<&str>,
+    ) -> String {
+        let expiry = expires_at
+            .map(|value| format!(r#""{value}""#))
+            .unwrap_or_else(|| "null".into());
+        let recurrence = recurrence.unwrap_or("null");
+        format!(
+            r#"{{"version":1,"kind":"paykit.payment_request","event_id":"{event_id}","payment_request_id":"{request_id}","request":{{"amount":{{"value":"0.001","asset":"btc"}},"payment_reference":"{reference}","proposal_expires_at":{expiry},"recurrence":{recurrence},"accepted_payment_endpoint_identifiers":["btc-lightning-bolt11"],"metadata":{{"note":"private"}}}}}}"#
+        )
+    }
+
+    fn acceptance_raw(event_id: &str, request_id: &str) -> String {
+        format!(
+            r#"{{"version":1,"kind":"paykit.payment_request_acceptance","event_id":"{event_id}","payment_request_id":"{request_id}"}}"#
+        )
+    }
+
+    fn rejection_raw(event_id: &str, request_id: &str) -> String {
+        format!(
+            r#"{{"version":1,"kind":"paykit.payment_request_rejection","event_id":"{event_id}","payment_request_id":"{request_id}"}}"#
+        )
+    }
+
+    fn cancellation_raw(event_id: &str, request_id: &str) -> String {
+        format!(
+            r#"{{"version":1,"kind":"paykit.payment_request_cancellation","event_id":"{event_id}","payment_request_id":"{request_id}"}}"#
+        )
+    }
+
+    fn malformed_cancellation_raw(event_id: &str, request_id: &str) -> String {
+        format!(
+            r#"{{"version":1,"kind":"paykit.payment_request_cancellation","event_id":"{event_id}","payment_request_id":"{request_id}","reason":null}}"#
+        )
+    }
+
+    fn malformed_missing_request_id_raw(event_id: &str) -> String {
+        format!(
+            r#"{{"version":1,"kind":"paykit.payment_request_acceptance","event_id":"{event_id}"}}"#
+        )
+    }
+
+    fn proof_raw(event_id: &str, request_id: &str, reference: &str) -> String {
+        format!(
+            r#"{{"version":1,"kind":"paykit.payment_proof","event_id":"{event_id}","payment_request_id":"{request_id}","payment_reference":"{reference}","billing_period":null,"payment_endpoint_identifier":"btc-lightning-bolt11","proof":{{"txid":"secret"}}}}"#
+        )
+    }
+
+    async fn persist_messages(
+        storage: &InMemoryStorage,
+        counterparty: PubkyPublicKey,
+        messages: Vec<String>,
+    ) {
+        persist_private_stream_batch(
+            storage,
+            counterparty,
+            messages.into_iter().map(private_message).collect(),
+            None,
+            timestamp(),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_payment_request_event_stores_canonical_payload() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let event = parsed_event(request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+            "invoice-2026-0001",
+            None,
+            None,
+        ));
+
+        let record =
+            enqueue_payment_request_event(&storage, counterparty.clone(), &event, timestamp())
+                .await
+                .unwrap();
+        let queued = queued_outbound_private_messages(&storage, &counterparty)
+            .await
+            .unwrap();
+
+        assert_eq!(queued, vec![record.clone()]);
+        assert_eq!(record.kind, "paykit.payment_request");
+        assert_eq!(
+            record.raw_json,
+            serialize_payment_request_event(&event).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_payment_request_acceptance_sets_kind() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let PaymentRequestEvent::Acceptance(event) = parsed_event(acceptance_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+        )) else {
+            panic!("expected acceptance event");
+        };
+
+        let record =
+            enqueue_payment_request_acceptance(&storage, counterparty, &event, timestamp())
+                .await
+                .unwrap();
+
+        assert_eq!(record.kind, "paykit.payment_request_acceptance");
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_payment_request_rejects_invalid_terms() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let PaymentRequestEvent::Request(mut event) = parsed_event(request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+            "invoice-2026-0001",
+            None,
+            None,
+        )) else {
+            panic!("expected request event");
+        };
+        event.request.accepted_payment_endpoint_identifiers.clear();
+
+        let err = enqueue_payment_request(&storage, counterparty.clone(), &event, timestamp())
+            .await
+            .unwrap_err();
+        let queued = queued_outbound_private_messages(&storage, &counterparty)
+            .await
+            .unwrap();
+
+        assert!(matches!(err, crate::PaykitSdkError::Protocol(_)));
+        assert!(queued.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_merge_outbound_acceptance() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            )],
+        )
+        .await;
+        let PaymentRequestEvent::Acceptance(acceptance) = parsed_event(acceptance_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            request_id,
+        )) else {
+            panic!("expected acceptance event");
+        };
+        enqueue_payment_request_acceptance(
+            &storage,
+            counterparty.clone(),
+            &acceptance,
+            timestamp(),
+        )
+        .await
+        .unwrap();
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(records[0].local_role, Some(PaymentRequestLocalRole::Payer));
+        assert_eq!(records[0].state, PaymentRequestLifecycleState::Accepted);
+        assert_eq!(
+            records[0].accepted_event_id.as_deref(),
+            Some("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_merge_sent_request_acceptance() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            None,
+            None,
+        )) else {
+            panic!("expected request event");
+        };
+        enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+            .await
+            .unwrap();
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![acceptance_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+                request_id,
+            )],
+        )
+        .await;
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(records[0].local_role, Some(PaymentRequestLocalRole::Payee));
+        assert_eq!(records[0].state, PaymentRequestLifecycleState::Accepted);
+        assert!(records[0].proposal_outbound_message_id.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_do_not_compare_independent_source_ids() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        enqueue_untyped_private_message(
+            &storage,
+            counterparty.clone(),
+            r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#.into(),
+            timestamp(),
+        )
+        .await
+        .unwrap();
+        let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            None,
+            None,
+        )) else {
+            panic!("expected request event");
+        };
+        enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+            .await
+            .unwrap();
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![acceptance_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+                request_id,
+            )],
+        )
+        .await;
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(records[0].state, PaymentRequestLifecycleState::Accepted);
+        assert_eq!(records[0].proposal_outbound_message_id, Some(1));
+        assert_eq!(records[0].last_stream_item_id, Some(0));
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_merge_outbound_proof() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            )],
+        )
+        .await;
+        let PaymentRequestEvent::Acceptance(acceptance) = parsed_event(acceptance_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            request_id,
+        )) else {
+            panic!("expected acceptance event");
+        };
+        enqueue_payment_request_acceptance(
+            &storage,
+            counterparty.clone(),
+            &acceptance,
+            timestamp(),
+        )
+        .await
+        .unwrap();
+        let PaymentRequestEvent::Proof(proof) = parsed_event(proof_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+            request_id,
+            "invoice-2026-0001",
+        )) else {
+            panic!("expected proof event");
+        };
+        enqueue_payment_proof(&storage, counterparty.clone(), &proof, timestamp())
+            .await
+            .unwrap();
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::ProofSubmitted
+        );
+        assert_eq!(records[0].payment_proofs.len(), 1);
+        assert!(!format!("{:?}", records[0].payment_proofs[0]).contains("secret"));
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_preserve_inbound_fifo_with_same_timestamp() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            None,
+            None,
+        )) else {
+            panic!("expected request event");
+        };
+        enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+            .await
+            .unwrap();
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                proof_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+                    request_id,
+                    "invoice-2026-0001",
+                ),
+                acceptance_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102", request_id),
+            ],
+        )
+        .await;
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("before acceptance")));
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_ignore_duplicate_outbound_event() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            )],
+        )
+        .await;
+        let PaymentRequestEvent::Acceptance(acceptance) = parsed_event(acceptance_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            request_id,
+        )) else {
+            panic!("expected acceptance event");
+        };
+        enqueue_payment_request_acceptance(
+            &storage,
+            counterparty.clone(),
+            &acceptance,
+            timestamp(),
+        )
+        .await
+        .unwrap();
+        enqueue_payment_request_acceptance(
+            &storage,
+            counterparty.clone(),
+            &acceptance,
+            timestamp(),
+        )
+        .await
+        .unwrap();
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(records[0].state, PaymentRequestLifecycleState::Accepted);
+        assert_eq!(
+            records[0].accepted_event_id.as_deref(),
+            Some("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_flag_outbound_event_id_conflict() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            )],
+        )
+        .await;
+        let PaymentRequestEvent::Acceptance(acceptance) = parsed_event(acceptance_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            request_id,
+        )) else {
+            panic!("expected acceptance event");
+        };
+        let PaymentRequestEvent::Rejection(rejection) = parsed_event(rejection_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            request_id,
+        )) else {
+            panic!("expected rejection event");
+        };
+        enqueue_payment_request_acceptance(
+            &storage,
+            counterparty.clone(),
+            &acceptance,
+            timestamp(),
+        )
+        .await
+        .unwrap();
+        enqueue_payment_request_rejection(&storage, counterparty.clone(), &rejection, timestamp())
+            .await
+            .unwrap();
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("Event ID")));
+        assert_eq!(records[0].last_outbound_message_id, Some(1));
+        assert!(records[0].last_stream_item_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_flag_outbound_reuse_of_tainted_event_id() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let inbound_request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        let outbound_request_id = "c7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    inbound_request_id,
+                    "invoice-2026-0001",
+                    None,
+                    None,
+                ),
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    inbound_request_id,
+                    "invoice-2026-0002",
+                    None,
+                    None,
+                ),
+            ],
+        )
+        .await;
+        let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            outbound_request_id,
+            "invoice-2026-0003",
+            None,
+            None,
+        )) else {
+            panic!("expected request event");
+        };
+        enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+            .await
+            .unwrap();
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+        let outbound = records
+            .iter()
+            .find(|record| record.payment_request_id == outbound_request_id)
+            .unwrap();
+
+        assert_eq!(
+            outbound.state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert!(outbound
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("Event ID")));
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_flag_cross_direction_duplicate_event_id() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        let raw = request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            None,
+            None,
+        );
+        let PaymentRequestEvent::Request(request) = parsed_event(raw.clone()) else {
+            panic!("expected request event");
+        };
+        enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+            .await
+            .unwrap();
+        persist_messages(&storage, counterparty.clone(), vec![raw]).await;
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("Event ID")));
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_keep_preinvalid_position_during_later_conflict() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let inbound_request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        let outbound_request_id = "c7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    inbound_request_id,
+                    "invoice-2026-0001",
+                    None,
+                    None,
+                ),
+                malformed_cancellation_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104",
+                    inbound_request_id,
+                ),
+            ],
+        )
+        .await;
+        let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            outbound_request_id,
+            "invoice-2026-0002",
+            None,
+            None,
+        )) else {
+            panic!("expected request event");
+        };
+        enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+            .await
+            .unwrap();
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+        let inbound = records
+            .iter()
+            .find(|record| record.payment_request_id == inbound_request_id)
+            .unwrap();
+        let outbound = records
+            .iter()
+            .find(|record| record.payment_request_id == outbound_request_id)
+            .unwrap();
+
+        assert_eq!(inbound.state, PaymentRequestLifecycleState::InvalidConflict);
+        assert_eq!(inbound.last_stream_item_id, Some(1));
+        assert_eq!(
+            outbound.state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_flag_outbound_reuse_of_malformed_event_id() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let inbound_request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        let outbound_request_id = "c7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![malformed_cancellation_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104",
+                inbound_request_id,
+            )],
+        )
+        .await;
+        let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104",
+            outbound_request_id,
+            "invoice-2026-0002",
+            None,
+            None,
+        )) else {
+            panic!("expected request event");
+        };
+        enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+            .await
+            .unwrap();
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+        let outbound = records
+            .iter()
+            .find(|record| record.payment_request_id == outbound_request_id)
+            .unwrap();
+
+        assert_eq!(
+            outbound.state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert!(outbound
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("Event ID")));
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_taint_event_id_without_request_id() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let outbound_request_id = "c7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![malformed_missing_request_id_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104",
+            )],
+        )
+        .await;
+        let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104",
+            outbound_request_id,
+            "invoice-2026-0002",
+            None,
+            None,
+        )) else {
+            panic!("expected request event");
+        };
+        enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+            .await
+            .unwrap();
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("Event ID")));
+    }
+
+    #[tokio::test]
+    async fn test_payment_request_records_keep_malformed_inbound_audit_position() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    request_id,
+                    "invoice-2026-0001",
+                    None,
+                    None,
+                ),
+                malformed_cancellation_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104", request_id),
+            ],
+        )
+        .await;
+
+        let records = payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert_eq!(records[0].last_stream_item_id, Some(1));
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("reason must be a string")));
+    }
+
+    #[tokio::test]
+    async fn test_received_payment_request_records_flag_inbound_acceptance_for_received_proposal() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    request_id,
+                    "invoice-2026-0001",
+                    None,
+                    None,
+                ),
+                acceptance_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102", request_id),
+            ],
+        )
+        .await;
+
+        let records = received_payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert_eq!(
+            records[0].terms.as_ref().unwrap().payment_reference,
+            "invoice-2026-0001"
+        );
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("outbound payer event")));
+        assert!(!format!("{:?}", records[0]).contains("private"));
+    }
+
+    #[tokio::test]
+    async fn test_received_payment_request_records_mark_proposal_expired() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+                "invoice-2026-0001",
+                Some("2026-06-03T11:59:59Z"),
+                None,
+            )],
+        )
+        .await;
+
+        let records = received_payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::ProposalExpired
+        );
+    }
+
+    #[tokio::test]
+    async fn test_received_payment_request_records_flag_inbound_proof_for_received_proposal() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    request_id,
+                    "invoice-2026-0001",
+                    None,
+                    None,
+                ),
+                proof_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+                    request_id,
+                    "invoice-2026-0001",
+                ),
+            ],
+        )
+        .await;
+
+        let records = received_payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("outbound payer event")));
+    }
+
+    #[tokio::test]
+    async fn test_received_payment_request_records_flag_event_id_conflict() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    request_id,
+                    "invoice-2026-0001",
+                    None,
+                    None,
+                ),
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    request_id,
+                    "invoice-2026-0002",
+                    None,
+                    None,
+                ),
+            ],
+        )
+        .await;
+
+        let records = received_payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("Event ID")));
+    }
+
+    #[tokio::test]
+    async fn test_received_payment_request_records_flag_invalid_transition() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![proof_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+                "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+                "invoice-2026-0001",
+            )],
+        )
+        .await;
+
+        let records = received_payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("before acceptance")));
+    }
+
+    #[tokio::test]
+    async fn test_received_payment_request_records_preserve_first_invalid_reason() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                proof_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+                    request_id,
+                    "invoice-2026-0001",
+                ),
+                malformed_cancellation_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104", request_id),
+            ],
+        )
+        .await;
+
+        let records = received_payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("before acceptance")));
+    }
+
+    #[tokio::test]
+    async fn test_received_payment_request_records_keep_invalid_before_later_proposal() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                proof_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+                    request_id,
+                    "invoice-2026-0001",
+                ),
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    request_id,
+                    "invoice-2026-0001",
+                    None,
+                    None,
+                ),
+            ],
+        )
+        .await;
+
+        let records = received_payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert!(records[0].terms.is_none());
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("before acceptance")));
+    }
+
+    #[tokio::test]
+    async fn test_received_payment_request_records_derive_cancellation() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    request_id,
+                    "invoice-2026-0001",
+                    None,
+                    None,
+                ),
+                cancellation_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104", request_id),
+            ],
+        )
+        .await;
+
+        let records = received_payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(records[0].state, PaymentRequestLifecycleState::Canceled);
+        assert_eq!(
+            records[0].canceled_event_id.as_deref(),
+            Some("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_received_payment_request_records_flag_second_cancellation() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    request_id,
+                    "invoice-2026-0001",
+                    None,
+                    None,
+                ),
+                cancellation_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104", request_id),
+                cancellation_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d105", request_id),
+            ],
+        )
+        .await;
+
+        let records = received_payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            records[0].state,
+            PaymentRequestLifecycleState::InvalidConflict
+        );
+        assert_eq!(
+            records[0].canceled_event_id.as_deref(),
+            Some("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104")
+        );
+        assert!(records[0]
+            .invalid_reason
+            .as_ref()
+            .is_some_and(|reason| reason.contains("terminal state")));
+    }
+
+    #[tokio::test]
+    async fn test_received_payment_request_records_return_newest_first() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let older_request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        let newer_request_id = "c7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+        persist_messages(
+            &storage,
+            counterparty.clone(),
+            vec![
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                    older_request_id,
+                    "invoice-2026-0001",
+                    None,
+                    None,
+                ),
+                request_raw(
+                    "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+                    newer_request_id,
+                    "invoice-2026-0002",
+                    None,
+                    None,
+                ),
+            ],
+        )
+        .await;
+
+        let records = received_payment_request_records(&storage, &counterparty, timestamp())
+            .await
+            .unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].payment_request_id, newer_request_id);
+        assert_eq!(records[1].payment_request_id, older_request_id);
+    }
+}

--- a/paykit-sdk/src/private_stream.rs
+++ b/paykit-sdk/src/private_stream.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::{
+    receipts::ReceiptAccessRecord,
     storage::{
         require_peer_link_operation_lease, EncryptedLinkStateRecord, EventDedupRecord,
         NewPrivateStreamItem, NewPrivateStreamItemDetails, PeerLinkOperationLease, StorageAdapter,
@@ -15,6 +16,7 @@ use crate::{
 use paykit_lib::{
     parse_payment_request_event_message, parse_private_payment_list_json,
     parse_receipt_access_event_message, PrivateApplicationMessage, PrivateMessageKind,
+    ReceiptAccess,
 };
 
 /// Parse status for one received Private Application Message.
@@ -97,7 +99,12 @@ where
             };
 
             for message in messages {
-                let classification = classify_message(&message);
+                let MessageClassification {
+                    status,
+                    parse_error,
+                    event,
+                    receipt_access,
+                } = classify_message(&message);
                 let stream_item_id = tx.insert_private_stream_item(NewPrivateStreamItem::new(
                     NewPrivateStreamItemDetails {
                         counterparty: counterparty.clone(),
@@ -108,13 +115,13 @@ where
                         known_paykit_kind: message
                             .known_kind()
                             .map(|kind| kind.as_str().to_owned()),
-                        parse_status: classification.status,
-                        parse_error: classification.parse_error,
+                        parse_status: status,
+                        parse_error,
                         received_at,
                     },
                 ));
 
-                if let Some(event) = classification.event {
+                let dedupe_outcome = event.map(|event| {
                     update_event_dedupe(
                         tx,
                         &counterparty,
@@ -123,7 +130,19 @@ where
                         payload_hash(&message.raw_json),
                         stream_item_id,
                         &mut report,
-                    );
+                    )
+                });
+
+                if matches!(dedupe_outcome, Some(EventDedupeOutcome::First)) {
+                    if let Some(access) = receipt_access.as_ref() {
+                        tx.save_receipt_access_record(ReceiptAccessRecord::from_access(
+                            counterparty.clone(),
+                            stream_item_id,
+                            receive_batch_id,
+                            received_at,
+                            access,
+                        ));
+                    }
                 }
 
                 report.stream_item_ids.push(stream_item_id);
@@ -145,6 +164,7 @@ struct MessageClassification {
     status: PrivateStreamParseStatus,
     parse_error: Option<String>,
     event: Option<EventHeader>,
+    receipt_access: Option<ReceiptAccess>,
 }
 
 struct EventHeader {
@@ -162,6 +182,7 @@ fn classify_message(message: &PrivateApplicationMessage) -> MessageClassificatio
             },
             parse_error: None,
             event: None,
+            receipt_access: None,
         };
     };
 
@@ -172,11 +193,13 @@ fn classify_message(message: &PrivateApplicationMessage) -> MessageClassificatio
                     status: PrivateStreamParseStatus::Valid,
                     parse_error: None,
                     event: None,
+                    receipt_access: None,
                 },
                 Err(err) => MessageClassification {
                     status: PrivateStreamParseStatus::MalformedRecognized,
                     parse_error: Some(err.to_string()),
                     event: None,
+                    receipt_access: None,
                 },
             }
         }
@@ -198,6 +221,7 @@ fn classify_message(message: &PrivateApplicationMessage) -> MessageClassificatio
                     .and_then(|parsed| parsed.validation_error())
                     .map(str::to_owned),
                 event,
+                receipt_access: parsed.and_then(|parsed| parsed.parsed_access().cloned()),
             }
         }
         PrivateMessageKind::PaymentRequest
@@ -222,6 +246,7 @@ fn classify_message(message: &PrivateApplicationMessage) -> MessageClassificatio
                     .and_then(|parsed| parsed.validation_error())
                     .map(str::to_owned),
                 event,
+                receipt_access: None,
             }
         }
     }
@@ -235,6 +260,13 @@ fn status_from_event_validity(is_valid: bool) -> PrivateStreamParseStatus {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EventDedupeOutcome {
+    First,
+    Duplicate,
+    Conflict,
+}
+
 fn update_event_dedupe(
     tx: &mut dyn crate::storage::StorageTransaction,
     counterparty: &PubkyPublicKey,
@@ -243,7 +275,7 @@ fn update_event_dedupe(
     payload_hash: String,
     stream_item_id: u64,
     report: &mut PrivateStreamIntakeReport,
-) {
+) -> EventDedupeOutcome {
     let Some(mut record) = tx.event_dedup_record(counterparty, &event_id) else {
         tx.save_event_dedup_record(EventDedupRecord {
             counterparty: counterparty.clone(),
@@ -254,11 +286,12 @@ fn update_event_dedupe(
             duplicate_stream_item_ids: Vec::new(),
             conflicting_stream_item_ids: Vec::new(),
         });
-        return;
+        return EventDedupeOutcome::First;
     };
 
-    if record.payload_hash == payload_hash {
+    let outcome = if record.payload_hash == payload_hash {
         record.duplicate_stream_item_ids.push(stream_item_id);
+        EventDedupeOutcome::Duplicate
     } else {
         record.conflicting_stream_item_ids.push(stream_item_id);
         report.event_conflicts.push(EventIdConflict {
@@ -266,9 +299,11 @@ fn update_event_dedupe(
             first_stream_item_id: record.first_stream_item_id,
             conflicting_stream_item_id: stream_item_id,
         });
-    }
+        EventDedupeOutcome::Conflict
+    };
 
     tx.save_event_dedup_record(record);
+    outcome
 }
 
 pub(crate) fn payload_hash(raw_json: &str) -> String {
@@ -315,6 +350,29 @@ mod tests {
         )
     }
 
+    fn receipt_access_raw(event_id: &str, receipt_id: &str, reference: &str) -> String {
+        let receipt_id = paykit_lib::ReceiptId::new(receipt_id).unwrap();
+        receipt_access_raw_with_location(
+            event_id,
+            receipt_id.as_str(),
+            reference,
+            &paykit_lib::ReceiptAccess::location_for(&receipt_id),
+        )
+    }
+
+    fn receipt_access_raw_with_location(
+        event_id: &str,
+        receipt_id: &str,
+        reference: &str,
+        location: &str,
+    ) -> String {
+        let key = paykit_lib::ReceiptDecryptionKey::generate();
+        format!(
+            r#"{{"version":1,"kind":"paykit.receipt_access","event_id":"{event_id}","receipt_id":"{receipt_id}","payment_reference":"{reference}","location":"{location}","key":"{}"}}"#,
+            key.as_str()
+        )
+    }
+
     #[tokio::test]
     async fn test_persist_private_stream_batch_stores_messages_and_checkpoint() {
         let storage = InMemoryStorage::new();
@@ -356,6 +414,124 @@ mod tests {
         );
         assert_eq!(snapshot.encrypted_link_states[&counterparty], link_state);
         assert_eq!(snapshot.event_dedup_records.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_persist_private_stream_batch_indexes_receipt_access() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let event_id = "650e8400-e29b-41d4-a716-446655440000";
+        let receipt_id = "550e8400-e29b-41d4-a716-446655440000";
+        let raw = receipt_access_raw(event_id, receipt_id, "invoice-2026-0001");
+
+        persist_private_stream_batch(
+            &storage,
+            counterparty.clone(),
+            vec![private_message(&raw)],
+            None,
+            timestamp(),
+        )
+        .await
+        .unwrap();
+
+        let records = crate::receipt_access_records(&storage, &counterparty)
+            .await
+            .unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].stream_item_id, 0);
+        assert_eq!(records[0].receive_batch_id, 0);
+        assert_eq!(records[0].event_id, event_id);
+        assert_eq!(records[0].receipt_id, receipt_id);
+        assert_eq!(records[0].payment_reference, "invoice-2026-0001");
+        assert!(records[0].payment_request_id.is_none());
+        assert!(records[0].billing_period.is_none());
+        assert!(records[0].location.ends_with(receipt_id));
+        let debug = format!("{:?}", records[0]);
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(&records[0].key));
+
+        let indexed =
+            crate::receipt_access_record_by_receipt_id(&storage, &counterparty, receipt_id)
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(indexed.event_id, event_id);
+    }
+
+    #[tokio::test]
+    async fn test_persist_private_stream_batch_dedupes_receipt_access_index() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let event_id = "650e8400-e29b-41d4-a716-446655440000";
+        let receipt_id = "550e8400-e29b-41d4-a716-446655440000";
+        let duplicate_raw = receipt_access_raw(event_id, receipt_id, "invoice-2026-0001");
+        let conflicting_raw = receipt_access_raw(
+            event_id,
+            "750e8400-e29b-41d4-a716-446655440000",
+            "invoice-2026-0002",
+        );
+
+        let report = persist_private_stream_batch(
+            &storage,
+            counterparty.clone(),
+            vec![
+                private_message(&duplicate_raw),
+                private_message(&duplicate_raw),
+                private_message(&conflicting_raw),
+            ],
+            None,
+            timestamp(),
+        )
+        .await
+        .unwrap();
+
+        let records = crate::receipt_access_records(&storage, &counterparty)
+            .await
+            .unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].stream_item_id, 0);
+        assert_eq!(records[0].receipt_id, receipt_id);
+        assert_eq!(report.event_conflicts.len(), 1);
+        assert_eq!(report.event_conflicts[0].conflicting_stream_item_id, 2);
+        let snapshot = storage.snapshot().unwrap();
+        let dedupe = snapshot
+            .event_dedup_records
+            .get(&(counterparty, event_id.into()))
+            .unwrap();
+        assert_eq!(dedupe.duplicate_stream_item_ids, vec![1]);
+        assert_eq!(dedupe.conflicting_stream_item_ids, vec![2]);
+    }
+
+    #[tokio::test]
+    async fn test_persist_private_stream_batch_skips_malformed_receipt_access_index() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let raw = receipt_access_raw_with_location(
+            "650e8400-e29b-41d4-a716-446655440000",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "invoice-2026-0001",
+            "/pub/paykit/v0/private/receipts/not-the-receipt-id",
+        );
+
+        persist_private_stream_batch(
+            &storage,
+            counterparty.clone(),
+            vec![private_message(&raw)],
+            None,
+            timestamp(),
+        )
+        .await
+        .unwrap();
+
+        let snapshot = storage.snapshot().unwrap();
+        assert_eq!(
+            snapshot.private_stream_items[0].parse_status,
+            PrivateStreamParseStatus::MalformedRecognized
+        );
+        let records = crate::receipt_access_records(&storage, &counterparty)
+            .await
+            .unwrap();
+        assert!(records.is_empty());
     }
 
     #[tokio::test]

--- a/paykit-sdk/src/receipts.rs
+++ b/paykit-sdk/src/receipts.rs
@@ -1,0 +1,644 @@
+//! Receipt Access indexing helpers.
+//!
+//! Indexed Receipt Access records include Receipt Decryption Keys. Store them
+//! as private SDK state and avoid logging field values directly.
+
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use paykit_lib::{Receipt, ReceiptAccess, ReceiptDecryptionKey};
+use pubky::{errors::RequestError, Error as PubkyError, StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+use sha2::{Digest, Sha256};
+
+use crate::{storage::StorageAdapter, PaykitSdkError, PubkyPublicKey, Result};
+
+/// Durable Billing Period fields copied from a Receipt Access event.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiptBillingPeriodRecord {
+    /// RFC3339 UTC timestamp using `Z`.
+    pub starts_at: String,
+    /// RFC3339 UTC timestamp using `Z`.
+    pub ends_at: String,
+}
+
+impl From<&paykit_lib::BillingPeriod> for ReceiptBillingPeriodRecord {
+    fn from(period: &paykit_lib::BillingPeriod) -> Self {
+        Self {
+            starts_at: period.starts_at.clone(),
+            ends_at: period.ends_at.clone(),
+        }
+    }
+}
+
+/// Receipt retrieval state for an indexed Receipt Access event.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReceiptRetrievalStatus {
+    /// Receipt Access has been indexed, but retrieval has not succeeded yet.
+    #[default]
+    Pending,
+    /// Encrypted Receipt was fetched and decrypted.
+    Retrieved,
+    /// Receipt Location was missing on the issuer homeserver.
+    NotFound,
+    /// Retrieval or decryption failed.
+    Failed,
+}
+
+/// Indexed Receipt Access event.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiptAccessRecord {
+    /// Counterparty that sent the Receipt Access event.
+    pub counterparty: PubkyPublicKey,
+    /// Stream item id that first carried this Event ID.
+    pub stream_item_id: u64,
+    /// Receive batch id that contained the stream item.
+    pub receive_batch_id: u64,
+    /// Receipt Access Event ID.
+    pub event_id: String,
+    /// Receipt ID.
+    pub receipt_id: String,
+    /// Payment Reference copied from Receipt Access.
+    pub payment_reference: String,
+    /// Optional Payment Request ID copied from Receipt Access.
+    pub payment_request_id: Option<String>,
+    /// Optional Billing Period copied from Receipt Access.
+    pub billing_period: Option<ReceiptBillingPeriodRecord>,
+    /// Receipt Location path on the issuer homeserver.
+    pub location: String,
+    /// Receipt Decryption Key material. Treat as secret storage data.
+    pub key: String,
+    /// Current retrieval state for the referenced receipt.
+    #[serde(default)]
+    pub retrieval_status: ReceiptRetrievalStatus,
+    /// Last retrieval attempt time.
+    #[serde(default)]
+    pub retrieval_attempted_at: Option<DateTime<Utc>>,
+    /// Successful retrieval/decryption time.
+    #[serde(default)]
+    pub retrieved_at: Option<DateTime<Utc>>,
+    /// Last retrieval/decryption error, when available.
+    #[serde(default)]
+    pub last_retrieval_error: Option<String>,
+    /// Receive time of the indexed stream item.
+    pub received_at: DateTime<Utc>,
+}
+
+impl ReceiptAccessRecord {
+    pub(crate) fn from_access(
+        counterparty: PubkyPublicKey,
+        stream_item_id: u64,
+        receive_batch_id: u64,
+        received_at: DateTime<Utc>,
+        access: &ReceiptAccess,
+    ) -> Self {
+        Self {
+            counterparty,
+            stream_item_id,
+            receive_batch_id,
+            event_id: access.event_id.as_str().to_owned(),
+            receipt_id: access.receipt_id.as_str().to_owned(),
+            payment_reference: access.payment_reference.as_str().to_owned(),
+            payment_request_id: access
+                .payment_request_id
+                .as_ref()
+                .map(|id| id.as_str().to_owned()),
+            billing_period: access
+                .billing_period
+                .as_ref()
+                .map(ReceiptBillingPeriodRecord::from),
+            location: access.location.clone(),
+            key: access.key.as_str().to_owned(),
+            retrieval_status: ReceiptRetrievalStatus::Pending,
+            retrieval_attempted_at: None,
+            retrieved_at: None,
+            last_retrieval_error: None,
+            received_at,
+        }
+    }
+
+    pub(crate) fn mark_retrieved(&self, retrieved_at: DateTime<Utc>) -> Self {
+        let mut record = self.clone();
+        record.retrieval_status = ReceiptRetrievalStatus::Retrieved;
+        record.retrieval_attempted_at = Some(retrieved_at);
+        record.retrieved_at = Some(retrieved_at);
+        record.last_retrieval_error = None;
+        record
+    }
+
+    pub(crate) fn mark_retrieval_error(
+        &self,
+        status: ReceiptRetrievalStatus,
+        attempted_at: DateTime<Utc>,
+        error: String,
+    ) -> Self {
+        let mut record = self.clone();
+        record.retrieval_status = status;
+        record.retrieval_attempted_at = Some(attempted_at);
+        record.retrieved_at = None;
+        record.last_retrieval_error = Some(error);
+        record
+    }
+}
+
+impl fmt::Debug for ReceiptAccessRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiptAccessRecord")
+            .field("counterparty", &self.counterparty)
+            .field("stream_item_id", &self.stream_item_id)
+            .field("receive_batch_id", &self.receive_batch_id)
+            .field("event_id", &self.event_id)
+            .field("receipt_id", &self.receipt_id)
+            .field("payment_reference", &self.payment_reference)
+            .field("payment_request_id", &self.payment_request_id)
+            .field("billing_period", &self.billing_period)
+            .field("location", &self.location)
+            .field("key", &"<redacted>")
+            .field("retrieval_status", &self.retrieval_status)
+            .field("retrieval_attempted_at", &self.retrieval_attempted_at)
+            .field("retrieved_at", &self.retrieved_at)
+            .field("last_retrieval_error", &self.last_retrieval_error)
+            .field("received_at", &self.received_at)
+            .finish()
+    }
+}
+
+/// Durable Payment Amount fields copied from a decrypted Receipt.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiptAmountRecord {
+    /// Decimal amount text.
+    pub value: String,
+    /// Asset code or unit.
+    pub asset: String,
+}
+
+/// Decrypted Receipt record stored by the SDK.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiptRecord {
+    /// Counterparty that issued the Receipt Access event.
+    pub issuer: PubkyPublicKey,
+    /// Receipt Access Event ID used for retrieval.
+    pub receipt_access_event_id: String,
+    /// Hash of the Receipt Access key that decrypted the Receipt.
+    #[serde(default)]
+    pub receipt_access_key_hash: String,
+    /// Receipt ID.
+    pub receipt_id: String,
+    /// Payment Reference copied from the decrypted Receipt.
+    pub payment_reference: String,
+    /// Optional Payment Request ID copied from the decrypted Receipt.
+    pub payment_request_id: Option<String>,
+    /// Optional Billing Period copied from the decrypted Receipt.
+    pub billing_period: Option<ReceiptBillingPeriodRecord>,
+    /// Recipient public key from the decrypted Receipt.
+    pub recipient_public_key: PubkyPublicKey,
+    /// Optional Payment Endpoint Identifier copied from the decrypted Receipt.
+    pub payment_endpoint_identifier: Option<String>,
+    /// Optional Payment Amount copied from the decrypted Receipt.
+    pub amount: Option<ReceiptAmountRecord>,
+    /// Caller-defined Receipt Metadata.
+    pub metadata: JsonMap<String, JsonValue>,
+    /// Receipt Location path used for retrieval.
+    pub location: String,
+    /// Successful retrieval/decryption time.
+    pub retrieved_at: DateTime<Utc>,
+}
+
+impl ReceiptRecord {
+    fn from_receipt(
+        issuer: PubkyPublicKey,
+        access: &ReceiptAccessRecord,
+        receipt: Receipt,
+        retrieved_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            issuer,
+            receipt_access_event_id: access.event_id.clone(),
+            receipt_access_key_hash: receipt_access_key_hash(&access.key),
+            receipt_id: receipt.receipt_id.as_str().to_owned(),
+            payment_reference: receipt.payment_reference.as_str().to_owned(),
+            payment_request_id: receipt
+                .payment_request_id
+                .as_ref()
+                .map(|id| id.as_str().to_owned()),
+            billing_period: receipt
+                .billing_period
+                .as_ref()
+                .map(ReceiptBillingPeriodRecord::from),
+            recipient_public_key: PubkyPublicKey::from_public_key(&receipt.recipient_public_key),
+            payment_endpoint_identifier: receipt
+                .payment_endpoint_identifier
+                .as_ref()
+                .map(|identifier| identifier.as_str().to_owned()),
+            amount: receipt.amount.as_ref().map(|amount| ReceiptAmountRecord {
+                value: amount.value.clone(),
+                asset: amount.asset.clone(),
+            }),
+            metadata: receipt.metadata,
+            location: access.location.clone(),
+            retrieved_at,
+        }
+    }
+}
+
+impl fmt::Debug for ReceiptRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiptRecord")
+            .field("issuer", &self.issuer)
+            .field("receipt_access_event_id", &self.receipt_access_event_id)
+            .field("receipt_access_key_hash", &self.receipt_access_key_hash)
+            .field("receipt_id", &self.receipt_id)
+            .field("payment_reference", &self.payment_reference)
+            .field("payment_request_id", &self.payment_request_id)
+            .field("billing_period", &self.billing_period)
+            .field("recipient_public_key", &self.recipient_public_key)
+            .field(
+                "payment_endpoint_identifier",
+                &self.payment_endpoint_identifier,
+            )
+            .field("amount", &self.amount.as_ref().map(|_| "<redacted>"))
+            .field(
+                "metadata",
+                &format_args!("<redacted:{} fields>", self.metadata.len()),
+            )
+            .field("location", &self.location)
+            .field("retrieved_at", &self.retrieved_at)
+            .finish()
+    }
+}
+
+/// List indexed Receipt Access records for one counterparty.
+pub async fn receipt_access_records<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Vec<ReceiptAccessRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.receipt_access_records(counterparty)))
+        .await
+}
+
+/// Load the latest indexed Receipt Access record for a receipt.
+pub async fn receipt_access_record_by_receipt_id<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    receipt_id: &str,
+) -> Result<Option<ReceiptAccessRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.receipt_access_record_by_receipt_id(counterparty, receipt_id)))
+        .await
+}
+
+/// Load a decrypted Receipt record.
+pub async fn receipt_record<S>(
+    storage: &S,
+    issuer: &PubkyPublicKey,
+    receipt_id: &str,
+) -> Result<Option<ReceiptRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.receipt_record(issuer, receipt_id)))
+        .await
+}
+
+pub(crate) async fn fetch_encrypted_receipt_json(
+    public_storage: &pubky::PublicStorage,
+    issuer: &PubkyPublicKey,
+    location: &str,
+) -> Result<Option<String>> {
+    let addr = format!("{}{}", issuer.to_public_key()?, location);
+    match public_storage.get(addr).await {
+        Ok(response) => {
+            let bytes = response
+                .bytes()
+                .await
+                .map_err(|err| PaykitSdkError::Transport {
+                    context: "read encrypted receipt bytes".into(),
+                    source: Some(err.into()),
+                })?;
+            let json = String::from_utf8(bytes.to_vec()).map_err(|err| {
+                PaykitSdkError::Protocol(format!("encrypted receipt is not UTF-8: {err}"))
+            })?;
+            Ok(Some(json))
+        }
+        Err(err) if is_not_found(&err) => Ok(None),
+        Err(err) => Err(PaykitSdkError::Transport {
+            context: "fetch encrypted receipt".into(),
+            source: Some(err.into()),
+        }),
+    }
+}
+
+pub(crate) fn decrypt_receipt_record_from_access(
+    access: &ReceiptAccessRecord,
+    encrypted_json: &str,
+    retrieved_at: DateTime<Utc>,
+    expected_recipient: &PubkyPublicKey,
+) -> Result<ReceiptRecord> {
+    let key = ReceiptDecryptionKey::new(access.key.clone())?;
+    let receipt = paykit_lib::decrypt_receipt(encrypted_json, &key, &access.location)?;
+    validate_receipt_matches_access(access, &receipt, expected_recipient)?;
+    Ok(ReceiptRecord::from_receipt(
+        access.counterparty.clone(),
+        access,
+        receipt,
+        retrieved_at,
+    ))
+}
+
+pub(crate) fn receipt_record_matches_access(
+    record: &ReceiptRecord,
+    access: &ReceiptAccessRecord,
+) -> bool {
+    record.issuer == access.counterparty
+        && record.receipt_access_key_hash == receipt_access_key_hash(&access.key)
+        && record.receipt_id == access.receipt_id
+        && record.payment_reference == access.payment_reference
+        && record.payment_request_id == access.payment_request_id
+        && record.billing_period == access.billing_period
+        && record.location == access.location
+}
+
+fn receipt_access_key_hash(key: &str) -> String {
+    let digest = Sha256::digest(key.as_bytes());
+    format!("sha256:{digest:x}")
+}
+
+fn validate_receipt_matches_access(
+    access: &ReceiptAccessRecord,
+    receipt: &Receipt,
+    expected_recipient: &PubkyPublicKey,
+) -> Result<()> {
+    if receipt.receipt_id.as_str() != access.receipt_id {
+        return Err(PaykitSdkError::Protocol(
+            "decrypted Receipt ID does not match Receipt Access".into(),
+        ));
+    }
+    let recipient = PubkyPublicKey::from_public_key(&receipt.recipient_public_key);
+    if &recipient != expected_recipient {
+        return Err(PaykitSdkError::Protocol(
+            "decrypted Receipt recipient does not match local identity".into(),
+        ));
+    }
+    if receipt.payment_reference.as_str() != access.payment_reference {
+        return Err(PaykitSdkError::Protocol(
+            "decrypted Receipt Payment Reference does not match Receipt Access".into(),
+        ));
+    }
+    let receipt_payment_request_id = receipt
+        .payment_request_id
+        .as_ref()
+        .map(|id| id.as_str().to_owned());
+    if receipt_payment_request_id != access.payment_request_id {
+        return Err(PaykitSdkError::Protocol(
+            "decrypted Receipt Payment Request ID does not match Receipt Access".into(),
+        ));
+    }
+    let receipt_billing_period = receipt
+        .billing_period
+        .as_ref()
+        .map(ReceiptBillingPeriodRecord::from);
+    if receipt_billing_period != access.billing_period {
+        return Err(PaykitSdkError::Protocol(
+            "decrypted Receipt Billing Period does not match Receipt Access".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_not_found(err: &PubkyError) -> bool {
+    matches!(
+        err,
+        PubkyError::Request(RequestError::Server { status, .. })
+            if *status == StatusCode::NOT_FOUND || *status == StatusCode::GONE
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+
+    fn timestamp() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+    }
+
+    fn public_key() -> paykit_lib::PublicKey {
+        pubky::Keypair::random().public_key()
+    }
+
+    fn receipt_access_record(
+        receipt_id: &paykit_lib::ReceiptId,
+        key: &ReceiptDecryptionKey,
+        payment_reference: &str,
+    ) -> ReceiptAccessRecord {
+        ReceiptAccessRecord {
+            counterparty: PubkyPublicKey::from_public_key(&public_key()),
+            stream_item_id: 0,
+            receive_batch_id: 0,
+            event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+            receipt_id: receipt_id.as_str().into(),
+            payment_reference: payment_reference.into(),
+            payment_request_id: None,
+            billing_period: None,
+            location: paykit_lib::ReceiptAccess::location_for(receipt_id),
+            key: key.as_str().into(),
+            retrieval_status: ReceiptRetrievalStatus::Pending,
+            retrieval_attempted_at: None,
+            retrieved_at: None,
+            last_retrieval_error: None,
+            received_at: timestamp(),
+        }
+    }
+
+    fn receipt(
+        receipt_id: paykit_lib::ReceiptId,
+        payment_reference: &str,
+        recipient_public_key: paykit_lib::PublicKey,
+    ) -> Receipt {
+        Receipt {
+            receipt_id,
+            payment_reference: paykit_lib::PaymentReference::new(payment_reference).unwrap(),
+            payment_request_id: None,
+            billing_period: None,
+            recipient_public_key,
+            payment_endpoint_identifier: Some(
+                paykit_lib::PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap(),
+            ),
+            amount: Some(paykit_lib::PaymentAmount::new("0.001", "btc").unwrap()),
+            metadata: serde_json::json!({"settlement_id": "abc-123"})
+                .as_object()
+                .cloned()
+                .unwrap(),
+        }
+    }
+
+    #[test]
+    fn test_decrypt_receipt_record_from_access_validates_and_redacts() {
+        let receipt_id =
+            paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let key = ReceiptDecryptionKey::generate();
+        let recipient_public_key = public_key();
+        let expected_recipient = PubkyPublicKey::from_public_key(&recipient_public_key);
+        let receipt = receipt(
+            receipt_id.clone(),
+            "invoice-2026-0001",
+            recipient_public_key,
+        );
+        let encrypted = receipt.encrypt(&key).unwrap();
+        let access = receipt_access_record(&receipt_id, &key, "invoice-2026-0001");
+
+        let record = decrypt_receipt_record_from_access(
+            &access,
+            &encrypted,
+            timestamp(),
+            &expected_recipient,
+        )
+        .unwrap();
+
+        assert_eq!(record.receipt_id, receipt_id.as_str());
+        assert!(receipt_record_matches_access(&record, &access));
+        assert_eq!(record.payment_reference, "invoice-2026-0001");
+        assert_eq!(record.receipt_access_event_id, access.event_id);
+        assert_eq!(record.amount.as_ref().unwrap().asset, "btc");
+        assert_eq!(record.metadata["settlement_id"], "abc-123");
+        let debug = format!("{record:?}");
+        assert!(debug.contains("<redacted:1 fields>"));
+        assert!(!debug.contains("abc-123"));
+    }
+
+    #[test]
+    fn test_receipt_record_matches_access_requires_decrypting_key() {
+        let receipt_id =
+            paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let key = ReceiptDecryptionKey::generate();
+        let recipient_public_key = public_key();
+        let expected_recipient = PubkyPublicKey::from_public_key(&recipient_public_key);
+        let receipt = receipt(
+            receipt_id.clone(),
+            "invoice-2026-0001",
+            recipient_public_key,
+        );
+        let encrypted = receipt.encrypt(&key).unwrap();
+        let access = receipt_access_record(&receipt_id, &key, "invoice-2026-0001");
+        let record = decrypt_receipt_record_from_access(
+            &access,
+            &encrypted,
+            timestamp(),
+            &expected_recipient,
+        )
+        .unwrap();
+        let wrong_key_access = receipt_access_record(
+            &receipt_id,
+            &ReceiptDecryptionKey::generate(),
+            "invoice-2026-0001",
+        );
+
+        assert!(!receipt_record_matches_access(&record, &wrong_key_access));
+    }
+
+    #[test]
+    fn test_receipt_access_record_deserializes_pending_retrieval_defaults() {
+        let counterparty = PubkyPublicKey::from_public_key(&public_key());
+        let value = serde_json::json!({
+            "counterparty": counterparty.as_str(),
+            "stream_item_id": 0,
+            "receive_batch_id": 0,
+            "event_id": "650e8400-e29b-41d4-a716-446655440000",
+            "receipt_id": "550e8400-e29b-41d4-a716-446655440000",
+            "payment_reference": "invoice-2026-0001",
+            "payment_request_id": null,
+            "billing_period": null,
+            "location": "/pub/paykit/v0/private/receipts/550e8400-e29b-41d4-a716-446655440000",
+            "key": "receipt-secret",
+            "received_at": timestamp(),
+        });
+
+        let record: ReceiptAccessRecord = serde_json::from_value(value).unwrap();
+
+        assert_eq!(record.retrieval_status, ReceiptRetrievalStatus::Pending);
+        assert!(record.retrieval_attempted_at.is_none());
+        assert!(record.retrieved_at.is_none());
+        assert!(record.last_retrieval_error.is_none());
+    }
+
+    #[test]
+    fn test_receipt_access_record_error_clears_success_timestamp() {
+        let receipt_id =
+            paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let key = ReceiptDecryptionKey::generate();
+        let record = receipt_access_record(&receipt_id, &key, "invoice-2026-0001")
+            .mark_retrieved(timestamp());
+
+        let failed = record.mark_retrieval_error(
+            ReceiptRetrievalStatus::Failed,
+            timestamp() + chrono::Duration::seconds(1),
+            "decryption failed".into(),
+        );
+
+        assert_eq!(failed.retrieval_status, ReceiptRetrievalStatus::Failed);
+        assert!(failed.retrieved_at.is_none());
+        assert_eq!(
+            failed.last_retrieval_error.as_deref(),
+            Some("decryption failed")
+        );
+    }
+
+    #[test]
+    fn test_decrypt_receipt_record_from_access_rejects_mismatch() {
+        let receipt_id =
+            paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let key = ReceiptDecryptionKey::generate();
+        let recipient_public_key = public_key();
+        let expected_recipient = PubkyPublicKey::from_public_key(&recipient_public_key);
+        let receipt = receipt(
+            receipt_id.clone(),
+            "invoice-2026-0002",
+            recipient_public_key,
+        );
+        let encrypted = receipt.encrypt(&key).unwrap();
+        let access = receipt_access_record(&receipt_id, &key, "invoice-2026-0001");
+
+        let err = decrypt_receipt_record_from_access(
+            &access,
+            &encrypted,
+            timestamp(),
+            &expected_recipient,
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, PaykitSdkError::Protocol(message) if message.contains("Payment Reference"))
+        );
+    }
+
+    #[test]
+    fn test_decrypt_receipt_record_from_access_rejects_wrong_recipient() {
+        let receipt_id =
+            paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let key = ReceiptDecryptionKey::generate();
+        let receipt = receipt(receipt_id.clone(), "invoice-2026-0001", public_key());
+        let encrypted = receipt.encrypt(&key).unwrap();
+        let access = receipt_access_record(&receipt_id, &key, "invoice-2026-0001");
+        let expected_recipient = PubkyPublicKey::from_public_key(&public_key());
+
+        let err = decrypt_receipt_record_from_access(
+            &access,
+            &encrypted,
+            timestamp(),
+            &expected_recipient,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, PaykitSdkError::Protocol(message) if message.contains("recipient")));
+    }
+}

--- a/paykit-sdk/src/runtime.rs
+++ b/paykit-sdk/src/runtime.rs
@@ -1,7 +1,13 @@
-use std::collections::HashSet;
+use std::{cmp::Reverse, collections::HashSet};
 
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use paykit_lib::{
+    BillingPeriod, EventId, PaymentEndpointIdentifier, PaymentProof, PaymentRequest,
+    PaymentRequestAcceptance, PaymentRequestCancellation, PaymentRequestEvent, PaymentRequestId,
+    PaymentRequestRejection, PaymentRequestTerms,
+};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::{
     config::{
@@ -28,11 +34,27 @@ use crate::{
         validate_queued_outbound_private_message, OutboundPrivateSendFailure,
         OutboundPrivateSendReport,
     },
+    payment_requests::{
+        enqueue_payment_proof as enqueue_payment_proof_message,
+        enqueue_payment_request as enqueue_payment_request_message,
+        enqueue_payment_request_acceptance as enqueue_payment_request_acceptance_message,
+        enqueue_payment_request_cancellation as enqueue_payment_request_cancellation_message,
+        enqueue_payment_request_event as enqueue_payment_request_event_message,
+        enqueue_payment_request_rejection as enqueue_payment_request_rejection_message,
+        payment_request_records as derive_payment_request_records,
+        received_payment_request_records as derive_received_payment_request_records,
+        request_from_record, PaymentRequestLifecycleState, PaymentRequestLocalRole,
+        PaymentRequestRecord,
+    },
     private_lists::{
         current_private_payment_list as load_current_private_payment_list,
         enqueue_private_payment_list as enqueue_private_payment_list_message,
     },
     private_stream::{persist_private_stream_batch_with_link_lease, PrivateStreamIntakeReport},
+    receipts::{
+        decrypt_receipt_record_from_access, fetch_encrypted_receipt_json,
+        receipt_record_matches_access, ReceiptAccessRecord, ReceiptRecord, ReceiptRetrievalStatus,
+    },
     storage::{
         EncryptedLinkStateRecord, OutboundPrivateMessageRecord, PeerLinkOperationLease,
         StorageAdapter,
@@ -211,15 +233,238 @@ where
         load_current_private_payment_list(&self.storage, counterparty).await
     }
 
-    /// Enqueue the current complete Private Payment List for one counterparty.
-    pub async fn enqueue_private_payment_list(
+    /// Fetch, decrypt, and store a receipt from an indexed Receipt Access event.
+    ///
+    /// The decrypted Receipt is private SDK state. This returns an already
+    /// stored Receipt record when available, and otherwise validates the
+    /// decrypted recipient against the current local Pubky identity before
+    /// saving it.
+    pub async fn retrieve_receipt(
         &self,
         counterparty: PubkyPublicKey,
-    ) -> Result<OutboundPrivateMessageRecord> {
+        receipt_id: &str,
+    ) -> Result<ReceiptRecord> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        let local_public_key = identity
+            .public_key
+            .ok_or_else(|| PaykitSdkError::Identity {
+                context: "no local Pubky identity available for receipt retrieval".into(),
+                source: None,
+            })?;
+        let (stored_receipt, access_records) = self
+            .storage
+            .transaction(|tx| {
+                let stored_receipt = tx.receipt_record(&counterparty, receipt_id);
+                let mut access_records = tx
+                    .receipt_access_records(&counterparty)
+                    .into_iter()
+                    .filter(|record| record.receipt_id == receipt_id)
+                    .collect::<Vec<_>>();
+                access_records.sort_by_key(|record| Reverse(record.stream_item_id));
+                Ok((stored_receipt, access_records))
+            })
+            .await?;
+        if let Some(record) = stored_receipt {
+            if record.recipient_public_key != local_public_key {
+                return Err(PaykitSdkError::Protocol(
+                    "stored Receipt recipient does not match local identity".into(),
+                ));
+            }
+            self.reconcile_cached_receipt_access_records(
+                &record,
+                &access_records,
+                self.clock.now(),
+            )
+            .await?;
+            return Ok(record);
+        }
+        let public_storage =
+            self.pubky
+                .load_public_storage()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: "no Pubky public storage available for receipt retrieval".into(),
+                    source: None,
+                })?;
+        if access_records.is_empty() {
+            return Err(PaykitSdkError::RecoveryRequired(format!(
+                "no Receipt Access record for receipt {receipt_id} from {counterparty}"
+            )));
+        }
+        let now = self.clock.now();
+        let latest_access = &access_records[0];
+
+        let encrypted_json = match fetch_encrypted_receipt_json(
+            &public_storage,
+            &counterparty,
+            &latest_access.location,
+        )
+        .await
+        {
+            Ok(Some(encrypted_json)) => encrypted_json,
+            Ok(None) => {
+                let error = format!(
+                    "encrypted receipt {} was not found at {}",
+                    latest_access.receipt_id, latest_access.location
+                );
+                self.save_receipt_retrieval_error(
+                    latest_access,
+                    ReceiptRetrievalStatus::NotFound,
+                    now,
+                    error.clone(),
+                )
+                .await?;
+                return Err(PaykitSdkError::Transport {
+                    context: error,
+                    source: None,
+                });
+            }
+            Err(err) => {
+                let error = err.to_string();
+                self.save_receipt_retrieval_error(
+                    latest_access,
+                    ReceiptRetrievalStatus::Failed,
+                    now,
+                    error,
+                )
+                .await?;
+                return Err(err);
+            }
+        };
+
+        let all_access_records = access_records.clone();
+        let mut last_error = None;
+        for access in access_records {
+            match decrypt_receipt_record_from_access(
+                &access,
+                &encrypted_json,
+                now,
+                &local_public_key,
+            ) {
+                Ok(record) => {
+                    self.storage
+                        .transaction({
+                            let access = access.mark_retrieved(now);
+                            let record = record.clone();
+                            move |tx| {
+                                tx.save_receipt_access_record(access);
+                                tx.save_receipt_record(record);
+                                Ok(())
+                            }
+                        })
+                        .await?;
+                    self.reconcile_cached_receipt_access_records(&record, &all_access_records, now)
+                        .await?;
+                    return Ok(record);
+                }
+                Err(err) => {
+                    let error = err.to_string();
+                    self.save_receipt_retrieval_error(
+                        &access,
+                        ReceiptRetrievalStatus::Failed,
+                        now,
+                        error,
+                    )
+                    .await?;
+                    last_error = Some(err);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| {
+            PaykitSdkError::RecoveryRequired(format!(
+                "no usable Receipt Access record for receipt {receipt_id} from {counterparty}"
+            ))
+        }))
+    }
+
+    async fn reconcile_cached_receipt_access_records(
+        &self,
+        record: &ReceiptRecord,
+        access_records: &[ReceiptAccessRecord],
+        now: DateTime<Utc>,
+    ) -> Result<()> {
+        self.storage
+            .transaction({
+                let record = record.clone();
+                let access_records = access_records.to_vec();
+                move |tx| {
+                    for access in access_records {
+                        if receipt_record_matches_access(&record, &access) {
+                            if access.retrieval_status != ReceiptRetrievalStatus::Retrieved {
+                                tx.save_receipt_access_record(access.mark_retrieved(now));
+                            }
+                        } else if access.retrieval_status == ReceiptRetrievalStatus::Pending {
+                            tx.save_receipt_access_record(access.mark_retrieval_error(
+                                ReceiptRetrievalStatus::Failed,
+                                now,
+                                "Receipt Access does not match stored Receipt".into(),
+                            ));
+                        }
+                    }
+                    Ok(())
+                }
+            })
+            .await
+    }
+
+    async fn save_receipt_retrieval_error(
+        &self,
+        access: &ReceiptAccessRecord,
+        status: ReceiptRetrievalStatus,
+        attempted_at: DateTime<Utc>,
+        error: String,
+    ) -> Result<()> {
+        self.storage
+            .transaction({
+                let access = access.mark_retrieval_error(status, attempted_at, error);
+                move |tx| {
+                    tx.save_receipt_access_record(access);
+                    Ok(())
+                }
+            })
+            .await
+    }
+
+    /// Return received Payment Request records for one counterparty.
+    ///
+    /// Records are derived from the persisted inbound private stream and
+    /// returned newest-first by last applied stream item. Malformed recognized
+    /// Payment Request events without a valid `payment_request_id` stay in the
+    /// raw private stream log and cannot be attached to a request-scoped record.
+    pub async fn received_payment_request_records(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Vec<PaymentRequestRecord>> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.capability != PubkyIdentityCapability::PrivateLinkCapable {
+            return Ok(Vec::new());
+        }
+        derive_received_payment_request_records(&self.storage, counterparty, self.clock.now()).await
+    }
+
+    /// Return merged local Payment Request records for one counterparty.
+    ///
+    /// Records combine received private-stream events and local outbound
+    /// Payment Request events, returned newest-first.
+    pub async fn payment_request_records(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Vec<PaymentRequestRecord>> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.capability != PubkyIdentityCapability::PrivateLinkCapable {
+            return Ok(Vec::new());
+        }
+        derive_payment_request_records(&self.storage, counterparty, self.clock.now()).await
+    }
+
+    async fn ensure_private_outbound_ready(
+        &self,
+        counterparty: &PubkyPublicKey,
+        disabled_message: &str,
+    ) -> Result<()> {
         if self.config.private_sharing == PrivateSharingPolicy::Disabled {
-            return Err(PaykitSdkError::Policy(
-                "private Payment List sharing is disabled".into(),
-            ));
+            return Err(PaykitSdkError::Policy(disabled_message.into()));
         }
 
         let (_, identity) = self.load_session_access_and_refresh_identity().await?;
@@ -234,7 +479,7 @@ where
             .storage
             .transaction(|tx| {
                 Ok(tx
-                    .encrypted_link_state(&counterparty)
+                    .encrypted_link_state(counterparty)
                     .and_then(|state| state.link_snapshot)
                     .is_some())
             })
@@ -244,6 +489,297 @@ where
                 "no active Encrypted Link snapshot for counterparty {counterparty}"
             )));
         }
+
+        Ok(())
+    }
+
+    /// Queue a new Payment Request proposal and return local derived state.
+    ///
+    /// The returned record reflects the local outbound queue, not delivery or
+    /// counterparty processing.
+    pub async fn propose_payment_request(
+        &self,
+        counterparty: PubkyPublicKey,
+        terms: PaymentRequestTerms,
+    ) -> Result<PaymentRequestRecord> {
+        let event = PaymentRequest::new(EventId::new_v4(), PaymentRequestId::new_v4(), terms);
+        let payment_request_id = event.payment_request_id.clone();
+        self.enqueue_raw_payment_request(counterparty.clone(), &event)
+            .await?;
+        self.load_payment_request_record(&counterparty, &payment_request_id)
+            .await
+    }
+
+    /// Queue acceptance for a received Payment Request and return local derived state.
+    ///
+    /// The returned record reflects the local outbound queue, not delivery or
+    /// counterparty processing.
+    pub async fn accept_payment_request(
+        &self,
+        counterparty: PubkyPublicKey,
+        payment_request_id: &PaymentRequestId,
+    ) -> Result<PaymentRequestRecord> {
+        let record = self
+            .load_payment_request_record(&counterparty, payment_request_id)
+            .await?;
+        require_payer_role(&record, "accept Payment Request")?;
+        require_state(
+            &record,
+            &[PaymentRequestLifecycleState::Proposed],
+            "accept Payment Request",
+        )?;
+        let event = PaymentRequestAcceptance::new(EventId::new_v4(), payment_request_id.clone());
+        self.enqueue_raw_payment_request_acceptance(counterparty.clone(), &event)
+            .await?;
+        self.load_payment_request_record(&counterparty, payment_request_id)
+            .await
+    }
+
+    /// Queue rejection for a received Payment Request and return local derived state.
+    ///
+    /// The returned record reflects the local outbound queue, not delivery or
+    /// counterparty processing.
+    pub async fn reject_payment_request(
+        &self,
+        counterparty: PubkyPublicKey,
+        payment_request_id: &PaymentRequestId,
+        reason: Option<String>,
+    ) -> Result<PaymentRequestRecord> {
+        let record = self
+            .load_payment_request_record(&counterparty, payment_request_id)
+            .await?;
+        require_payer_role(&record, "reject Payment Request")?;
+        require_state(
+            &record,
+            &[PaymentRequestLifecycleState::Proposed],
+            "reject Payment Request",
+        )?;
+        let event =
+            PaymentRequestRejection::new(EventId::new_v4(), payment_request_id.clone(), reason);
+        self.enqueue_raw_payment_request_rejection(counterparty.clone(), &event)
+            .await?;
+        self.load_payment_request_record(&counterparty, payment_request_id)
+            .await
+    }
+
+    /// Queue cancellation for a known non-terminal Payment Request and return local derived state.
+    ///
+    /// The returned record reflects the local outbound queue, not delivery or
+    /// counterparty processing.
+    pub async fn cancel_payment_request(
+        &self,
+        counterparty: PubkyPublicKey,
+        payment_request_id: &PaymentRequestId,
+        reason: Option<String>,
+    ) -> Result<PaymentRequestRecord> {
+        let record = self
+            .load_payment_request_record(&counterparty, payment_request_id)
+            .await?;
+        require_state(
+            &record,
+            &[
+                PaymentRequestLifecycleState::Proposed,
+                PaymentRequestLifecycleState::ProposalExpired,
+                PaymentRequestLifecycleState::Accepted,
+                PaymentRequestLifecycleState::ActiveRecurring,
+                PaymentRequestLifecycleState::ProofSubmitted,
+            ],
+            "cancel Payment Request",
+        )?;
+        let event =
+            PaymentRequestCancellation::new(EventId::new_v4(), payment_request_id.clone(), reason);
+        self.enqueue_raw_payment_request_cancellation(counterparty.clone(), &event)
+            .await?;
+        self.load_payment_request_record(&counterparty, payment_request_id)
+            .await
+    }
+
+    /// Queue a Payment Proof for an accepted Payment Request and return local derived state.
+    ///
+    /// The returned record reflects the local outbound queue, not delivery or
+    /// counterparty processing.
+    pub async fn submit_payment_proof(
+        &self,
+        counterparty: PubkyPublicKey,
+        payment_request_id: &PaymentRequestId,
+        billing_period: Option<BillingPeriod>,
+        payment_endpoint_identifier: PaymentEndpointIdentifier,
+        proof: JsonMap<String, JsonValue>,
+    ) -> Result<PaymentRequestRecord> {
+        let record = self
+            .load_payment_request_record(&counterparty, payment_request_id)
+            .await?;
+        require_payer_role(&record, "submit Payment Proof")?;
+        require_state(
+            &record,
+            &[
+                PaymentRequestLifecycleState::Accepted,
+                PaymentRequestLifecycleState::ActiveRecurring,
+            ],
+            "submit Payment Proof",
+        )?;
+        let request = request_from_record(&record).ok_or_else(|| {
+            PaykitSdkError::Protocol("Payment Request terms are unavailable".into())
+        })?;
+        let event = PaymentProof::new(
+            EventId::new_v4(),
+            payment_request_id.clone(),
+            request.request.payment_reference.clone(),
+            billing_period,
+            payment_endpoint_identifier,
+            proof,
+        );
+        event.validate_for_request(&request)?;
+        self.enqueue_raw_payment_proof(counterparty.clone(), &event)
+            .await?;
+        self.load_payment_request_record(&counterparty, payment_request_id)
+            .await
+    }
+
+    async fn load_payment_request_record(
+        &self,
+        counterparty: &PubkyPublicKey,
+        payment_request_id: &PaymentRequestId,
+    ) -> Result<PaymentRequestRecord> {
+        derive_payment_request_records(&self.storage, counterparty, self.clock.now())
+            .await?
+            .into_iter()
+            .find(|record| record.payment_request_id == payment_request_id.as_str())
+            .ok_or_else(|| {
+                PaykitSdkError::Protocol(format!(
+                    "Payment Request {} is not known for counterparty {}",
+                    payment_request_id, counterparty
+                ))
+            })
+    }
+
+    /// Enqueue one raw Payment Request protocol event for outbound delivery.
+    ///
+    /// This validates private-send readiness and stores canonical JSON, but it
+    /// does not enforce role, lifecycle, or proof/request correlation policy.
+    pub async fn enqueue_raw_payment_request_event(
+        &self,
+        counterparty: PubkyPublicKey,
+        event: &PaymentRequestEvent,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(
+            &counterparty,
+            "private Payment Request messaging is disabled",
+        )
+        .await?;
+        enqueue_payment_request_event_message(&self.storage, counterparty, event, self.clock.now())
+            .await
+    }
+
+    /// Enqueue a raw Payment Request proposal for outbound delivery.
+    ///
+    /// This is a queueing primitive; it does not enforce role or lifecycle policy.
+    pub async fn enqueue_raw_payment_request(
+        &self,
+        counterparty: PubkyPublicKey,
+        event: &PaymentRequest,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(
+            &counterparty,
+            "private Payment Request messaging is disabled",
+        )
+        .await?;
+        enqueue_payment_request_message(&self.storage, counterparty, event, self.clock.now()).await
+    }
+
+    /// Enqueue a raw Payment Request acceptance for outbound delivery.
+    ///
+    /// This is a queueing primitive; it does not enforce role or lifecycle policy.
+    pub async fn enqueue_raw_payment_request_acceptance(
+        &self,
+        counterparty: PubkyPublicKey,
+        event: &PaymentRequestAcceptance,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(
+            &counterparty,
+            "private Payment Request messaging is disabled",
+        )
+        .await?;
+        enqueue_payment_request_acceptance_message(
+            &self.storage,
+            counterparty,
+            event,
+            self.clock.now(),
+        )
+        .await
+    }
+
+    /// Enqueue a raw Payment Request rejection for outbound delivery.
+    ///
+    /// This is a queueing primitive; it does not enforce role or lifecycle policy.
+    pub async fn enqueue_raw_payment_request_rejection(
+        &self,
+        counterparty: PubkyPublicKey,
+        event: &PaymentRequestRejection,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(
+            &counterparty,
+            "private Payment Request messaging is disabled",
+        )
+        .await?;
+        enqueue_payment_request_rejection_message(
+            &self.storage,
+            counterparty,
+            event,
+            self.clock.now(),
+        )
+        .await
+    }
+
+    /// Enqueue a raw Payment Request cancellation for outbound delivery.
+    ///
+    /// This is a queueing primitive; it does not enforce role or lifecycle policy.
+    pub async fn enqueue_raw_payment_request_cancellation(
+        &self,
+        counterparty: PubkyPublicKey,
+        event: &PaymentRequestCancellation,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(
+            &counterparty,
+            "private Payment Request messaging is disabled",
+        )
+        .await?;
+        enqueue_payment_request_cancellation_message(
+            &self.storage,
+            counterparty,
+            event,
+            self.clock.now(),
+        )
+        .await
+    }
+
+    /// Enqueue a raw Payment Proof for outbound delivery.
+    ///
+    /// This is a queueing primitive; it does not enforce role, lifecycle, or
+    /// proof/request correlation policy.
+    pub async fn enqueue_raw_payment_proof(
+        &self,
+        counterparty: PubkyPublicKey,
+        event: &PaymentProof,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(
+            &counterparty,
+            "private Payment Request messaging is disabled",
+        )
+        .await?;
+        enqueue_payment_proof_message(&self.storage, counterparty, event, self.clock.now()).await
+    }
+
+    /// Enqueue the current complete Private Payment List for one counterparty.
+    pub async fn enqueue_private_payment_list(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(
+            &counterparty,
+            "private Payment List sharing is disabled",
+        )
+        .await?;
 
         let receiving_details = self
             .payment
@@ -923,8 +1459,17 @@ where
         &self,
         counterparty: PubkyPublicKey,
     ) -> Result<OutboundPrivateSendReport> {
-        let (session_access, _) = self.load_session_access_and_refresh_identity().await?;
         let report = OutboundPrivateSendReport::default();
+        let queued = queued_outbound_private_messages(&self.storage, &counterparty).await?;
+        if queued.is_empty() {
+            return Ok(report);
+        }
+        if self.config.private_sharing == PrivateSharingPolicy::Disabled {
+            return Err(PaykitSdkError::Policy(
+                "private Paykit message sending is disabled".into(),
+            ));
+        }
+        let (session_access, _) = self.load_session_access_and_refresh_identity().await?;
         let queued = queued_outbound_private_messages(&self.storage, &counterparty).await?;
         if queued.is_empty() {
             return Ok(report);
@@ -1455,6 +2000,31 @@ fn selected_from_batch(
     }
 }
 
+fn require_payer_role(record: &PaymentRequestRecord, action: &str) -> Result<()> {
+    if record.local_role == Some(PaymentRequestLocalRole::Payer) {
+        Ok(())
+    } else {
+        Err(PaykitSdkError::Policy(format!(
+            "cannot {action}: local identity is not the payer"
+        )))
+    }
+}
+
+fn require_state(
+    record: &PaymentRequestRecord,
+    allowed: &[PaymentRequestLifecycleState],
+    action: &str,
+) -> Result<()> {
+    if allowed.contains(&record.state) {
+        Ok(())
+    } else {
+        Err(PaykitSdkError::Policy(format!(
+            "cannot {action}: Payment Request {} is in state {:?}",
+            record.payment_request_id, record.state
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
@@ -1703,6 +2273,23 @@ mod tests {
         r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#.into()
     }
 
+    fn payment_request_message(
+        event_id: &str,
+        request_id: &str,
+        expires_at: Option<&str>,
+    ) -> PrivateApplicationMessage {
+        let expiry = expires_at
+            .map(|value| format!(r#""{value}""#))
+            .unwrap_or_else(|| "null".into());
+        PrivateApplicationMessage {
+            version: Some(1),
+            kind: Some("paykit.payment_request".into()),
+            raw_json: format!(
+                r#"{{"version":1,"kind":"paykit.payment_request","event_id":"{event_id}","payment_request_id":"{request_id}","request":{{"amount":{{"value":"0.001","asset":"btc"}},"payment_reference":"invoice-2026-0001","proposal_expires_at":{expiry},"recurrence":null,"accepted_payment_endpoint_identifiers":["btc-lightning-bolt11"],"metadata":{{}}}}}}"#
+            ),
+        }
+    }
+
     async fn seed_private_capable_identity_and_link(
         storage: &InMemoryStorage,
         counterparty: PubkyPublicKey,
@@ -1770,6 +2357,213 @@ mod tests {
         let result = sdk.enqueue_private_payment_list(counterparty).await;
 
         assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_payment_request_event_requires_private_capable_identity() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let sdk = PaykitSdk::with_clock(
+            storage,
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+        let event = PaymentRequestAcceptance::new(
+            paykit_lib::EventId::new("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102").unwrap(),
+            paykit_lib::PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap(),
+        );
+
+        let result = sdk
+            .enqueue_raw_payment_request_acceptance(counterparty, &event)
+            .await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_payment_request_event_respects_private_sharing_policy() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig {
+                private_sharing: PrivateSharingPolicy::Disabled,
+                ..PaykitSdkConfig::default()
+            },
+            FixedClock,
+        );
+        let event = PaymentRequestAcceptance::new(
+            paykit_lib::EventId::new("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102").unwrap(),
+            paykit_lib::PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap(),
+        );
+
+        let result = sdk
+            .enqueue_raw_payment_request_acceptance(counterparty, &event)
+            .await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+        assert!(storage
+            .snapshot()
+            .unwrap()
+            .outbound_private_messages
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_process_outbound_private_messages_respects_private_sharing_policy() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let event = PaymentRequestAcceptance::new(
+            paykit_lib::EventId::new("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102").unwrap(),
+            paykit_lib::PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap(),
+        );
+        let event = PaymentRequestEvent::Acceptance(event);
+        crate::payment_requests::enqueue_payment_request_event(
+            &storage,
+            counterparty.clone(),
+            &event,
+            FixedClock.now(),
+        )
+        .await
+        .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig {
+                private_sharing: PrivateSharingPolicy::Disabled,
+                ..PaykitSdkConfig::default()
+            },
+            FixedClock,
+        );
+
+        let result = sdk.process_outbound_private_messages(counterparty).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+        assert_eq!(
+            storage
+                .snapshot()
+                .unwrap()
+                .outbound_private_messages
+                .first()
+                .unwrap()
+                .status,
+            crate::OutboundPrivateMessageStatus::Pending
+        );
+    }
+
+    #[tokio::test]
+    async fn test_accept_payment_request_rejects_expired_proposal_before_enqueue() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let request_id = PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap();
+        persist_private_stream_batch(
+            &storage,
+            counterparty.clone(),
+            vec![payment_request_message(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id.as_str(),
+                Some("2026-06-03T11:59:59Z"),
+            )],
+            None,
+            FixedClock.now(),
+        )
+        .await
+        .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let result = sdk.accept_payment_request(counterparty, &request_id).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+        assert!(storage
+            .snapshot()
+            .unwrap()
+            .outbound_private_messages
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_reject_payment_request_rejects_expired_proposal_before_enqueue() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let request_id = PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap();
+        persist_private_stream_batch(
+            &storage,
+            counterparty.clone(),
+            vec![payment_request_message(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id.as_str(),
+                Some("2026-06-03T11:59:59Z"),
+            )],
+            None,
+            FixedClock.now(),
+        )
+        .await
+        .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let result = sdk
+            .reject_payment_request(counterparty, &request_id, None)
+            .await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+        assert!(storage
+            .snapshot()
+            .unwrap()
+            .outbound_private_messages
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_accept_payment_request_checks_lifecycle_before_send_readiness() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let request_id = PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap();
+        persist_private_stream_batch(
+            &storage,
+            counterparty.clone(),
+            vec![payment_request_message(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id.as_str(),
+                None,
+            )],
+            None,
+            FixedClock.now(),
+        )
+        .await
+        .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let result = sdk.accept_payment_request(counterparty, &request_id).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+        assert!(storage
+            .snapshot()
+            .unwrap()
+            .outbound_private_messages
+            .is_empty());
     }
 
     #[tokio::test]

--- a/paykit-sdk/src/storage.rs
+++ b/paykit-sdk/src/storage.rs
@@ -14,6 +14,7 @@ use crate::{
     linked_peers::LinkedPeerState,
     outbound_private::OutboundPrivateMessageStatus,
     private_stream::PrivateStreamParseStatus,
+    receipts::{ReceiptAccessRecord, ReceiptRecord},
     PaykitSdkError, Result,
 };
 
@@ -105,6 +106,12 @@ pub trait StorageTransaction {
         counterparty: &PubkyPublicKey,
     ) -> Vec<OutboundPrivateMessageRecord>;
 
+    /// List all outbound private messages for one counterparty.
+    fn outbound_private_messages(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Vec<OutboundPrivateMessageRecord>;
+
     /// Claim the next outbound private message for sending, preserving FIFO.
     fn claim_next_outbound_private_message(
         &mut self,
@@ -134,6 +141,25 @@ pub trait StorageTransaction {
 
     /// Save an Event Message dedupe record.
     fn save_event_dedup_record(&mut self, record: EventDedupRecord);
+
+    /// Save one indexed Receipt Access record.
+    fn save_receipt_access_record(&mut self, record: ReceiptAccessRecord);
+
+    /// List indexed Receipt Access records for one counterparty.
+    fn receipt_access_records(&self, counterparty: &PubkyPublicKey) -> Vec<ReceiptAccessRecord>;
+
+    /// Load the latest indexed Receipt Access record for a receipt.
+    fn receipt_access_record_by_receipt_id(
+        &self,
+        counterparty: &PubkyPublicKey,
+        receipt_id: &str,
+    ) -> Option<ReceiptAccessRecord>;
+
+    /// Save one decrypted Receipt record.
+    fn save_receipt_record(&mut self, record: ReceiptRecord);
+
+    /// Load one decrypted Receipt record.
+    fn receipt_record(&self, issuer: &PubkyPublicKey, receipt_id: &str) -> Option<ReceiptRecord>;
 }
 
 /// Durable Linked Peer state.
@@ -582,6 +608,10 @@ pub struct StorageState {
     pub next_private_stream_item_id: u64,
     /// Event dedupe records by counterparty and Event ID.
     pub event_dedup_records: HashMap<(PubkyPublicKey, String), EventDedupRecord>,
+    /// Receipt Access records by counterparty and Event ID.
+    pub receipt_access_records: HashMap<(PubkyPublicKey, String), ReceiptAccessRecord>,
+    /// Decrypted Receipt records by issuer and Receipt ID.
+    pub receipt_records: HashMap<(PubkyPublicKey, String), ReceiptRecord>,
 }
 
 /// In-memory SDK storage implementation for tests and examples.
@@ -657,6 +687,8 @@ impl StorageTransaction for InMemoryStorageTransaction {
         self.state.outbound_private_messages.clear();
         self.state.private_stream_items.clear();
         self.state.event_dedup_records.clear();
+        self.state.receipt_access_records.clear();
+        self.state.receipt_records.clear();
     }
 
     fn linked_peer(&self, counterparty: &PubkyPublicKey) -> Option<LinkedPeerRecord> {
@@ -776,6 +808,21 @@ impl StorageTransaction for InMemoryStorageTransaction {
         messages
     }
 
+    fn outbound_private_messages(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Vec<OutboundPrivateMessageRecord> {
+        let mut messages = self
+            .state
+            .outbound_private_messages
+            .iter()
+            .filter(|message| &message.counterparty == counterparty)
+            .cloned()
+            .collect::<Vec<_>>();
+        messages.sort_by_key(|message| message.outbound_message_id);
+        messages
+    }
+
     fn claim_next_outbound_private_message(
         &mut self,
         counterparty: &PubkyPublicKey,
@@ -864,6 +911,53 @@ impl StorageTransaction for InMemoryStorageTransaction {
             record,
         );
     }
+
+    fn save_receipt_access_record(&mut self, record: ReceiptAccessRecord) {
+        self.state.receipt_access_records.insert(
+            (record.counterparty.clone(), record.event_id.clone()),
+            record,
+        );
+    }
+
+    fn receipt_access_records(&self, counterparty: &PubkyPublicKey) -> Vec<ReceiptAccessRecord> {
+        let mut records = self
+            .state
+            .receipt_access_records
+            .values()
+            .filter(|record| &record.counterparty == counterparty)
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by_key(|record| record.stream_item_id);
+        records
+    }
+
+    fn receipt_access_record_by_receipt_id(
+        &self,
+        counterparty: &PubkyPublicKey,
+        receipt_id: &str,
+    ) -> Option<ReceiptAccessRecord> {
+        self.state
+            .receipt_access_records
+            .values()
+            .filter(|record| {
+                &record.counterparty == counterparty && record.receipt_id == receipt_id
+            })
+            .max_by_key(|record| record.stream_item_id)
+            .cloned()
+    }
+
+    fn save_receipt_record(&mut self, record: ReceiptRecord) {
+        self.state
+            .receipt_records
+            .insert((record.issuer.clone(), record.receipt_id.clone()), record);
+    }
+
+    fn receipt_record(&self, issuer: &PubkyPublicKey, receipt_id: &str) -> Option<ReceiptRecord> {
+        self.state
+            .receipt_records
+            .get(&(issuer.clone(), receipt_id.to_owned()))
+            .cloned()
+    }
 }
 
 fn is_claimable_outbound_private_message(
@@ -920,6 +1014,46 @@ mod tests {
         )
     }
 
+    fn receipt_access_record(counterparty: PubkyPublicKey) -> ReceiptAccessRecord {
+        ReceiptAccessRecord {
+            counterparty,
+            stream_item_id: 0,
+            receive_batch_id: 0,
+            event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+            receipt_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            payment_reference: "invoice-2026-0001".into(),
+            payment_request_id: None,
+            billing_period: None,
+            location: "/pub/paykit/v0/private/receipts/550e8400-e29b-41d4-a716-446655440000".into(),
+            key: "receipt-secret".into(),
+            retrieval_status: crate::ReceiptRetrievalStatus::Pending,
+            retrieval_attempted_at: None,
+            retrieved_at: None,
+            last_retrieval_error: None,
+            received_at: timestamp(),
+        }
+    }
+
+    fn receipt_record(issuer: PubkyPublicKey) -> ReceiptRecord {
+        ReceiptRecord {
+            issuer,
+            receipt_access_event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+            receipt_access_key_hash: "sha256:test".into(),
+            receipt_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            payment_reference: "invoice-2026-0001".into(),
+            payment_request_id: None,
+            billing_period: None,
+            recipient_public_key: PubkyPublicKey::from_public_key(
+                &pubky::Keypair::random().public_key(),
+            ),
+            payment_endpoint_identifier: None,
+            amount: None,
+            metadata: serde_json::Map::new(),
+            location: "/pub/paykit/v0/private/receipts/550e8400-e29b-41d4-a716-446655440000".into(),
+            retrieved_at: timestamp(),
+        }
+    }
+
     #[test]
     fn test_sensitive_storage_debug_is_redacted() {
         let counterparty = counterparty();
@@ -949,10 +1083,14 @@ mod tests {
                 received_at: timestamp(),
             }),
         );
+        let receipt_access = receipt_access_record(stream.counterparty.clone());
+        let receipt = receipt_record(receipt_access.counterparty.clone());
 
-        let debug = format!("{link_state:?} {outbound:?} {stream:?}");
+        let debug =
+            format!("{link_state:?} {outbound:?} {stream:?} {receipt_access:?} {receipt:?}");
         assert!(debug.contains("<redacted:"));
         assert!(!debug.contains("secret"));
+        assert!(!debug.contains("receipt-secret"));
         assert!(!debug.contains("[1, 2, 3]"));
     }
 
@@ -1001,6 +1139,9 @@ mod tests {
                         conflicting_stream_item_ids: Vec::new(),
                     });
 
+                    tx.save_receipt_access_record(receipt_access_record(counterparty.clone()));
+                    tx.save_receipt_record(receipt_record(counterparty));
+
                     Ok(stream_item_id)
                 }
             })
@@ -1017,6 +1158,8 @@ mod tests {
         assert_eq!(snapshot.outbound_private_messages.len(), 1);
         assert_eq!(snapshot.private_stream_items.len(), 1);
         assert_eq!(snapshot.event_dedup_records.len(), 1);
+        assert_eq!(snapshot.receipt_access_records.len(), 1);
+        assert_eq!(snapshot.receipt_records.len(), 1);
         assert_eq!(snapshot.next_private_stream_item_id, 1);
         assert_eq!(snapshot.next_outbound_private_message_id, 1);
     }
@@ -1214,6 +1357,8 @@ mod tests {
                             received_at: timestamp(),
                         },
                     ));
+                    tx.save_receipt_access_record(receipt_access_record(counterparty.clone()));
+                    tx.save_receipt_record(receipt_record(counterparty));
                     tx.clear_identity_scoped_state();
                     Ok(())
                 }
@@ -1229,6 +1374,8 @@ mod tests {
         assert!(snapshot.outbound_private_messages.is_empty());
         assert!(snapshot.private_stream_items.is_empty());
         assert!(snapshot.event_dedup_records.is_empty());
+        assert!(snapshot.receipt_access_records.is_empty());
+        assert!(snapshot.receipt_records.is_empty());
     }
 
     #[tokio::test]
@@ -1268,7 +1415,7 @@ mod tests {
                     ));
                     tx.insert_private_stream_item(NewPrivateStreamItem::new(
                         NewPrivateStreamItemDetails {
-                            counterparty,
+                            counterparty: counterparty.clone(),
                             receive_batch_id: 0,
                             raw_json: r#"{"version":1,"kind":"paykit.test"}"#.into(),
                             parsed_version: Some(1),
@@ -1279,6 +1426,8 @@ mod tests {
                             received_at: timestamp(),
                         },
                     ));
+                    tx.save_receipt_access_record(receipt_access_record(counterparty.clone()));
+                    tx.save_receipt_record(receipt_record(counterparty));
                     tx.clear_private_identity_scoped_state();
                     Ok(())
                 }
@@ -1294,6 +1443,8 @@ mod tests {
         assert!(snapshot.outbound_private_messages.is_empty());
         assert!(snapshot.private_stream_items.is_empty());
         assert!(snapshot.event_dedup_records.is_empty());
+        assert!(snapshot.receipt_access_records.is_empty());
+        assert!(snapshot.receipt_records.is_empty());
         assert_eq!(snapshot.next_peer_link_operation_lease_id, 1);
         assert_eq!(snapshot.next_outbound_private_message_id, 1);
         assert_eq!(snapshot.next_receive_batch_id, 1);

--- a/specs/paykit-sdk.md
+++ b/specs/paykit-sdk.md
@@ -1,11 +1,11 @@
 # Paykit SDK Plan
 
-Status: planning / implementation design
-Date: 2026-06-03
+Status: implementation plan with initial Rust SDK foundation
+Date: 2026-06-04
 
 ## Goal
 
-Define the future Paykit SDK layer that sits above Paykit Library.
+Define the Paykit SDK layer that sits above Paykit Library.
 
 Paykit Library remains the stateless Rust implementation of Paykit Protocol
 wire formats, Pubky storage helpers, Encrypted Link transport helpers, and
@@ -32,8 +32,8 @@ payment methods through adapters without baking any one method into the SDK.
   profile/contact records and shared paths, but it should not own app screens,
   social graph semantics, or product-specific profile schemas.
 - Keep payment execution separate. Payment adapters provide receiving details,
-  endpoint compatibility, payment execution, settlement detection, and
-  method-specific state.
+  endpoint compatibility, payment-target construction, and method-specific
+  endpoint state.
 - Prefer typed records at the SDK boundary. Apps should not have to parse raw
   JSON or reason about Encrypted Link snapshots directly for normal workflows.
 - Expose low-level escape hatches where useful, but make the safe durable path
@@ -51,8 +51,7 @@ The system should have three main layers:
   recovery, Pubky session/capability handling, Pubky-backed Paykit
   profile/contact metadata, and app-facing APIs.
 - Payment adapter layer: receiving-detail generation, endpoint compatibility,
-  payment execution, settlement detection, method/provider state, and activity
-  records.
+  payment-target construction, method/provider state, and activity records.
 
 The SDK may still accept narrow platform hooks for secure session persistence,
 auth UI/Ring session handoff, custom profile/contact storage, scheduling, and
@@ -65,7 +64,7 @@ only for low-level protocol operations.
 
 ## Crate Layout
 
-The first implementation should add a new Rust crate:
+The initial implementation adds a new Rust crate:
 
 ```text
 paykit-sdk/
@@ -83,12 +82,6 @@ paykit-sdk/
     linked_peers.rs
     private_stream.rs
     private_lists.rs
-    payment_requests.rs
-    receipts.rs
-    reservations.rs
-    backup.rs
-    scheduler.rs
-    telemetry.rs
 ```
 
 Suggested module responsibilities:
@@ -96,27 +89,31 @@ Suggested module responsibilities:
 - `runtime`: owns `PaykitSdk`, coordinates adapters, storage, and workflow
   modules.
 - `config`: product-neutral policy knobs such as fallback behavior, retry
-  limits, stale cache rules, and message retention limits.
-- `adapters`: payment-method adapters plus narrow platform hooks for session
-  persistence, scheduling, reservations, and logging.
+  limits, stale cache rules, and future message retention limits.
+- `adapters`: payment-method adapter plus narrow platform hook for live Pubky
+  session access.
 - `storage`: durable records, transaction interface, migrations, and in-memory
   test storage.
 - `identity`: SDK-owned Pubky session capability state and identity
   refresh/import/export workflows.
 - `endpoints`: public Payment Endpoint publication, cleanup, and remote public
   Payment List reads.
-- `contacts`: SDK-owned Paykit-facing contact/profile records, shared namespace
-  handling, and optional custom path/schema hooks.
+- `contacts`: contact payment resolution types. SDK-owned Paykit-facing
+  contact/profile records, shared namespace handling, and optional custom
+  path/schema hooks are future scope.
 - `linked_peers`: Encrypted Link establishment, restore, recovery, and
   per-counterparty runtime state.
 - `private_stream`: ordered Private Application Message intake, persistence,
-  routing, dedupe, and derived view rebuild.
+  parsing, dedupe, and current derived view rebuilds.
 - `private_lists`: local and remote Private Payment List publication, caching,
   latest-state derivation, and size policy.
+- `receipts`: Receipt Access event indexing, Encrypted Receipt retrieval,
+  decryption, and retrieval state.
+
+Future modules should be added only when they have concrete implementation:
+
 - `payment_requests`: Payment Request event state machine, outbound event
   queueing, proof correlation, and scheduling hooks.
-- `receipts`: Receipt Access event indexing, Encrypted Receipt retrieval,
-  decryption, and retry of access messages.
 - `reservations`: optional contact-scoped or single-use receiving-detail
   reservation records.
 - `backup`: versioned export/import of SDK-managed state.
@@ -182,17 +179,19 @@ pub trait StorageAdapter {
 }
 ```
 
-`StorageTransaction` should support records for:
+The current Rust SDK foundation supports records for:
 
-- identity/session state
+- identity state
 - linked peer state
 - Encrypted Link snapshots and handshake snapshots
-- raw private stream items
-- parsed event records
-- dedupe indexes
-- derived current views
-- outbound messages and retry state
 - endpoint publication records
+- outbound Private Application Message records and retry state
+- raw Private Application Message stream items
+- Event Message dedupe indexes
+
+Future SDK storage should add records for:
+
+- parsed event records and derived current views
 - endpoint reservations
 - receipt records
 - backup metadata
@@ -208,6 +207,7 @@ Required for loading and storing local Pubky session material.
 ```rust
 pub trait PubkySessionProvider {
     async fn load_session_access(&self) -> Result<Option<PubkySessionAccess>>;
+    async fn load_public_storage(&self) -> Result<Option<pubky::PublicStorage>>;
     async fn clear_session_access(&self) -> Result<()>;
 }
 ```
@@ -216,6 +216,11 @@ pub trait PubkySessionProvider {
 client for counterparty homeserver access, and optional `PubkyLocalSecretKey`
 needed for Encrypted Links. The SDK derives and persists public `IdentityState`
 from that access during initialization.
+
+`load_public_storage` lets contact resolution fetch public Payment Endpoints
+without requiring authenticated session access. Implementations can reuse the
+Pubky client from `PubkySessionAccess` when they have one, or provide a separate
+public-storage client when only unauthenticated reads are available.
 
 The SDK derives Paykit capability from the session access:
 
@@ -282,7 +287,8 @@ contact grouping, or UI behavior.
 
 ### PaymentAdapter
 
-Required for endpoint publication and payment execution workflows.
+Required for endpoint publication, endpoint selection, and payment-target
+building.
 
 ```rust
 pub trait PaymentAdapter {
@@ -300,11 +306,6 @@ pub trait PaymentAdapter {
         &self,
         endpoint: &PaymentEndpointCandidate,
     ) -> Result<PaymentTarget>;
-
-    async fn execute_payment_request(
-        &self,
-        request: &PaymentRequestExecution,
-    ) -> Result<PaymentExecutionResult>;
 }
 ```
 
@@ -312,47 +313,28 @@ Endpoint selection requests include all discovered candidates, each candidate's
 source, and optional amount context. The adapter returns evaluations and may
 select one candidate from that batch.
 
-The adapter owns payment-method-specific details:
+The adapter owns payment-method-specific endpoint details:
 
 - receiving-detail generation
 - network or method metadata
 - balances, quote policy, fees, and route policy
-- payment execution
-- settlement detection
 - method-specific payload parsing beyond basic Paykit compatibility
 
-### EndpointReservationAdapter
+Payment execution and settlement detection stay with the integrating
+application or payment provider. Future SDK APIs may accept execution results
+from those systems.
 
-Optional. Used when payment methods need contact-scoped or single-use receiving
-details.
+### Future Endpoint Reservations
 
-```rust
-pub trait EndpointReservationAdapter {
-    async fn reserve(
-        &self,
-        contact: PubkyPublicKey,
-        method: PaymentEndpointIdentifier,
-    ) -> Result<ReservedReceivingDetail>;
+Some payment methods need contact-scoped or single-use receiving details. The
+current SDK keeps this out of the public adapter surface. A future reservation
+module can add durable records and adapter hooks once the first product
+integration proves the exact shape.
 
-    async fn rotate_after_use(
-        &self,
-        reservation_id: ReservationId,
-    ) -> Result<Option<ReservedReceivingDetail>>;
-}
-```
+### Future Scheduling
 
-### SchedulerAdapter
-
-Optional. Used for recurring Payment Requests.
-
-```rust
-pub trait SchedulerAdapter {
-    async fn schedule(&self, job: ScheduledPaymentJob) -> Result<()>;
-    async fn cancel(&self, job_id: ScheduledJobId) -> Result<()>;
-}
-```
-
-The SDK derives scheduling eligibility, but the integrating app/runtime may own
+Recurring Payment Request scheduling is future SDK scope. The SDK should derive
+eligibility and durable state, while the integrating app/runtime may still own
 the actual timer service.
 
 ### Logger And Clock
@@ -414,7 +396,7 @@ Append-only raw private stream item:
 - counterparty
 - stream sequence number assigned by the SDK
 - receive batch id
-- raw JSON payload
+- raw UTF-8 payload
 - parsed `version`
 - parsed `kind`
 - known Paykit kind, when recognized
@@ -428,6 +410,7 @@ This is the source of truth for private protocol-derived state.
 
 Tracks Event Message idempotency:
 
+- counterparty
 - event id
 - event kind
 - payload hash of the exact stored payload
@@ -451,15 +434,16 @@ view. They remain in the raw log.
 
 ### EndpointPublicationRecord
 
-Tracks local public and private endpoint publication:
+Tracks SDK-managed public Payment Endpoint publication:
 
-- scope: public or counterparty-private
 - Payment Endpoint Identifier
-- payload hash
+- last payload the SDK tried to publish
 - publication status: desired, published, pending removal, removed, failed
-- last attempted time
-- last confirmed time
-- retry count
+- last status update time
+- last error, when available
+
+Future versions may add payload hashes, separate attempt/confirmation times,
+and retry counters if the SDK needs change detection or richer retry policy.
 
 ### EndpointReservationRecord
 
@@ -518,54 +502,44 @@ Receipt Access records:
 - Receipt Decryption Key
 - optional Payment Request ID
 - optional Billing Period
-- retrieval state
+- retrieval state, timestamps, and last retrieval error
 
 Receipt records:
 
 - receipt id
-- decrypted receipt payload
 - payment reference
 - optional Payment Request ID
 - optional Billing Period
 - issuer context
+- recipient public key
+- optional Payment Endpoint Identifier
+- optional Payment Amount
+- caller-defined Receipt Metadata
 - retrieval/decryption time
+- Receipt Access Event ID and key hash used for retrieval
 
 Receipt Decryption Keys must be redacted in logs and debug output.
 
 ### OutboundPrivateMessageRecord
 
-Durable outbound private-message queue:
+Durable outbound Private Application Message queue:
 
 - outbound id
 - counterparty
-- message kind
-- event id, when applicable
-- exact raw JSON payload
+- Private Message Kind
+- exact raw JSON payload, including Event ID when the message kind has one
 - send status
 - attempt count
 - created, updated, attempted, and sent timestamps
 - last error
 
-The SDK should use one generic outbound private-message record type for all
-Private Application Message kinds, but process it as a FIFO queue per
+The SDK should use one generic outbound Private Application Message record type
+for all Private Application Message kinds, but process it as a FIFO queue per
 counterparty/Encrypted Link. Send workers must claim the next message through
 storage before sending it, and in-progress claims must expire so a crashed
 worker can be retried without letting two workers advance the same link at once.
 
 Event Message retries must reuse the same Event ID and exact payload.
-
-### UnknownPrivateMessageRetention
-
-Unknown valid Private Application Messages should be retained by default. The
-SDK config should define:
-
-- maximum retained unknown messages per counterparty
-- maximum retained bytes per counterparty
-- retention duration
-- whether discard is allowed
-
-Discard policy should never apply to recognized Paykit Event Messages unless
-the app explicitly purges all SDK state.
 
 ## Storage And Checkpoint Invariant
 
@@ -581,10 +555,10 @@ For each receive cycle:
 1. Claim the per-counterparty peer link operation lease.
 2. Restore or establish the Encrypted Link.
 3. Receive the full batch from `paykit-lib`.
-4. Parse every syntactically valid JSON Private Application Message enough to
-   identify version/kind.
-5. In one transaction, insert raw stream items, update dedupe records, update
-   derived views, and then save the advanced link snapshot.
+4. Persist every received Private Application Message plaintext and parse enough
+   to identify version/kind when the payload is valid JSON.
+5. In one transaction, insert raw stream items, update Event Message dedupe
+   records, and then save the advanced link snapshot.
 6. Release the lease.
 
 If the app crashes after messages are stored but before the snapshot is stored,
@@ -605,7 +579,7 @@ Recommended locks:
   handshake, send, receive, and snapshot updates per counterparty.
 - outbound queue claim/lock: serializes retry workers per counterparty.
 - reservation lock: serializes contact-scoped receiving-detail reservation and
-  rotation per counterparty/method.
+  rotation per counterparty/Payment Endpoint Identifier.
 
 These are local SDK/runtime locks, not protocol messages. They can be in-memory
 with durable recovery markers where needed. If a platform can run multiple
@@ -642,8 +616,8 @@ after a newer lease has replaced it.
 1. Ask `PaymentAdapter` for current public receiving details.
 2. Convert receiving details into Payment Endpoint payloads.
 3. Validate identifiers and payloads through `paykit-lib`.
-4. Compare desired payload hashes with `EndpointPublicationRecord`.
-5. Publish changed endpoints.
+4. Persist desired endpoint state.
+5. Publish desired endpoints.
 6. Remove stale managed endpoints.
 7. Persist confirmed/pending/failed state.
 8. Return an `EndpointSyncReport`.
@@ -673,7 +647,8 @@ configured to manage the whole Paykit public namespace.
 5. Build a complete Private Payment List.
 6. Enforce the pubky-noise message size limit.
 7. Persist outbound record and exact payload.
-8. Let the outbound private-message worker send through Encrypted Link.
+8. Let the outbound Private Application Message worker send through Encrypted
+   Link.
 9. Persist send result and updated link snapshot.
 
 Private Payment Lists publish endpoints only. Payment References come from
@@ -685,14 +660,14 @@ Payment Requests, Payment Proofs, and Receipts.
 2. Restore or establish Encrypted Link.
 3. Receive ordered Private Application Messages through `paykit-lib`.
 4. Persist raw messages and parse results.
-5. Route recognized messages:
-   - Private Payment List updates latest-state view.
-   - Receipt Access appends event records.
-   - Payment Request messages update lifecycle state.
-   - Payment Proof messages update proof records.
-6. Detect duplicate Event IDs and conflicting payloads.
-7. Persist updated snapshot after messages and derived state.
+5. Update Event Message dedupe records.
+6. Persist the updated Encrypted Link snapshot in the same transaction.
+7. Index Receipt Access events. Private Payment List views are derived on read
+   from stored stream items.
 8. Return a receive report.
+
+Future receive routing should extend the same raw stream log to Payment
+Requests, Payment Proofs, and any other Event Message kinds.
 
 ### Resolve Contact Payment
 
@@ -718,7 +693,6 @@ Flow:
    - `UnsupportedEndpoint`
    - `PrivateRecoveryPending`
    - `PublicOnlySession`
-   - `Error`
 
 The SDK should not block indefinitely waiting for private recovery.
 
@@ -776,7 +750,10 @@ settlement confirmation.
 4. Fetch Encrypted Receipt when requested or configured.
 5. Decrypt with Receipt Decryption Key.
 6. Verify Receipt ID/location correlation through `paykit-lib`.
-7. Index by Receipt ID, Payment Reference, Payment Request ID, Billing Period,
+7. Verify the decrypted receipt recipient matches the local Pubky identity.
+8. Try newer Receipt Access records first, but fall back to older valid records
+   for the same Receipt ID.
+9. Index by Receipt ID, Payment Reference, Payment Request ID, Billing Period,
    counterparty, and issuer.
 
 ### Backup And Restore
@@ -812,64 +789,24 @@ Restore flow:
 
 ## Public SDK API Shape
 
-The exact API will evolve, but the SDK should expose operations like:
+The current Rust SDK exposes initialization, identity status, public endpoint
+sync, linked peer handshakes, private stream receive, Private Payment List
+derivation/publication, contact payment resolution, and outbound Private
+Application Message processing, Receipt Access indexing/retrieval, and Payment
+Request lifecycle derivation plus checked outbound lifecycle queueing. Use
+`paykit-sdk` rustdoc for the exact current signatures.
+
+Future SDK versions should extend the current surface with operations like:
 
 ```rust
 impl PaykitSdk {
-    async fn initialize(&mut self) -> Result<InitializationReport>;
-    async fn identity_status(&self) -> Result<IdentityStatus>;
     async fn import_session(&mut self, session_secret: String) -> Result<IdentityStatus>;
     async fn sign_out(&mut self) -> Result<()>;
 
-    async fn sync_public_endpoints(&mut self) -> Result<EndpointSyncReport>;
     async fn clear_public_endpoints(&mut self) -> Result<EndpointSyncReport>;
 
     async fn sync_contact(&mut self, counterparty: PubkyPublicKey) -> Result<ContactSyncReport>;
     async fn sync_saved_contacts(&mut self, contacts: Vec<PubkyPublicKey>) -> Result<SyncReport>;
-
-    async fn receive_private_messages(
-        &mut self,
-        counterparty: PubkyPublicKey,
-    ) -> Result<PrivateReceiveReport>;
-
-    async fn current_private_payment_list(
-        &self,
-        counterparty: PubkyPublicKey,
-    ) -> Result<Option<PrivatePaymentListView>>;
-
-    async fn resolve_contact_payment(
-        &mut self,
-        request: ContactPaymentResolutionRequest,
-    ) -> Result<ContactPaymentResolution>;
-
-    async fn propose_payment_request(
-        &mut self,
-        counterparty: PubkyPublicKey,
-        terms: PaymentRequestTermsInput,
-    ) -> Result<PaymentRequestRecord>;
-
-    async fn accept_payment_request(
-        &mut self,
-        id: PaymentRequestId,
-    ) -> Result<PaymentRequestRecord>;
-
-    async fn reject_payment_request(
-        &mut self,
-        id: PaymentRequestId,
-        reason: Option<String>,
-    ) -> Result<PaymentRequestRecord>;
-
-    async fn cancel_payment_request(
-        &mut self,
-        id: PaymentRequestId,
-        reason: Option<String>,
-    ) -> Result<PaymentRequestRecord>;
-
-    async fn record_payment_proof(
-        &mut self,
-        id: PaymentRequestId,
-        proof: PaymentProofInput,
-    ) -> Result<PaymentRequestRecord>;
 
     async fn list_payment_requests(
         &self,
@@ -938,14 +875,19 @@ belongs to the app.
 
 ## Policy Configuration
 
-`PaykitSdkConfig` should include:
+Current `PaykitSdkConfig` includes:
 
 - public endpoint management scope
 - private sharing enabled/disabled
 - public fallback policy
-- private recovery wait duration and retry limits
+- private recovery wait duration
+- peer link operation lease timeout
+- outbound private send lease timeout
+
+Future policy configuration may add:
+
 - stale private cache policy
-- outbound retry policy
+- outbound retry policy beyond lease expiry
 - unknown message retention policy
 - receipt auto-retrieval policy
 - recurring Payment Request scheduling policy
@@ -980,24 +922,23 @@ These should stay outside Paykit SDK:
 - app backup transport and cloud sync
 - seed/secret derivation policy unless standardized
 
-## Implementation Build Order
+## Current Foundation And Next Work
 
-1. Add `paykit-sdk` crate skeleton, error type, config, adapter traits, and
-   in-memory test storage.
-2. Implement durable storage records and transaction/checkpoint contract.
-3. Implement identity capability state and public endpoint sync.
-4. Implement Encrypted Link runtime, peer records, private stream intake, and
-   checkpoint-safe persistence.
-5. Implement Private Payment List latest-state derivation and contact payment
-   resolution.
-6. Implement outbound queue and retry model for private messages.
-7. Implement Receipt Access indexing and Receipt retrieval.
-8. Implement Payment Request lifecycle derivation and outbound lifecycle APIs.
-9. Implement optional endpoint reservation subsystem.
-10. Implement backup/export/restore for SDK-managed state.
-11. Add FFI and platform wrappers.
-12. Migrate one existing app integration behind the SDK and use that to refine
-    adapters.
+The current Rust SDK foundation includes the crate skeleton, error/config
+types, adapter traits, in-memory test storage, identity state, public endpoint
+sync, Encrypted Link runtime records, private stream intake, Private Payment
+List latest-state derivation, contact payment resolution, outbound Private
+Application Message delivery, Receipt Access indexing, receipt retrieval,
+Payment Request lifecycle derivation, and checked outbound Payment Request
+lifecycle queueing.
+
+Next work:
+
+1. Add optional endpoint reservation support.
+2. Add backup/export/restore for SDK-managed state.
+3. Add SDK FFI and platform wrappers.
+4. Migrate one existing app integration behind the SDK and use that to refine
+   adapters.
 
 Each step should include unit tests for storage invariants and at least one
 integration-style test using an in-memory adapter setup.
@@ -1035,10 +976,12 @@ Platform tests:
 2. Should the default Paykit SDK profile/contact namespace use a reserved
    subdirectory under `/pub/paykit/v0/`, or an unversioned Paykit-level path
    under `/pub/paykit/`?
-3. What is the default public fallback policy for saved contacts?
+3. Should the current default public fallback and private recovery timeouts
+   differ for saved contacts versus one-off counterparties?
 4. How much endpoint reservation should be generalized in the first SDK version?
 5. How much recurring Payment Request scheduling should the SDK own versus
    delegating to app/runtime schedulers?
-6. What are the unknown Private Application Message retention defaults?
+6. What unknown Private Application Message retention defaults are appropriate
+   for mobile storage budgets once retention enforcement is implemented?
 7. Should SDK bindings become the primary mobile API while `paykit-ffi` remains
    low-level protocol API?


### PR DESCRIPTION
## Summary

Stack PR 3/6 for the Paykit SDK split.

Adds SDK-level Payment Request and Receipt support: Receipt Access indexing, receipt retrieval, Payment Request lifecycle derivation, outbound Payment Request event helpers, and related storage/runtime records.

## Review Notes

- Base: `codex/sdk-stack-private-runtime`
- Head: `codex/sdk-stack-requests-receipts`
- This builds on the private runtime and stream handling PR.
- The final stack branch was verified to have the same tree as #55's head.

## Verification

The final stacked branch matches #55's final tree exactly.
