### PR TITLE
Add SDK reservations and backup restore

### DIFF
--- a/paykit-sdk/README.md
+++ b/paykit-sdk/README.md
@@ -5,8 +5,10 @@ Stateful Rust runtime for Paykit integrations.
 `paykit-sdk` builds on `paykit-lib` and owns SDK-level local state for Pubky
 identity status, public Payment Endpoint sync, Encrypted Link state, private
 stream intake, Private Payment List derivation, contact payment resolution, and
-outbound Private Application Message delivery. It also indexes Receipt Access
-events and retrieves/decrypts Encrypted Receipts into private SDK state.
+outbound Private Application Message delivery. It also derives Payment Request
+state, indexes Receipt Access events, retrieves/decrypts Encrypted Receipts,
+tracks optional Payment Endpoint Reservations, and exports/restores
+SDK-managed backup state.
 
 The crate is currently Rust-only. Existing Swift, Kotlin, and React Native
 bindings continue to expose low-level `paykit-lib` APIs until SDK bindings are

--- a/paykit-sdk/src/adapters.rs
+++ b/paykit-sdk/src/adapters.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 use crate::{identity::PubkyPublicKey, PubkySessionAccess, Result};
 
@@ -35,6 +36,33 @@ pub trait PaymentAdapter: Send + Sync {
         scope: ReceivingDetailScope,
     ) -> Result<Vec<ReceivingDetail>>;
 
+    /// Reserve receiving details for a counterparty's Private Payment List.
+    ///
+    /// Returning `None` means this adapter does not handle reservations and the
+    /// SDK should use regular receiving details.
+    ///
+    /// Returning `Some` means the returned reservations are the complete set of
+    /// private receiving details to share for that counterparty.
+    ///
+    /// Reservation happens in the payment adapter before the SDK can persist
+    /// linked records. Adapters that return reservations should make them
+    /// idempotent, expiring, or otherwise safe to abandon if the process stops
+    /// before the SDK queues a Private Payment List.
+    async fn reserve_receiving_details(
+        &self,
+        _request: &PaymentEndpointReservationRequest,
+    ) -> Result<Option<Vec<PaymentEndpointReservation>>> {
+        Ok(None)
+    }
+
+    /// Release a previously reserved receiving detail, when supported.
+    async fn release_receiving_detail_reservation(
+        &self,
+        _release: &PaymentEndpointReservationRelease,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     /// Rank and evaluate candidate endpoints for a payment.
     async fn select_payment_endpoint(
         &self,
@@ -60,6 +88,13 @@ pub enum ReceivingDetailScope {
     },
 }
 
+/// Request passed to the payment adapter for receiving-detail reservation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentEndpointReservationRequest {
+    /// Counterparty whose Private Payment List will receive the reserved details.
+    pub counterparty: PubkyPublicKey,
+}
+
 /// Payment-method-specific receiving detail returned by an adapter.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReceivingDetail {
@@ -74,6 +109,63 @@ impl fmt::Debug for ReceivingDetail {
         f.debug_struct("ReceivingDetail")
             .field("identifier", &self.identifier)
             .field("payload", &redacted_payload(&self.payload))
+            .finish()
+    }
+}
+
+/// Receiving detail reserved by the payment adapter.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentEndpointReservation {
+    /// Adapter-stable reservation id.
+    pub reservation_id: String,
+    /// Reserved receiving detail.
+    pub receiving_detail: ReceivingDetail,
+    /// Optional reservation expiry.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Adapter-provided attribution metadata.
+    pub attribution: HashMap<String, String>,
+}
+
+/// Request passed to release a receiving-detail reservation.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentEndpointReservationRelease {
+    /// Adapter-stable reservation id.
+    pub reservation_id: String,
+    /// Counterparty the reservation was intended for.
+    pub counterparty: PubkyPublicKey,
+    /// Payment Endpoint Identifier.
+    pub identifier: String,
+    /// Hash of the reserved endpoint payload.
+    pub payload_hash: String,
+    /// Adapter-provided attribution metadata from the reservation.
+    pub attribution: HashMap<String, String>,
+}
+
+impl fmt::Debug for PaymentEndpointReservationRelease {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentEndpointReservationRelease")
+            .field("reservation_id", &self.reservation_id)
+            .field("counterparty", &self.counterparty)
+            .field("identifier", &self.identifier)
+            .field("payload_hash", &self.payload_hash)
+            .field(
+                "attribution",
+                &format_args!("<redacted:{} fields>", self.attribution.len()),
+            )
+            .finish()
+    }
+}
+
+impl fmt::Debug for PaymentEndpointReservation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentEndpointReservation")
+            .field("reservation_id", &self.reservation_id)
+            .field("receiving_detail", &self.receiving_detail)
+            .field("expires_at", &self.expires_at)
+            .field(
+                "attribution",
+                &format_args!("<redacted:{} fields>", self.attribution.len()),
+            )
             .finish()
     }
 }

--- a/paykit-sdk/src/backup.rs
+++ b/paykit-sdk/src/backup.rs
@@ -1,0 +1,1342 @@
+//! SDK backup and restore state.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    identity::{IdentityState, PubkyPublicKey},
+    linked_peers::LinkedPeerState,
+    outbound_private::validate_queued_outbound_private_message,
+    private_stream::{payload_hash, PrivateStreamParseStatus},
+    receipts::{ReceiptAccessRecord, ReceiptRecord},
+    storage::{
+        EncryptedLinkStateRecord, EventDedupRecord, LinkedPeerRecord, OutboundPrivateMessageRecord,
+        PaymentEndpointReservationRecord, PrivateStreamItemRecord, PublicEndpointRecord,
+        StorageAdapter, StorageState,
+    },
+    PaykitSdkError, Result,
+};
+use paykit_lib::{
+    PaymentEndpointIdentifier, PrivateApplicationMessage, PrivateMessageKind, ReceiptId,
+};
+
+/// Current SDK backup schema version.
+pub const SDK_BACKUP_VERSION: u32 = 1;
+
+/// Versioned SDK-managed backup payload.
+///
+/// This payload includes private SDK recovery data such as Encrypted Link
+/// snapshots, raw Private Application Messages, outbound payloads, and Receipt
+/// Decryption Keys. Store and transport it with caller-managed encryption.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SdkBackupState {
+    /// Backup schema version.
+    pub version: u32,
+    /// Current identity state.
+    pub identity_state: Option<IdentityState>,
+    /// Linked Peer records.
+    pub linked_peers: Vec<LinkedPeerRecord>,
+    /// Public Payment Endpoint records.
+    pub public_endpoint_records: Vec<PublicEndpointRecord>,
+    /// Payment Endpoint Reservation records.
+    pub payment_endpoint_reservations: Vec<PaymentEndpointReservationRecord>,
+    /// Encrypted Link state records.
+    pub encrypted_link_states: Vec<EncryptedLinkStateRecord>,
+    /// Outbound Private Application Message records.
+    pub outbound_private_messages: Vec<OutboundPrivateMessageRecord>,
+    /// Private stream item records.
+    pub private_stream_items: Vec<PrivateStreamItemRecord>,
+    /// Event Message dedupe records.
+    pub event_dedup_records: Vec<EventDedupRecord>,
+    /// Receipt Access records.
+    pub receipt_access_records: Vec<ReceiptAccessRecord>,
+    /// Decrypted Receipt records.
+    pub receipt_records: Vec<ReceiptRecord>,
+    /// Next outbound Private Application Message id.
+    pub next_outbound_private_message_id: u64,
+    /// Next private receive batch id.
+    pub next_receive_batch_id: u64,
+    /// Next private stream item id.
+    pub next_private_stream_item_id: u64,
+}
+
+impl fmt::Debug for SdkBackupState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SdkBackupState")
+            .field("version", &self.version)
+            .field("identity_state", &self.identity_state)
+            .field("linked_peers", &self.linked_peers.len())
+            .field(
+                "public_endpoint_records",
+                &self.public_endpoint_records.len(),
+            )
+            .field(
+                "payment_endpoint_reservations",
+                &self.payment_endpoint_reservations.len(),
+            )
+            .field("encrypted_link_states", &self.encrypted_link_states.len())
+            .field(
+                "outbound_private_messages",
+                &self.outbound_private_messages.len(),
+            )
+            .field("private_stream_items", &self.private_stream_items.len())
+            .field("event_dedup_records", &self.event_dedup_records.len())
+            .field("receipt_access_records", &self.receipt_access_records.len())
+            .field("receipt_records", &self.receipt_records.len())
+            .field(
+                "next_outbound_private_message_id",
+                &self.next_outbound_private_message_id,
+            )
+            .field("next_receive_batch_id", &self.next_receive_batch_id)
+            .field(
+                "next_private_stream_item_id",
+                &self.next_private_stream_item_id,
+            )
+            .finish()
+    }
+}
+
+/// Report returned after restoring SDK-managed backup state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RestoreReport {
+    /// Restored backup schema version.
+    pub version: u32,
+    /// Whether identity state was restored.
+    pub restored_identity: bool,
+    /// Number of restored Linked Peer records.
+    pub linked_peers: usize,
+    /// Number of restored public Payment Endpoint records.
+    pub public_endpoint_records: usize,
+    /// Number of restored Payment Endpoint Reservation records.
+    pub payment_endpoint_reservations: usize,
+    /// Number of restored Encrypted Link state records.
+    pub encrypted_link_states: usize,
+    /// Number of restored outbound Private Application Message records.
+    pub outbound_private_messages: usize,
+    /// Number of restored private stream item records.
+    pub private_stream_items: usize,
+    /// Number of restored Event Message dedupe records.
+    pub event_dedup_records: usize,
+    /// Number of restored Receipt Access records.
+    pub receipt_access_records: usize,
+    /// Number of restored decrypted Receipt records.
+    pub receipt_records: usize,
+    /// Counterparties marked recovery-required during restore.
+    pub recovery_required_peers: Vec<PubkyPublicKey>,
+}
+
+/// Backup-validated storage replacement payload.
+///
+/// This type is intentionally opaque to callers. It prevents arbitrary full
+/// storage replacement through [`StorageTransaction`](crate::StorageTransaction)
+/// while still letting storage adapters apply validated backup state.
+pub struct ValidatedStorageState {
+    state: StorageState,
+}
+
+impl ValidatedStorageState {
+    pub(crate) fn new(state: StorageState) -> Self {
+        Self { state }
+    }
+
+    /// Consume the validated wrapper and return the storage state.
+    pub fn into_storage_state(self) -> StorageState {
+        self.state
+    }
+}
+
+/// Export SDK-managed state from storage.
+pub async fn export_backup_state<S>(storage: &S) -> Result<SdkBackupState>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| {
+            Ok(SdkBackupState::from_storage_state(
+                tx.export_storage_state(),
+            ))
+        })
+        .await
+}
+
+pub(crate) async fn restore_backup_state<S>(
+    storage: &S,
+    backup: SdkBackupState,
+) -> Result<RestoreReport>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(move |tx| {
+            let current_identity = tx.load_identity_state();
+            let (state, report) = backup.into_storage_state(current_identity.as_ref())?;
+            tx.replace_storage_state(state);
+            Ok(report)
+        })
+        .await
+}
+
+impl SdkBackupState {
+    pub(crate) fn from_storage_state(state: StorageState) -> Self {
+        let mut linked_peers = state.linked_peers.into_values().collect::<Vec<_>>();
+        linked_peers
+            .sort_by(|left, right| left.counterparty.as_str().cmp(right.counterparty.as_str()));
+
+        let mut public_endpoint_records = state
+            .public_endpoint_records
+            .into_values()
+            .collect::<Vec<_>>();
+        public_endpoint_records.sort_by(|left, right| left.identifier.cmp(&right.identifier));
+
+        let mut payment_endpoint_reservations = state
+            .payment_endpoint_reservations
+            .into_values()
+            .collect::<Vec<_>>();
+        payment_endpoint_reservations.sort_by(|left, right| {
+            left.counterparty
+                .as_str()
+                .cmp(right.counterparty.as_str())
+                .then(left.reservation_id.cmp(&right.reservation_id))
+        });
+
+        let mut encrypted_link_states = state
+            .encrypted_link_states
+            .into_values()
+            .collect::<Vec<_>>();
+        encrypted_link_states
+            .sort_by(|left, right| left.counterparty.as_str().cmp(right.counterparty.as_str()));
+
+        let mut event_dedup_records = state.event_dedup_records.into_values().collect::<Vec<_>>();
+        event_dedup_records.sort_by(|left, right| {
+            left.counterparty
+                .as_str()
+                .cmp(right.counterparty.as_str())
+                .then(left.event_id.cmp(&right.event_id))
+        });
+
+        let mut receipt_access_records = state
+            .receipt_access_records
+            .into_values()
+            .collect::<Vec<_>>();
+        receipt_access_records.sort_by(|left, right| {
+            left.counterparty
+                .as_str()
+                .cmp(right.counterparty.as_str())
+                .then(left.event_id.cmp(&right.event_id))
+        });
+
+        let mut receipt_records = state.receipt_records.into_values().collect::<Vec<_>>();
+        receipt_records.sort_by(|left, right| {
+            left.issuer
+                .as_str()
+                .cmp(right.issuer.as_str())
+                .then(left.receipt_id.cmp(&right.receipt_id))
+        });
+
+        Self {
+            version: SDK_BACKUP_VERSION,
+            identity_state: state.identity_state,
+            linked_peers,
+            public_endpoint_records,
+            payment_endpoint_reservations,
+            encrypted_link_states,
+            outbound_private_messages: state.outbound_private_messages,
+            private_stream_items: state.private_stream_items,
+            event_dedup_records,
+            receipt_access_records,
+            receipt_records,
+            next_outbound_private_message_id: state.next_outbound_private_message_id,
+            next_receive_batch_id: state.next_receive_batch_id,
+            next_private_stream_item_id: state.next_private_stream_item_id,
+        }
+    }
+
+    fn into_storage_state(
+        self,
+        current_identity: Option<&IdentityState>,
+    ) -> Result<(ValidatedStorageState, RestoreReport)> {
+        self.validate(current_identity)?;
+
+        let mut linked_peers = keyed_by_counterparty(self.linked_peers, "Linked Peer")?;
+        let public_endpoint_records = keyed_by_string(
+            self.public_endpoint_records,
+            |record| record.identifier.clone(),
+            "public Payment Endpoint",
+        )?;
+        validate_public_endpoint_records(&public_endpoint_records)?;
+        let payment_endpoint_reservations = keyed_by_tuple(
+            self.payment_endpoint_reservations,
+            |record| (record.counterparty.clone(), record.reservation_id.clone()),
+            "Payment Endpoint Reservation",
+        )?;
+        validate_payment_endpoint_reservations(&payment_endpoint_reservations)?;
+        let encrypted_link_states =
+            keyed_by_counterparty(self.encrypted_link_states, "Encrypted Link state")?;
+        validate_encrypted_link_snapshots(&encrypted_link_states)?;
+        let outbound_private_messages = unique_outbound_messages(self.outbound_private_messages)?;
+        validate_outbound_private_messages(&outbound_private_messages)?;
+        let private_stream_items = unique_private_stream_items(self.private_stream_items)?;
+        validate_private_stream_items(&private_stream_items)?;
+        let event_dedup_records = keyed_by_tuple(
+            self.event_dedup_records,
+            |record| (record.counterparty.clone(), record.event_id.clone()),
+            "Event dedupe",
+        )?;
+        validate_event_dedup_records(&event_dedup_records, &private_stream_items)?;
+        let receipt_access_records = keyed_by_tuple(
+            self.receipt_access_records,
+            |record| (record.counterparty.clone(), record.event_id.clone()),
+            "Receipt Access",
+        )?;
+        validate_receipt_access_records(&receipt_access_records, &private_stream_items)?;
+        let receipt_records = keyed_by_tuple(
+            self.receipt_records,
+            |record| (record.issuer.clone(), record.receipt_id.clone()),
+            "Receipt",
+        )?;
+        validate_receipt_records(&receipt_records, &receipt_access_records)?;
+
+        let recovery_counterparties = recovery_counterparties(RecoverySources {
+            linked_peers: &linked_peers,
+            payment_endpoint_reservations: &payment_endpoint_reservations,
+            encrypted_link_states: &encrypted_link_states,
+            outbound_private_messages: &outbound_private_messages,
+            private_stream_items: &private_stream_items,
+            event_dedup_records: &event_dedup_records,
+            receipt_access_records: &receipt_access_records,
+            receipt_records: &receipt_records,
+        });
+        let recovery_required_peers =
+            mark_restored_peers_recovery_required(&mut linked_peers, &recovery_counterparties);
+
+        let next_outbound_private_message_id = self
+            .next_outbound_private_message_id
+            .max(next_outbound_id(&outbound_private_messages));
+        let next_receive_batch_id = self
+            .next_receive_batch_id
+            .max(next_receive_batch_id(&private_stream_items));
+        let next_private_stream_item_id = self
+            .next_private_stream_item_id
+            .max(next_private_stream_item_id(&private_stream_items));
+
+        let report = RestoreReport {
+            version: self.version,
+            restored_identity: self.identity_state.is_some(),
+            linked_peers: linked_peers.len(),
+            public_endpoint_records: public_endpoint_records.len(),
+            payment_endpoint_reservations: payment_endpoint_reservations.len(),
+            encrypted_link_states: encrypted_link_states.len(),
+            outbound_private_messages: outbound_private_messages.len(),
+            private_stream_items: private_stream_items.len(),
+            event_dedup_records: event_dedup_records.len(),
+            receipt_access_records: receipt_access_records.len(),
+            receipt_records: receipt_records.len(),
+            recovery_required_peers,
+        };
+
+        let state = StorageState {
+            identity_state: self.identity_state,
+            linked_peers,
+            public_endpoint_records,
+            payment_endpoint_reservations,
+            encrypted_link_states,
+            peer_link_operation_leases: HashMap::new(),
+            next_peer_link_operation_lease_id: 0,
+            outbound_private_messages,
+            next_outbound_private_message_id,
+            private_stream_items,
+            next_receive_batch_id,
+            next_private_stream_item_id,
+            event_dedup_records,
+            receipt_access_records,
+            receipt_records,
+        };
+
+        Ok((ValidatedStorageState::new(state), report))
+    }
+
+    fn validate(&self, current_identity: Option<&IdentityState>) -> Result<()> {
+        if self.version != SDK_BACKUP_VERSION {
+            return Err(PaykitSdkError::Protocol(format!(
+                "unsupported SDK backup version {}",
+                self.version
+            )));
+        }
+
+        if let Some(current_public_key) =
+            current_identity.and_then(|state| state.public_key.as_ref())
+        {
+            let backup_public_key = self
+                .identity_state
+                .as_ref()
+                .and_then(|state| state.public_key.as_ref());
+            if backup_public_key != Some(current_public_key) {
+                return Err(PaykitSdkError::Identity {
+                    context: "backup identity does not match current local identity".into(),
+                    source: None,
+                });
+            }
+        }
+
+        let backup_public_key = self
+            .identity_state
+            .as_ref()
+            .and_then(|state| state.public_key.as_ref());
+        if backup_public_key.is_none() && self.has_identity_scoped_state() {
+            return Err(PaykitSdkError::Protocol(
+                "backup has SDK state but no local public identity".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn identity_public_key(&self) -> Option<&PubkyPublicKey> {
+        self.identity_state
+            .as_ref()
+            .and_then(|state| state.public_key.as_ref())
+    }
+
+    pub(crate) fn has_identity_scoped_state(&self) -> bool {
+        !self.linked_peers.is_empty()
+            || !self.public_endpoint_records.is_empty()
+            || !self.payment_endpoint_reservations.is_empty()
+            || !self.encrypted_link_states.is_empty()
+            || !self.outbound_private_messages.is_empty()
+            || !self.private_stream_items.is_empty()
+            || !self.event_dedup_records.is_empty()
+            || !self.receipt_access_records.is_empty()
+            || !self.receipt_records.is_empty()
+    }
+
+    pub(crate) fn has_private_identity_scoped_state(&self) -> bool {
+        !self.linked_peers.is_empty()
+            || !self.payment_endpoint_reservations.is_empty()
+            || !self.encrypted_link_states.is_empty()
+            || !self.outbound_private_messages.is_empty()
+            || !self.private_stream_items.is_empty()
+            || !self.event_dedup_records.is_empty()
+            || !self.receipt_access_records.is_empty()
+            || !self.receipt_records.is_empty()
+    }
+}
+
+fn keyed_by_counterparty<T>(records: Vec<T>, label: &str) -> Result<HashMap<PubkyPublicKey, T>>
+where
+    T: HasCounterparty,
+{
+    keyed_by_tuple(records, |record| record.counterparty().clone(), label)
+}
+
+trait HasCounterparty {
+    fn counterparty(&self) -> &PubkyPublicKey;
+}
+
+impl HasCounterparty for LinkedPeerRecord {
+    fn counterparty(&self) -> &PubkyPublicKey {
+        &self.counterparty
+    }
+}
+
+impl HasCounterparty for EncryptedLinkStateRecord {
+    fn counterparty(&self) -> &PubkyPublicKey {
+        &self.counterparty
+    }
+}
+
+fn keyed_by_string<T, F>(records: Vec<T>, key: F, label: &str) -> Result<HashMap<String, T>>
+where
+    F: Fn(&T) -> String,
+{
+    keyed_by_tuple(records, key, label)
+}
+
+fn keyed_by_tuple<K, T, F>(records: Vec<T>, key: F, label: &str) -> Result<HashMap<K, T>>
+where
+    K: Eq + std::hash::Hash + fmt::Debug,
+    F: Fn(&T) -> K,
+{
+    let mut keyed = HashMap::new();
+    for record in records {
+        let key = key(&record);
+        if keyed.insert(key, record).is_some() {
+            return Err(PaykitSdkError::Protocol(format!(
+                "duplicate {label} backup key"
+            )));
+        }
+    }
+    Ok(keyed)
+}
+
+fn unique_outbound_messages(
+    mut records: Vec<OutboundPrivateMessageRecord>,
+) -> Result<Vec<OutboundPrivateMessageRecord>> {
+    let mut ids = HashSet::new();
+    for record in &records {
+        if !ids.insert(record.outbound_message_id) {
+            return Err(PaykitSdkError::Protocol(format!(
+                "duplicate outbound Private Application Message id {}",
+                record.outbound_message_id
+            )));
+        }
+    }
+    records.sort_by_key(|record| record.outbound_message_id);
+    Ok(records)
+}
+
+fn unique_private_stream_items(
+    mut records: Vec<PrivateStreamItemRecord>,
+) -> Result<Vec<PrivateStreamItemRecord>> {
+    let mut ids = HashSet::new();
+    for record in &records {
+        if !ids.insert(record.stream_item_id) {
+            return Err(PaykitSdkError::Protocol(format!(
+                "duplicate private stream item id {}",
+                record.stream_item_id
+            )));
+        }
+    }
+    records.sort_by_key(|record| record.stream_item_id);
+    Ok(records)
+}
+
+fn next_outbound_id(records: &[OutboundPrivateMessageRecord]) -> u64 {
+    records
+        .iter()
+        .map(|record| record.outbound_message_id.saturating_add(1))
+        .max()
+        .unwrap_or_default()
+}
+
+fn next_receive_batch_id(records: &[PrivateStreamItemRecord]) -> u64 {
+    records
+        .iter()
+        .map(|record| record.receive_batch_id.saturating_add(1))
+        .max()
+        .unwrap_or_default()
+}
+
+fn next_private_stream_item_id(records: &[PrivateStreamItemRecord]) -> u64 {
+    records
+        .iter()
+        .map(|record| record.stream_item_id.saturating_add(1))
+        .max()
+        .unwrap_or_default()
+}
+
+fn mark_restored_peers_recovery_required(
+    linked_peers: &mut HashMap<PubkyPublicKey, LinkedPeerRecord>,
+    recovery_counterparties: &HashSet<PubkyPublicKey>,
+) -> Vec<PubkyPublicKey> {
+    for counterparty in recovery_counterparties {
+        linked_peers
+            .entry(counterparty.clone())
+            .or_insert_with(|| LinkedPeerRecord {
+                counterparty: counterparty.clone(),
+                state: LinkedPeerState::RecoveryRequired,
+                last_sync_at: None,
+                last_private_receive_at: None,
+                failure_count: 0,
+            });
+    }
+
+    let mut peers = Vec::new();
+    for record in linked_peers.values_mut() {
+        if record.state != LinkedPeerState::Blocked
+            && (recovery_counterparties.contains(&record.counterparty)
+                || matches!(
+                    record.state,
+                    LinkedPeerState::Linked | LinkedPeerState::Linking
+                ))
+        {
+            record.state = LinkedPeerState::RecoveryRequired;
+        }
+        if record.state == LinkedPeerState::RecoveryRequired {
+            peers.push(record.counterparty.clone());
+        }
+    }
+    peers.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+    peers
+}
+
+struct RecoverySources<'a> {
+    linked_peers: &'a HashMap<PubkyPublicKey, LinkedPeerRecord>,
+    payment_endpoint_reservations:
+        &'a HashMap<(PubkyPublicKey, String), PaymentEndpointReservationRecord>,
+    encrypted_link_states: &'a HashMap<PubkyPublicKey, EncryptedLinkStateRecord>,
+    outbound_private_messages: &'a [OutboundPrivateMessageRecord],
+    private_stream_items: &'a [PrivateStreamItemRecord],
+    event_dedup_records: &'a HashMap<(PubkyPublicKey, String), EventDedupRecord>,
+    receipt_access_records: &'a HashMap<(PubkyPublicKey, String), ReceiptAccessRecord>,
+    receipt_records: &'a HashMap<(PubkyPublicKey, String), ReceiptRecord>,
+}
+
+fn recovery_counterparties(sources: RecoverySources<'_>) -> HashSet<PubkyPublicKey> {
+    let mut counterparties = HashSet::new();
+    for record in sources.linked_peers.values() {
+        if matches!(
+            record.state,
+            LinkedPeerState::Linked | LinkedPeerState::Linking
+        ) {
+            counterparties.insert(record.counterparty.clone());
+        }
+    }
+    counterparties.extend(
+        sources
+            .payment_endpoint_reservations
+            .values()
+            .map(|record| record.counterparty.clone()),
+    );
+    counterparties.extend(sources.encrypted_link_states.keys().cloned());
+    counterparties.extend(
+        sources
+            .outbound_private_messages
+            .iter()
+            .map(|record| record.counterparty.clone()),
+    );
+    counterparties.extend(
+        sources
+            .private_stream_items
+            .iter()
+            .map(|record| record.counterparty.clone()),
+    );
+    counterparties.extend(
+        sources
+            .event_dedup_records
+            .values()
+            .map(|record| record.counterparty.clone()),
+    );
+    counterparties.extend(
+        sources
+            .receipt_access_records
+            .values()
+            .map(|record| record.counterparty.clone()),
+    );
+    counterparties.extend(
+        sources
+            .receipt_records
+            .values()
+            .map(|record| record.issuer.clone()),
+    );
+    counterparties
+}
+
+fn validate_encrypted_link_snapshots(
+    records: &HashMap<PubkyPublicKey, EncryptedLinkStateRecord>,
+) -> Result<()> {
+    for (counterparty, record) in records {
+        let expected_recipient = counterparty.to_public_key()?;
+        if let Some(snapshot_bytes) = record.link_snapshot.as_ref() {
+            let snapshot = paykit_lib::EncryptedLinkSnapshot::deserialize(snapshot_bytes)
+                .map_err(PaykitSdkError::from)?;
+            if snapshot.recipient() != &expected_recipient {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Encrypted Link snapshot recipient does not match counterparty {counterparty}"
+                )));
+            }
+        }
+        if let Some(snapshot_bytes) = record.handshake_snapshot.as_ref() {
+            let snapshot = paykit_lib::EncryptedLinkHandshakeSnapshot::deserialize(snapshot_bytes)
+                .map_err(PaykitSdkError::from)?;
+            if snapshot.recipient() != &expected_recipient {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Encrypted Link Handshake snapshot recipient does not match counterparty {counterparty}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_public_endpoint_records(records: &HashMap<String, PublicEndpointRecord>) -> Result<()> {
+    for record in records.values() {
+        PaymentEndpointIdentifier::new(&record.identifier)?;
+    }
+    Ok(())
+}
+
+fn validate_payment_endpoint_reservations(
+    records: &HashMap<(PubkyPublicKey, String), PaymentEndpointReservationRecord>,
+) -> Result<()> {
+    for record in records.values() {
+        if record.reservation_id.trim().is_empty() {
+            return Err(PaykitSdkError::Protocol(
+                "Payment Endpoint Reservation id must not be empty".into(),
+            ));
+        }
+        PaymentEndpointIdentifier::new(&record.identifier)?;
+    }
+    Ok(())
+}
+
+fn validate_outbound_private_messages(records: &[OutboundPrivateMessageRecord]) -> Result<()> {
+    for record in records {
+        validate_queued_outbound_private_message(record)?;
+    }
+    Ok(())
+}
+
+fn validate_private_stream_items(records: &[PrivateStreamItemRecord]) -> Result<()> {
+    for record in records {
+        let (parsed_version, parsed_kind, known_kind) = private_message_header(&record.raw_json)?;
+        if record.parsed_version != parsed_version {
+            return Err(PaykitSdkError::Protocol(format!(
+                "private stream item {} has stale parsed version metadata",
+                record.stream_item_id
+            )));
+        }
+        if record.parsed_kind.as_deref() != parsed_kind.as_deref() {
+            return Err(PaykitSdkError::Protocol(format!(
+                "private stream item {} has stale parsed kind metadata",
+                record.stream_item_id
+            )));
+        }
+        if record.known_paykit_kind.as_deref() != known_kind.map(PrivateMessageKind::as_str) {
+            return Err(PaykitSdkError::Protocol(format!(
+                "private stream item {} has stale known kind metadata",
+                record.stream_item_id
+            )));
+        }
+        if record.parse_status == PrivateStreamParseStatus::Valid {
+            let Some(kind) = known_kind else {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "private stream item {} is marked valid without a recognized Paykit kind",
+                    record.stream_item_id
+                )));
+            };
+            validate_valid_private_stream_body(record, kind)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_event_dedup_records(
+    records: &HashMap<(PubkyPublicKey, String), EventDedupRecord>,
+    stream_items: &[PrivateStreamItemRecord],
+) -> Result<()> {
+    let stream_by_id = stream_items
+        .iter()
+        .map(|item| (item.stream_item_id, item))
+        .collect::<HashMap<_, _>>();
+    for record in records.values() {
+        let Some(first) = stream_by_id.get(&record.first_stream_item_id) else {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Event dedupe record '{}' references missing first stream item {}",
+                record.event_id, record.first_stream_item_id
+            )));
+        };
+        if first.counterparty != record.counterparty {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Event dedupe record '{}' counterparty does not match first stream item",
+                record.event_id
+            )));
+        }
+        if payload_hash(&first.raw_json) != record.payload_hash {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Event dedupe record '{}' payload hash does not match first stream item",
+                record.event_id
+            )));
+        }
+        for stream_item_id in record
+            .duplicate_stream_item_ids
+            .iter()
+            .chain(record.conflicting_stream_item_ids.iter())
+        {
+            let Some(item) = stream_by_id.get(stream_item_id) else {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Event dedupe record '{}' references missing stream item {}",
+                    record.event_id, stream_item_id
+                )));
+            };
+            if item.counterparty != record.counterparty {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Event dedupe record '{}' counterparty does not match stream item {}",
+                    record.event_id, stream_item_id
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_receipt_access_records(
+    records: &HashMap<(PubkyPublicKey, String), ReceiptAccessRecord>,
+    stream_items: &[PrivateStreamItemRecord],
+) -> Result<()> {
+    let stream_by_id = stream_items
+        .iter()
+        .map(|item| (item.stream_item_id, item))
+        .collect::<HashMap<_, _>>();
+    for record in records.values() {
+        let Some(item) = stream_by_id.get(&record.stream_item_id) else {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt Access record '{}' references missing stream item {}",
+                record.event_id, record.stream_item_id
+            )));
+        };
+        if item.counterparty != record.counterparty
+            || item.receive_batch_id != record.receive_batch_id
+            || item.known_paykit_kind.as_deref() != Some(PrivateMessageKind::ReceiptAccess.as_str())
+        {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt Access record '{}' does not match its stream item",
+                record.event_id
+            )));
+        }
+        let event = paykit_lib::parse_receipt_access_event_message(&private_application_message(
+            item,
+            PrivateMessageKind::ReceiptAccess,
+        ))
+        .ok_or_else(|| {
+            PaykitSdkError::Protocol(format!(
+                "Receipt Access record '{}' stream item is not parseable",
+                record.event_id
+            ))
+        })?;
+        let Some(access) = event.parsed_access() else {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt Access record '{}' stream item is malformed",
+                record.event_id
+            )));
+        };
+        if access.event_id.as_str() != record.event_id
+            || access.receipt_id.as_str() != record.receipt_id
+            || access.payment_reference.as_str() != record.payment_reference
+            || access.location != record.location
+            || access.key.as_str() != record.key
+        {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt Access record '{}' does not match parsed stream payload",
+                record.event_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_receipt_records(
+    records: &HashMap<(PubkyPublicKey, String), ReceiptRecord>,
+    access_records: &HashMap<(PubkyPublicKey, String), ReceiptAccessRecord>,
+) -> Result<()> {
+    for record in records.values() {
+        ReceiptId::new(&record.receipt_id)?;
+        if let Some(identifier) = record.payment_endpoint_identifier.as_ref() {
+            PaymentEndpointIdentifier::new(identifier)?;
+        }
+        let access_key = (
+            record.issuer.clone(),
+            record.receipt_access_event_id.clone(),
+        );
+        let Some(access) = access_records.get(&access_key) else {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt record '{}' references missing Receipt Access event '{}'",
+                record.receipt_id, record.receipt_access_event_id
+            )));
+        };
+        if access.receipt_id != record.receipt_id
+            || access.payment_reference != record.payment_reference
+            || access.payment_request_id != record.payment_request_id
+            || access.billing_period != record.billing_period
+            || access.location != record.location
+        {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt record '{}' does not match its Receipt Access record",
+                record.receipt_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn private_message_header(
+    raw_json: &str,
+) -> Result<(Option<u32>, Option<String>, Option<PrivateMessageKind>)> {
+    let value = match serde_json::from_str::<serde_json::Value>(raw_json) {
+        Ok(value) => value,
+        Err(_) => return Ok((None, None, None)),
+    };
+    let parsed_version = value
+        .get("version")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|version| u8::try_from(version).ok())
+        .map(u32::from);
+    let parsed_kind = value
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned);
+    let known_kind = parsed_kind.as_deref().and_then(PrivateMessageKind::parse);
+    Ok((parsed_version, parsed_kind, known_kind))
+}
+
+fn validate_valid_private_stream_body(
+    record: &PrivateStreamItemRecord,
+    kind: PrivateMessageKind,
+) -> Result<()> {
+    match kind {
+        PrivateMessageKind::PrivatePaymentList => {
+            paykit_lib::parse_private_payment_list_json(&record.raw_json)?;
+        }
+        PrivateMessageKind::ReceiptAccess => {
+            let event = paykit_lib::parse_receipt_access_event_message(
+                &private_application_message(record, kind),
+            )
+            .ok_or_else(|| {
+                PaykitSdkError::Protocol(format!(
+                    "private stream item {} Receipt Access payload does not match its kind",
+                    record.stream_item_id
+                ))
+            })?;
+            if let Some(error) = event.validation_error() {
+                return Err(PaykitSdkError::Protocol(error.to_owned()));
+            }
+        }
+        PrivateMessageKind::PaymentRequest
+        | PrivateMessageKind::PaymentRequestAcceptance
+        | PrivateMessageKind::PaymentRequestRejection
+        | PrivateMessageKind::PaymentRequestCancellation
+        | PrivateMessageKind::PaymentProof => {
+            let event = paykit_lib::parse_payment_request_event_message(
+                &private_application_message(record, kind),
+            )
+            .ok_or_else(|| {
+                PaykitSdkError::Protocol(format!(
+                    "private stream item {} Payment Request payload does not match its kind",
+                    record.stream_item_id
+                ))
+            })?;
+            if let Some(error) = event.validation_error() {
+                return Err(PaykitSdkError::Protocol(error.to_owned()));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn private_application_message(
+    record: &PrivateStreamItemRecord,
+    kind: PrivateMessageKind,
+) -> PrivateApplicationMessage {
+    PrivateApplicationMessage {
+        version: record
+            .parsed_version
+            .and_then(|version| u8::try_from(version).ok()),
+        kind: Some(kind.as_str().to_owned()),
+        raw_json: record.raw_json.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+    use crate::{
+        identity::PubkyIdentityCapability, outbound_private::OutboundPrivateMessageStatus,
+        private_stream::PrivateStreamParseStatus, storage::InMemoryStorage,
+    };
+
+    fn timestamp() -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+    }
+
+    fn public_key() -> PubkyPublicKey {
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+    }
+
+    fn identity(public_key: PubkyPublicKey) -> IdentityState {
+        IdentityState {
+            public_key: Some(public_key),
+            capability: PubkyIdentityCapability::PrivateLinkCapable,
+            local_secret_available: true,
+            initialized_at: timestamp(),
+            sign_out_generation: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_export_backup_state_redacts_debug() {
+        let storage = InMemoryStorage::new();
+        let counterparty = public_key();
+        storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| {
+                    tx.save_identity_state(identity(counterparty.clone()));
+                    tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                        counterparty: counterparty.clone(),
+                        link_snapshot: Some(vec![1, 2, 3]),
+                        handshake_snapshot: None,
+                        handshake_role: None,
+                        generation: 0,
+                        checkpointed_at: timestamp(),
+                    });
+                    tx.insert_outbound_private_message(crate::storage::NewOutboundPrivateMessage::new(
+                        counterparty,
+                        "paykit.private_payment_list".into(),
+                        r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{"btc-lightning-bolt11":"ln-private-payload-marker"}}"#.into(),
+                        timestamp(),
+                    ));
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+
+        let backup = export_backup_state(&storage).await.unwrap();
+        let debug = format!("{backup:?}");
+
+        assert!(!debug.contains("ln-private-payload-marker"));
+        assert!(!debug.contains("[1, 2, 3]"));
+        assert_eq!(backup.outbound_private_messages.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_marks_restored_links_recovery_required() {
+        let storage = InMemoryStorage::new();
+        let counterparty = public_key();
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: Some(identity(counterparty.clone())),
+            linked_peers: vec![LinkedPeerRecord {
+                counterparty: counterparty.clone(),
+                state: LinkedPeerState::Linked,
+                last_sync_at: Some(timestamp()),
+                last_private_receive_at: None,
+                failure_count: 0,
+            }],
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: vec![EncryptedLinkStateRecord {
+                counterparty: counterparty.clone(),
+                link_snapshot: None,
+                handshake_snapshot: None,
+                handshake_role: None,
+                generation: 0,
+                checkpointed_at: timestamp(),
+            }],
+            outbound_private_messages: Vec::new(),
+            private_stream_items: Vec::new(),
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 0,
+            next_private_stream_item_id: 0,
+        };
+
+        let report = restore_backup_state(&storage, backup).await.unwrap();
+        let restored = storage.snapshot().unwrap();
+
+        assert_eq!(report.recovery_required_peers, vec![counterparty.clone()]);
+        assert_eq!(
+            restored.linked_peers.get(&counterparty).unwrap().state,
+            LinkedPeerState::RecoveryRequired
+        );
+        assert!(restored.peer_link_operation_leases.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_marks_link_state_without_peer_recovery_required() {
+        let storage = InMemoryStorage::new();
+        let counterparty = public_key();
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: Some(identity(counterparty.clone())),
+            linked_peers: Vec::new(),
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: vec![EncryptedLinkStateRecord {
+                counterparty: counterparty.clone(),
+                link_snapshot: None,
+                handshake_snapshot: None,
+                handshake_role: None,
+                generation: 0,
+                checkpointed_at: timestamp(),
+            }],
+            outbound_private_messages: Vec::new(),
+            private_stream_items: Vec::new(),
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 0,
+            next_private_stream_item_id: 0,
+        };
+
+        restore_backup_state(&storage, backup).await.unwrap();
+        let restored = storage.snapshot().unwrap();
+
+        assert_eq!(
+            restored.linked_peers.get(&counterparty).unwrap().state,
+            LinkedPeerState::RecoveryRequired
+        );
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_marks_private_stream_only_peer_recovery_required() {
+        let storage = InMemoryStorage::new();
+        let counterparty = public_key();
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: Some(identity(counterparty.clone())),
+            linked_peers: Vec::new(),
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: Vec::new(),
+            outbound_private_messages: Vec::new(),
+            private_stream_items: vec![PrivateStreamItemRecord {
+                stream_item_id: 1,
+                counterparty: counterparty.clone(),
+                receive_batch_id: 0,
+                raw_json:
+                    r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#
+                        .into(),
+                parsed_version: Some(1),
+                parsed_kind: Some("paykit.private_payment_list".into()),
+                known_paykit_kind: Some("paykit.private_payment_list".into()),
+                parse_status: PrivateStreamParseStatus::Valid,
+                parse_error: None,
+                received_at: timestamp(),
+            }],
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 1,
+            next_private_stream_item_id: 2,
+        };
+
+        restore_backup_state(&storage, backup).await.unwrap();
+        let restored = storage.snapshot().unwrap();
+
+        assert_eq!(
+            restored.linked_peers.get(&counterparty).unwrap().state,
+            LinkedPeerState::RecoveryRequired
+        );
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_rejects_malformed_link_snapshot() {
+        let storage = InMemoryStorage::new();
+        let counterparty = public_key();
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: Some(identity(counterparty.clone())),
+            linked_peers: Vec::new(),
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: vec![EncryptedLinkStateRecord {
+                counterparty,
+                link_snapshot: Some(vec![1, 2, 3]),
+                handshake_snapshot: None,
+                handshake_role: None,
+                generation: 0,
+                checkpointed_at: timestamp(),
+            }],
+            outbound_private_messages: Vec::new(),
+            private_stream_items: Vec::new(),
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 0,
+            next_private_stream_item_id: 0,
+        };
+
+        let result = restore_backup_state(&storage, backup).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_rejects_records_without_identity() {
+        let storage = InMemoryStorage::new();
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: None,
+            linked_peers: Vec::new(),
+            public_endpoint_records: vec![PublicEndpointRecord {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: Some("ln".into()),
+                status: crate::EndpointPublicationStatus::Published,
+                updated_at: timestamp(),
+                last_error: None,
+            }],
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: Vec::new(),
+            outbound_private_messages: Vec::new(),
+            private_stream_items: Vec::new(),
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 0,
+            next_private_stream_item_id: 0,
+        };
+
+        let result = restore_backup_state(&storage, backup).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_rejects_invalid_public_endpoint_record() {
+        let storage = InMemoryStorage::new();
+        let local_public_key = public_key();
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: Some(identity(local_public_key)),
+            linked_peers: Vec::new(),
+            public_endpoint_records: vec![PublicEndpointRecord {
+                identifier: "private".into(),
+                payload: Some("ln".into()),
+                status: crate::EndpointPublicationStatus::Published,
+                updated_at: timestamp(),
+                last_error: None,
+            }],
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: Vec::new(),
+            outbound_private_messages: Vec::new(),
+            private_stream_items: Vec::new(),
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 0,
+            next_private_stream_item_id: 0,
+        };
+
+        let result = restore_backup_state(&storage, backup).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_rejects_stale_private_stream_metadata() {
+        let storage = InMemoryStorage::new();
+        let counterparty = public_key();
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: Some(identity(counterparty.clone())),
+            linked_peers: Vec::new(),
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: Vec::new(),
+            outbound_private_messages: Vec::new(),
+            private_stream_items: vec![PrivateStreamItemRecord {
+                stream_item_id: 1,
+                counterparty,
+                receive_batch_id: 0,
+                raw_json:
+                    r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#
+                        .into(),
+                parsed_version: Some(1),
+                parsed_kind: Some("paykit.receipt_access".into()),
+                known_paykit_kind: Some("paykit.receipt_access".into()),
+                parse_status: PrivateStreamParseStatus::Valid,
+                parse_error: None,
+                received_at: timestamp(),
+            }],
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 1,
+            next_private_stream_item_id: 2,
+        };
+
+        let result = restore_backup_state(&storage, backup).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_rejects_wrong_identity() {
+        let storage = InMemoryStorage::new();
+        let current = public_key();
+        let backup_public_key = public_key();
+        storage
+            .save_identity_state(identity(current))
+            .await
+            .unwrap();
+
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: Some(identity(backup_public_key)),
+            linked_peers: Vec::new(),
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: Vec::new(),
+            outbound_private_messages: Vec::new(),
+            private_stream_items: Vec::new(),
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 0,
+            next_private_stream_item_id: 0,
+        };
+
+        let result = restore_backup_state(&storage, backup).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_advances_counters() {
+        let storage = InMemoryStorage::new();
+        let counterparty = public_key();
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: Some(identity(counterparty.clone())),
+            linked_peers: Vec::new(),
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: Vec::new(),
+            outbound_private_messages: vec![OutboundPrivateMessageRecord {
+                outbound_message_id: 7,
+                counterparty: counterparty.clone(),
+                kind: "paykit.private_payment_list".into(),
+                raw_json:
+                    r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#
+                        .into(),
+                status: OutboundPrivateMessageStatus::Pending,
+                attempt_count: 0,
+                created_at: timestamp(),
+                updated_at: timestamp(),
+                last_attempt_at: None,
+                sent_at: None,
+                last_error: None,
+            }],
+            private_stream_items: vec![PrivateStreamItemRecord {
+                stream_item_id: 9,
+                counterparty,
+                receive_batch_id: 3,
+                raw_json: "{}".into(),
+                parsed_version: None,
+                parsed_kind: None,
+                known_paykit_kind: None,
+                parse_status: PrivateStreamParseStatus::InvalidJson,
+                parse_error: Some("invalid".into()),
+                received_at: timestamp(),
+            }],
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 1,
+            next_receive_batch_id: 1,
+            next_private_stream_item_id: 1,
+        };
+
+        restore_backup_state(&storage, backup).await.unwrap();
+        let restored = storage.snapshot().unwrap();
+
+        assert_eq!(restored.next_outbound_private_message_id, 8);
+        assert_eq!(restored.next_receive_batch_id, 4);
+        assert_eq!(restored.next_private_stream_item_id, 10);
+    }
+}

--- a/paykit-sdk/src/endpoint_reservations.rs
+++ b/paykit-sdk/src/endpoint_reservations.rs
@@ -1,0 +1,388 @@
+//! Payment Endpoint Reservation records.
+
+use std::{collections::HashMap, fmt};
+
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    adapters::{PaymentEndpointReservation, PaymentEndpointReservationRequest, ReceivingDetail},
+    endpoints::normalize_receiving_details,
+    outbound_private::validate_outbound_private_message,
+    storage::{
+        NewOutboundPrivateMessage, OutboundPrivateMessageRecord, PaymentEndpointReservationRecord,
+        StorageAdapter,
+    },
+    PaykitSdkError, PubkyPublicKey, Result,
+};
+use paykit_lib::{serialize_private_payment_list_json, PrivatePaymentList};
+
+/// Load Payment Endpoint Reservation records for one counterparty.
+pub(crate) async fn payment_endpoint_reservations<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Vec<PaymentEndpointReservationRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.payment_endpoint_reservations(counterparty)))
+        .await
+}
+
+/// Queue a Private Payment List and persist linked reservation records atomically.
+pub(crate) async fn queue_private_payment_list_with_reservations<S>(
+    storage: &S,
+    request: &PaymentEndpointReservationRequest,
+    reservations: Vec<PaymentEndpointReservation>,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let (receiving_details, drafts) = build_reservation_records(request, reservations, now)?;
+    let payment_endpoints = normalize_receiving_details(receiving_details)?;
+    let list = PrivatePaymentList::new(payment_endpoints);
+    let raw_json = serialize_private_payment_list_json(&list)?;
+    let kind = validate_outbound_private_message(&raw_json)?;
+    let counterparty = request.counterparty.clone();
+
+    storage
+        .transaction(move |tx| {
+            let mut checked_drafts = Vec::with_capacity(drafts.len());
+            for draft in drafts {
+                let existing =
+                    tx.payment_endpoint_reservation(&draft.counterparty, &draft.reservation_id);
+                if let Some(existing) = existing.as_ref() {
+                    if !draft.matches_existing(existing) {
+                        return Err(PaykitSdkError::Protocol(format!(
+                            "Payment Endpoint Reservation id '{}' already exists with different details",
+                            draft.reservation_id
+                        )));
+                    }
+                }
+                checked_drafts.push((draft, existing));
+            }
+
+            let outbound = tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                counterparty,
+                kind,
+                raw_json,
+                now,
+            ));
+            for (draft, existing) in checked_drafts {
+                let record = draft.into_record(outbound.outbound_message_id, existing);
+                tx.save_payment_endpoint_reservation(record);
+            }
+            Ok(outbound)
+        })
+        .await
+}
+
+#[derive(Clone)]
+struct PaymentEndpointReservationRecordDraft {
+    reservation_id: String,
+    counterparty: PubkyPublicKey,
+    identifier: String,
+    payload_hash: String,
+    attribution: HashMap<String, String>,
+    expires_at: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
+}
+
+impl PaymentEndpointReservationRecordDraft {
+    fn matches_existing(&self, existing: &PaymentEndpointReservationRecord) -> bool {
+        existing.counterparty == self.counterparty
+            && existing.identifier == self.identifier
+            && existing.payload_hash == self.payload_hash
+    }
+
+    fn into_record(
+        self,
+        outbound_message_id: u64,
+        existing: Option<PaymentEndpointReservationRecord>,
+    ) -> PaymentEndpointReservationRecord {
+        let (attribution, expires_at, created_at) = existing
+            .map(|record| (record.attribution, record.expires_at, record.created_at))
+            .unwrap_or((self.attribution, self.expires_at, self.created_at));
+        PaymentEndpointReservationRecord {
+            reservation_id: self.reservation_id,
+            counterparty: self.counterparty,
+            identifier: self.identifier,
+            payload_hash: self.payload_hash,
+            outbound_message_id,
+            attribution,
+            expires_at,
+            created_at,
+        }
+    }
+}
+
+fn build_reservation_records(
+    request: &PaymentEndpointReservationRequest,
+    reservations: Vec<PaymentEndpointReservation>,
+    now: DateTime<Utc>,
+) -> Result<(
+    Vec<ReceivingDetail>,
+    Vec<PaymentEndpointReservationRecordDraft>,
+)> {
+    let mut reservation_ids = HashMap::new();
+    let mut records = Vec::with_capacity(reservations.len());
+    let mut receiving_details = Vec::with_capacity(reservations.len());
+
+    for reservation in reservations {
+        validate_reservation_id(&reservation.reservation_id)?;
+        if reservation_ids
+            .insert(reservation.reservation_id.clone(), ())
+            .is_some()
+        {
+            return Err(PaykitSdkError::Protocol(format!(
+                "duplicate Payment Endpoint Reservation id '{}'",
+                reservation.reservation_id
+            )));
+        }
+        receiving_details.push(reservation.receiving_detail.clone());
+        records.push(record_from_reservation(request, reservation, now));
+    }
+
+    normalize_receiving_details(receiving_details.clone())?;
+    Ok((receiving_details, records))
+}
+
+fn validate_reservation_id(reservation_id: &str) -> Result<()> {
+    if reservation_id.trim().is_empty() {
+        return Err(PaykitSdkError::Protocol(
+            "Payment Endpoint Reservation id must not be empty".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn record_from_reservation(
+    request: &PaymentEndpointReservationRequest,
+    reservation: PaymentEndpointReservation,
+    now: DateTime<Utc>,
+) -> PaymentEndpointReservationRecordDraft {
+    let payload_hash = reservation_payload_hash(&reservation.receiving_detail.payload);
+    PaymentEndpointReservationRecordDraft {
+        reservation_id: reservation.reservation_id,
+        counterparty: request.counterparty.clone(),
+        identifier: reservation.receiving_detail.identifier,
+        payload_hash,
+        attribution: reservation.attribution,
+        expires_at: reservation.expires_at,
+        created_at: now,
+    }
+}
+
+pub(crate) fn reservation_payload_hash(payload: &str) -> String {
+    let digest = Sha256::digest(payload.as_bytes());
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+impl fmt::Debug for PaymentEndpointReservationRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentEndpointReservationRecord")
+            .field("reservation_id", &self.reservation_id)
+            .field("counterparty", &self.counterparty)
+            .field("identifier", &self.identifier)
+            .field("payload_hash", &self.payload_hash)
+            .field("outbound_message_id", &self.outbound_message_id)
+            .field(
+                "attribution",
+                &format_args!("<redacted:{} fields>", self.attribution.len()),
+            )
+            .field("expires_at", &self.expires_at)
+            .field("created_at", &self.created_at)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+    use crate::storage::InMemoryStorage;
+    use paykit_lib::PaymentEndpointIdentifier;
+
+    fn timestamp() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+    }
+
+    fn counterparty() -> PubkyPublicKey {
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+    }
+
+    fn request(counterparty: PubkyPublicKey) -> PaymentEndpointReservationRequest {
+        PaymentEndpointReservationRequest { counterparty }
+    }
+
+    fn reservation(id: &str, payload: &str) -> PaymentEndpointReservation {
+        PaymentEndpointReservation {
+            reservation_id: id.into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: payload.into(),
+            },
+            expires_at: None,
+            attribution: HashMap::from([("contact".into(), "alice".into())]),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_queue_private_payment_list_with_reservations_stores_linked_records() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let outbound = queue_private_payment_list_with_reservations(
+            &storage,
+            &request(counterparty.clone()),
+            vec![reservation("res-1", "ln-secret")],
+            timestamp(),
+        )
+        .await
+        .unwrap();
+
+        let list = paykit_lib::parse_private_payment_list_json(&outbound.raw_json).unwrap();
+        let records = payment_endpoint_reservations(&storage, &counterparty)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            list.get(&PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap())
+                .unwrap()
+                .as_str(),
+            "ln-secret"
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].outbound_message_id, outbound.outbound_message_id);
+        assert_ne!(records[0].payload_hash, "ln-secret");
+        assert!(!format!("{:?}", records[0]).contains("ln-secret"));
+        assert!(!format!("{:?}", records[0]).contains("alice"));
+    }
+
+    #[tokio::test]
+    async fn test_queue_private_payment_list_with_reservations_rejects_duplicate_identifiers() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        let result = queue_private_payment_list_with_reservations(
+            &storage,
+            &request(counterparty),
+            vec![reservation("res-1", "one"), reservation("res-2", "two")],
+            timestamp(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+        assert!(storage
+            .snapshot()
+            .unwrap()
+            .payment_endpoint_reservations
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_queue_private_payment_list_with_reservations_reuses_existing_id() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        queue_private_payment_list_with_reservations(
+            &storage,
+            &request(counterparty.clone()),
+            vec![reservation("res-1", "one")],
+            timestamp(),
+        )
+        .await
+        .unwrap();
+
+        let outbound = queue_private_payment_list_with_reservations(
+            &storage,
+            &request(counterparty.clone()),
+            vec![PaymentEndpointReservation {
+                reservation_id: "res-1".into(),
+                receiving_detail: ReceivingDetail {
+                    identifier: "btc-lightning-bolt11".into(),
+                    payload: "one".into(),
+                },
+                expires_at: Some(timestamp()),
+                attribution: HashMap::from([("contact".into(), "bob".into())]),
+            }],
+            timestamp(),
+        )
+        .await
+        .unwrap();
+        let snapshot = storage.snapshot().unwrap();
+
+        assert_eq!(snapshot.payment_endpoint_reservations.len(), 1);
+        assert_eq!(
+            snapshot
+                .payment_endpoint_reservations
+                .get(&(counterparty.clone(), "res-1".into()))
+                .unwrap()
+                .outbound_message_id,
+            outbound.outbound_message_id
+        );
+        let record = snapshot
+            .payment_endpoint_reservations
+            .get(&(counterparty.clone(), "res-1".into()))
+            .unwrap();
+        assert_eq!(record.attribution.get("contact").unwrap(), "alice");
+        assert!(record.expires_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_queue_private_payment_list_with_reservations_rejects_conflicting_existing_id() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+        queue_private_payment_list_with_reservations(
+            &storage,
+            &request(counterparty.clone()),
+            vec![reservation("res-1", "one")],
+            timestamp(),
+        )
+        .await
+        .unwrap();
+
+        let result = queue_private_payment_list_with_reservations(
+            &storage,
+            &request(counterparty),
+            vec![reservation("res-1", "two")],
+            timestamp(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn test_queue_private_payment_list_with_reservations_scopes_ids_by_counterparty() {
+        let storage = InMemoryStorage::new();
+        let first = counterparty();
+        let second = counterparty();
+
+        queue_private_payment_list_with_reservations(
+            &storage,
+            &request(first),
+            vec![reservation("res-1", "one")],
+            timestamp(),
+        )
+        .await
+        .unwrap();
+        queue_private_payment_list_with_reservations(
+            &storage,
+            &request(second),
+            vec![reservation("res-1", "two")],
+            timestamp(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            storage
+                .snapshot()
+                .unwrap()
+                .payment_endpoint_reservations
+                .len(),
+            2
+        );
+    }
+}

--- a/paykit-sdk/src/lib.rs
+++ b/paykit-sdk/src/lib.rs
@@ -3,9 +3,12 @@
 
 /// Adapter traits and payment endpoint selection types.
 pub mod adapters;
+/// SDK backup and restore payloads.
+pub mod backup;
 /// SDK runtime policy configuration.
 pub mod config;
 pub mod contacts;
+pub mod endpoint_reservations;
 pub mod endpoints;
 /// SDK error type.
 pub mod error;
@@ -25,10 +28,13 @@ pub mod storage;
 #[doc(inline)]
 pub use adapters::{
     EndpointCompatibility, PaymentAdapter, PaymentAmountContext, PaymentEndpointCandidate,
-    PaymentEndpointEvaluation, PaymentEndpointSelection, PaymentEndpointSelectionRequest,
+    PaymentEndpointEvaluation, PaymentEndpointReservation, PaymentEndpointReservationRelease,
+    PaymentEndpointReservationRequest, PaymentEndpointSelection, PaymentEndpointSelectionRequest,
     PaymentEndpointSource, PaymentTarget, PubkySessionProvider, ReceivingDetail,
     ReceivingDetailScope,
 };
+#[doc(inline)]
+pub use backup::{export_backup_state, RestoreReport, SdkBackupState, SDK_BACKUP_VERSION};
 #[doc(inline)]
 pub use config::{
     EndpointManagementScope, PaykitSdkConfig, PrivateSharingPolicy, PublicFallbackPolicy,
@@ -55,25 +61,20 @@ pub use linked_peers::{
 };
 #[doc(inline)]
 pub use outbound_private::{
-    queued_outbound_private_messages, OutboundPrivateMessageStatus, OutboundPrivateSendFailure,
-    OutboundPrivateSendReport,
+    OutboundPrivateMessageStatus, OutboundPrivateSendFailure, OutboundPrivateSendReport,
 };
 #[doc(inline)]
 pub use payment_requests::{
-    payment_request_records, received_payment_request_records, PaymentProofRecord,
-    PaymentRequestAmountRecord, PaymentRequestBillingPeriodRecord, PaymentRequestLifecycleState,
-    PaymentRequestLocalRole, PaymentRequestRecord, PaymentRequestRecurrenceRecord,
-    PaymentRequestTermsRecord,
+    PaymentProofRecord, PaymentRequestAmountRecord, PaymentRequestBillingPeriodRecord,
+    PaymentRequestLifecycleState, PaymentRequestLocalRole, PaymentRequestRecord,
+    PaymentRequestRecurrenceRecord, PaymentRequestTermsRecord,
 };
 #[doc(inline)]
-pub use private_lists::{
-    current_private_payment_list, derive_private_payment_list_view, PrivatePaymentListView,
-};
+pub use private_lists::PrivatePaymentListView;
 #[doc(inline)]
 pub use private_stream::{EventIdConflict, PrivateStreamIntakeReport, PrivateStreamParseStatus};
 #[doc(inline)]
 pub use receipts::{
-    receipt_access_record_by_receipt_id, receipt_access_records, receipt_record,
     ReceiptAccessRecord, ReceiptAmountRecord, ReceiptBillingPeriodRecord, ReceiptRecord,
     ReceiptRetrievalStatus,
 };
@@ -82,8 +83,8 @@ pub use runtime::{Clock, InitializationReport, PaykitSdk, SystemClock};
 #[doc(inline)]
 pub use storage::{
     EncryptedLinkStateRecord, EventDedupRecord, InMemoryStorage, LinkedPeerRecord,
-    OutboundPrivateMessageRecord, PrivateStreamItemRecord, PublicEndpointRecord, StorageAdapter,
-    StorageState, StorageTransaction,
+    OutboundPrivateMessageRecord, PaymentEndpointReservationRecord, PrivateStreamItemRecord,
+    PublicEndpointRecord, StorageAdapter, StorageState, StorageTransaction,
 };
 
 /// Common result alias for Paykit SDK operations.

--- a/paykit-sdk/src/outbound_private.rs
+++ b/paykit-sdk/src/outbound_private.rs
@@ -72,7 +72,7 @@ where
 }
 
 /// Load private messages that should be attempted for one counterparty.
-pub async fn queued_outbound_private_messages<S>(
+pub(crate) async fn queued_outbound_private_messages<S>(
     storage: &S,
     counterparty: &PubkyPublicKey,
 ) -> Result<Vec<OutboundPrivateMessageRecord>>
@@ -165,7 +165,7 @@ pub(crate) fn validate_queued_outbound_private_message(
     Ok(())
 }
 
-fn validate_outbound_private_message(raw_json: &str) -> Result<String> {
+pub(crate) fn validate_outbound_private_message(raw_json: &str) -> Result<String> {
     if raw_json.len() > paykit_lib::pubky_noise::snow_crypto::PUBKY_NOISE_MSG_LEN {
         return Err(PaykitSdkError::Protocol(
             "Private Application Message exceeds pubky-noise message size".into(),

--- a/paykit-sdk/src/payment_requests.rs
+++ b/paykit-sdk/src/payment_requests.rs
@@ -315,7 +315,7 @@ impl PaymentRequestRecord {
 /// newest-first by the last applied stream item. Malformed recognized Payment
 /// Request events without a valid `payment_request_id` remain available in the
 /// raw private stream log but cannot be attached to a request-scoped record.
-pub async fn received_payment_request_records<S>(
+pub(crate) async fn received_payment_request_records<S>(
     storage: &S,
     counterparty: &PubkyPublicKey,
     now: DateTime<Utc>,
@@ -352,7 +352,7 @@ where
 /// Records merge received Payment Request events from the private stream with
 /// local outbound Payment Request events from the outbound private-message log.
 /// Returned records are newest-first by local record time.
-pub async fn payment_request_records<S>(
+pub(crate) async fn payment_request_records<S>(
     storage: &S,
     counterparty: &PubkyPublicKey,
     now: DateTime<Utc>,

--- a/paykit-sdk/src/private_lists.rs
+++ b/paykit-sdk/src/private_lists.rs
@@ -41,7 +41,7 @@ impl fmt::Debug for PrivatePaymentListView {
 }
 
 /// Load the current Private Payment List view for one counterparty.
-pub async fn current_private_payment_list<S>(
+pub(crate) async fn current_private_payment_list<S>(
     storage: &S,
     counterparty: &PubkyPublicKey,
 ) -> Result<Option<PrivatePaymentListView>>
@@ -74,7 +74,7 @@ where
 }
 
 /// Derive the latest valid Private Payment List view from private stream items.
-pub fn derive_private_payment_list_view(
+pub(crate) fn derive_private_payment_list_view(
     mut items: Vec<PrivateStreamItemRecord>,
 ) -> Result<Option<PrivatePaymentListView>> {
     items.sort_by_key(|item| item.stream_item_id);

--- a/paykit-sdk/src/private_stream.rs
+++ b/paykit-sdk/src/private_stream.rs
@@ -434,7 +434,7 @@ mod tests {
         .await
         .unwrap();
 
-        let records = crate::receipt_access_records(&storage, &counterparty)
+        let records = crate::receipts::receipt_access_records(&storage, &counterparty)
             .await
             .unwrap();
         assert_eq!(records.len(), 1);
@@ -450,11 +450,14 @@ mod tests {
         assert!(debug.contains("<redacted>"));
         assert!(!debug.contains(&records[0].key));
 
-        let indexed =
-            crate::receipt_access_record_by_receipt_id(&storage, &counterparty, receipt_id)
-                .await
-                .unwrap()
-                .unwrap();
+        let indexed = crate::receipts::receipt_access_record_by_receipt_id(
+            &storage,
+            &counterparty,
+            receipt_id,
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert_eq!(indexed.event_id, event_id);
     }
 
@@ -485,7 +488,7 @@ mod tests {
         .await
         .unwrap();
 
-        let records = crate::receipt_access_records(&storage, &counterparty)
+        let records = crate::receipts::receipt_access_records(&storage, &counterparty)
             .await
             .unwrap();
         assert_eq!(records.len(), 1);
@@ -528,7 +531,7 @@ mod tests {
             snapshot.private_stream_items[0].parse_status,
             PrivateStreamParseStatus::MalformedRecognized
         );
-        let records = crate::receipt_access_records(&storage, &counterparty)
+        let records = crate::receipts::receipt_access_records(&storage, &counterparty)
             .await
             .unwrap();
         assert!(records.is_empty());

--- a/paykit-sdk/src/receipts.rs
+++ b/paykit-sdk/src/receipts.rs
@@ -12,7 +12,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use sha2::{Digest, Sha256};
 
-use crate::{storage::StorageAdapter, PaykitSdkError, PubkyPublicKey, Result};
+use crate::{PaykitSdkError, PubkyPublicKey, Result};
+
+#[cfg(test)]
+use crate::storage::StorageAdapter;
 
 /// Durable Billing Period fields copied from a Receipt Access event.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -269,7 +272,8 @@ impl fmt::Debug for ReceiptRecord {
 }
 
 /// List indexed Receipt Access records for one counterparty.
-pub async fn receipt_access_records<S>(
+#[cfg(test)]
+pub(crate) async fn receipt_access_records<S>(
     storage: &S,
     counterparty: &PubkyPublicKey,
 ) -> Result<Vec<ReceiptAccessRecord>>
@@ -282,7 +286,8 @@ where
 }
 
 /// Load the latest indexed Receipt Access record for a receipt.
-pub async fn receipt_access_record_by_receipt_id<S>(
+#[cfg(test)]
+pub(crate) async fn receipt_access_record_by_receipt_id<S>(
     storage: &S,
     counterparty: &PubkyPublicKey,
     receipt_id: &str,
@@ -292,20 +297,6 @@ where
 {
     storage
         .transaction(|tx| Ok(tx.receipt_access_record_by_receipt_id(counterparty, receipt_id)))
-        .await
-}
-
-/// Load a decrypted Receipt record.
-pub async fn receipt_record<S>(
-    storage: &S,
-    issuer: &PubkyPublicKey,
-    receipt_id: &str,
-) -> Result<Option<ReceiptRecord>>
-where
-    S: StorageAdapter,
-{
-    storage
-        .transaction(|tx| Ok(tx.receipt_record(issuer, receipt_id)))
         .await
 }
 

--- a/paykit-sdk/src/runtime.rs
+++ b/paykit-sdk/src/runtime.rs
@@ -10,11 +10,19 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::{
+    backup::{
+        export_backup_state as export_sdk_backup_state,
+        restore_backup_state as restore_sdk_backup_state, RestoreReport, SdkBackupState,
+    },
     config::{
         EndpointManagementScope, PaykitSdkConfig, PrivateSharingPolicy, PublicFallbackPolicy,
     },
     contacts::{
         ContactPaymentResolution, ContactPaymentResolutionRequest, ContactPaymentResolutionStatus,
+    },
+    endpoint_reservations::{
+        payment_endpoint_reservations, queue_private_payment_list_with_reservations,
+        reservation_payload_hash,
     },
     endpoints::{
         desired_record, failed_record, normalize_receiving_details, pending_removal_record,
@@ -60,9 +68,10 @@ use crate::{
         StorageAdapter,
     },
     PaykitSdkError, PaymentAdapter, PaymentEndpointCandidate, PaymentEndpointEvaluation,
-    PaymentEndpointSelection, PaymentEndpointSelectionRequest, PaymentEndpointSource,
-    PrivatePaymentListView, PubkyPublicKey, PubkySessionAccess, PubkySessionProvider,
-    ReceivingDetailScope, Result,
+    PaymentEndpointReservation, PaymentEndpointReservationRelease,
+    PaymentEndpointReservationRequest, PaymentEndpointSelection, PaymentEndpointSelectionRequest,
+    PaymentEndpointSource, PrivatePaymentListView, PubkyPublicKey, PubkySessionAccess,
+    PubkySessionProvider, ReceivingDetail, ReceivingDetailScope, Result,
 };
 
 /// Clock abstraction used by SDK workflows and tests.
@@ -221,6 +230,44 @@ where
         &self.pubky
     }
 
+    /// Export SDK-managed backup state.
+    pub async fn export_backup_state(&self) -> Result<SdkBackupState> {
+        export_sdk_backup_state(&self.storage).await
+    }
+
+    /// Restore SDK-managed backup state.
+    pub async fn restore_backup_state(&self, backup: SdkBackupState) -> Result<RestoreReport> {
+        if backup.identity_public_key().is_some() || backup.has_identity_scoped_state() {
+            let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+            let local_public_key =
+                identity
+                    .public_key
+                    .as_ref()
+                    .ok_or_else(|| PaykitSdkError::Identity {
+                        context:
+                            "cannot restore identity-scoped backup without an active Pubky identity"
+                                .into(),
+                        source: None,
+                    })?;
+            if backup.identity_public_key() != Some(local_public_key) {
+                return Err(PaykitSdkError::Identity {
+                    context: "backup identity does not match active Pubky identity".into(),
+                    source: None,
+                });
+            }
+            if backup.has_private_identity_scoped_state()
+                && identity.capability != PubkyIdentityCapability::PrivateLinkCapable
+            {
+                return Err(PaykitSdkError::Identity {
+                    context: "cannot restore private Paykit state without private-link capability"
+                        .into(),
+                    source: None,
+                });
+            }
+        }
+        restore_sdk_backup_state(&self.storage, backup).await
+    }
+
     /// Return the latest valid Private Payment List view for a counterparty.
     pub async fn current_private_payment_list(
         &self,
@@ -230,6 +277,8 @@ where
         if identity.capability != PubkyIdentityCapability::PrivateLinkCapable {
             return Ok(None);
         }
+        self.ensure_peer_allows_private_automation(counterparty)
+            .await?;
         load_current_private_payment_list(&self.storage, counterparty).await
     }
 
@@ -251,6 +300,8 @@ where
                 context: "no local Pubky identity available for receipt retrieval".into(),
                 source: None,
             })?;
+        self.ensure_peer_allows_private_automation(&counterparty)
+            .await?;
         let (stored_receipt, access_records) = self
             .storage
             .transaction(|tx| {
@@ -440,6 +491,8 @@ where
         if identity.capability != PubkyIdentityCapability::PrivateLinkCapable {
             return Ok(Vec::new());
         }
+        self.ensure_peer_allows_private_automation(counterparty)
+            .await?;
         derive_received_payment_request_records(&self.storage, counterparty, self.clock.now()).await
     }
 
@@ -455,6 +508,8 @@ where
         if identity.capability != PubkyIdentityCapability::PrivateLinkCapable {
             return Ok(Vec::new());
         }
+        self.ensure_peer_allows_private_automation(counterparty)
+            .await?;
         derive_payment_request_records(&self.storage, counterparty, self.clock.now()).await
     }
 
@@ -474,6 +529,9 @@ where
                 source: None,
             });
         }
+
+        self.ensure_peer_allows_private_automation(counterparty)
+            .await?;
 
         let has_active_link = self
             .storage
@@ -781,19 +839,118 @@ where
         )
         .await?;
 
-        let receiving_details = self
-            .payment
+        self.enqueue_private_payment_list_from_receiving_details(counterparty)
+            .await
+    }
+
+    async fn enqueue_private_payment_list_from_receiving_details(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        let request = PaymentEndpointReservationRequest {
+            counterparty: counterparty.clone(),
+        };
+        if let Some(reservations) = self.payment.reserve_receiving_details(&request).await? {
+            let releases = reservations
+                .iter()
+                .map(|reservation| reservation_release(&counterparty, reservation))
+                .collect::<Vec<_>>();
+            let now = self.clock.now();
+            let result = queue_private_payment_list_with_reservations(
+                &self.storage,
+                &request,
+                reservations,
+                now,
+            )
+            .await;
+            match result {
+                Ok(record) => Ok(record),
+                Err(err) => {
+                    if let Err(release_err) = self
+                        .release_reservations_after_queue_error(&releases, &counterparty)
+                        .await
+                    {
+                        return Err(PaykitSdkError::Policy(format!(
+                            "failed to queue reserved receiving details: {err}; reservation cleanup also failed: {release_err}"
+                        )));
+                    }
+                    Err(err)
+                }
+            }
+        } else {
+            let receiving_details = self.private_receiving_details(&counterparty).await?;
+            enqueue_private_payment_list_message(
+                &self.storage,
+                counterparty,
+                receiving_details,
+                self.clock.now(),
+            )
+            .await
+        }
+    }
+
+    async fn release_reservations_after_queue_error(
+        &self,
+        releases: &[PaymentEndpointReservationRelease],
+        counterparty: &PubkyPublicKey,
+    ) -> Result<()> {
+        let existing = payment_endpoint_reservations(&self.storage, counterparty).await?;
+        let mut release_errors = Vec::new();
+        for release in releases {
+            if existing.iter().any(|record| {
+                record.reservation_id == release.reservation_id
+                    && record.counterparty == release.counterparty
+                    && record.identifier == release.identifier
+                    && record.payload_hash == release.payload_hash
+            }) {
+                continue;
+            }
+            if let Err(err) = self
+                .payment
+                .release_receiving_detail_reservation(release)
+                .await
+            {
+                release_errors.push(format!("{}: {err}", release.reservation_id));
+            }
+        }
+        if release_errors.is_empty() {
+            Ok(())
+        } else {
+            Err(PaykitSdkError::Policy(format!(
+                "failed to release reserved receiving details: {}",
+                release_errors.join("; ")
+            )))
+        }
+    }
+
+    async fn private_receiving_details(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Vec<ReceivingDetail>> {
+        self.payment
             .current_receiving_details(ReceivingDetailScope::Private {
                 counterparty: counterparty.clone(),
             })
+            .await
+    }
+
+    async fn ensure_peer_allows_private_automation(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<()> {
+        let peer_state = self
+            .storage
+            .transaction(|tx| Ok(tx.linked_peer(counterparty).map(|peer| peer.state)))
             .await?;
-        enqueue_private_payment_list_message(
-            &self.storage,
-            counterparty,
-            receiving_details,
-            self.clock.now(),
-        )
-        .await
+        match peer_state {
+            Some(LinkedPeerState::RecoveryRequired) => Err(PaykitSdkError::RecoveryRequired(
+                format!("Encrypted Link recovery is required for counterparty {counterparty}"),
+            )),
+            Some(LinkedPeerState::Blocked) => Err(PaykitSdkError::Policy(format!(
+                "counterparty {counterparty} is blocked"
+            ))),
+            _ => Ok(()),
+        }
     }
 
     /// Start an Encrypted Link Handshake as the initiator.
@@ -832,7 +989,8 @@ where
         counterparty: PubkyPublicKey,
         lease: PeerLinkOperationLease,
     ) -> Result<LinkedPeerHandshakeReport> {
-        self.ensure_peer_not_blocked(&counterparty).await?;
+        self.ensure_peer_allows_private_automation(&counterparty)
+            .await?;
         let Some(stored_link_state) = self
             .storage
             .transaction(|tx| Ok(tx.encrypted_link_state(&counterparty)))
@@ -910,7 +1068,17 @@ where
     ) -> Result<ContactPaymentResolution> {
         let (_, identity) = self.load_session_access_and_refresh_identity().await?;
         let mut evaluations = Vec::new();
-        let private_view = if identity.capability == PubkyIdentityCapability::PrivateLinkCapable {
+        let private_allowed = match self
+            .ensure_peer_allows_private_automation(&request.counterparty)
+            .await
+        {
+            Ok(()) => true,
+            Err(PaykitSdkError::RecoveryRequired(_)) => false,
+            Err(err) => return Err(err),
+        };
+        let private_view = if private_allowed
+            && identity.capability == PubkyIdentityCapability::PrivateLinkCapable
+        {
             load_current_private_payment_list(&self.storage, &request.counterparty).await?
         } else {
             None
@@ -1364,6 +1532,8 @@ where
             context: "no Pubky session available".into(),
             source: None,
         })?;
+        self.ensure_peer_allows_private_automation(&counterparty)
+            .await?;
         let lease = self.claim_peer_link_operation(&counterparty).await?;
         let result = self
             .receive_private_messages_with_claim(counterparty, lease.clone(), session_access)
@@ -1469,6 +1639,8 @@ where
                 "private Paykit message sending is disabled".into(),
             ));
         }
+        self.ensure_peer_allows_private_automation(&counterparty)
+            .await?;
         let (session_access, _) = self.load_session_access_and_refresh_identity().await?;
         let queued = queued_outbound_private_messages(&self.storage, &counterparty).await?;
         if queued.is_empty() {
@@ -1701,7 +1873,8 @@ where
         role: EncryptedLinkHandshakeRole,
         lease: PeerLinkOperationLease,
     ) -> Result<LinkedPeerHandshakeReport> {
-        self.ensure_peer_not_blocked(&counterparty).await?;
+        self.ensure_peer_allows_private_automation(&counterparty)
+            .await?;
         if let Some(existing) = self
             .storage
             .transaction(|tx| Ok(tx.encrypted_link_state(&counterparty)))
@@ -1821,22 +1994,6 @@ where
             (Err(err), _) => Err(err),
             (Ok(_), Err(err)) => Err(err),
         }
-    }
-
-    async fn ensure_peer_not_blocked(&self, counterparty: &PubkyPublicKey) -> Result<()> {
-        let peer = self
-            .storage
-            .transaction(|tx| Ok(tx.linked_peer(counterparty)))
-            .await?;
-        if peer
-            .as_ref()
-            .is_some_and(|peer| peer.state == LinkedPeerState::Blocked)
-        {
-            return Err(PaykitSdkError::Policy(format!(
-                "Linked Peer {counterparty} is blocked"
-            )));
-        }
-        Ok(())
     }
 
     async fn advance_link_handshake_from_snapshot(
@@ -2025,17 +2182,35 @@ fn require_state(
     }
 }
 
+fn reservation_release(
+    counterparty: &PubkyPublicKey,
+    reservation: &PaymentEndpointReservation,
+) -> PaymentEndpointReservationRelease {
+    PaymentEndpointReservationRelease {
+        reservation_id: reservation.reservation_id.clone(),
+        counterparty: counterparty.clone(),
+        identifier: reservation.receiving_detail.identifier.clone(),
+        payload_hash: reservation_payload_hash(&reservation.receiving_detail.payload),
+        attribution: reservation.attribution.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
     use chrono::{TimeZone, Utc};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
 
     use super::*;
     use crate::{
         adapters::{
             EndpointCompatibility, PaymentEndpointCandidate, PaymentEndpointEvaluation,
-            PaymentEndpointSelection, PaymentEndpointSelectionRequest, PaymentTarget,
-            ReceivingDetail, ReceivingDetailScope,
+            PaymentEndpointReservation, PaymentEndpointReservationRelease,
+            PaymentEndpointReservationRequest, PaymentEndpointSelection,
+            PaymentEndpointSelectionRequest, PaymentTarget, ReceivingDetail, ReceivingDetailScope,
         },
         private_stream::persist_private_stream_batch,
         storage::{EncryptedLinkStateRecord, InMemoryStorage},
@@ -2120,6 +2295,193 @@ mod tests {
                 identifier: "btc-lightning-bolt11".into(),
                 payload: "ln-private".into(),
             }])
+        }
+
+        async fn select_payment_endpoint(
+            &self,
+            _request: &PaymentEndpointSelectionRequest,
+        ) -> Result<PaymentEndpointSelection> {
+            Ok(PaymentEndpointSelection {
+                selected: None,
+                evaluations: Vec::new(),
+            })
+        }
+
+        async fn build_payment_target(
+            &self,
+            endpoint: &PaymentEndpointCandidate,
+        ) -> Result<PaymentTarget> {
+            Ok(PaymentTarget {
+                payload: endpoint.payload.clone(),
+            })
+        }
+    }
+
+    struct ReservedPrivateListPaymentAdapter;
+
+    #[async_trait]
+    impl PaymentAdapter for ReservedPrivateListPaymentAdapter {
+        async fn current_receiving_details(
+            &self,
+            _scope: ReceivingDetailScope,
+        ) -> Result<Vec<ReceivingDetail>> {
+            panic!("reservation-capable adapter should not use fallback details");
+        }
+
+        async fn reserve_receiving_details(
+            &self,
+            request: &PaymentEndpointReservationRequest,
+        ) -> Result<Option<Vec<PaymentEndpointReservation>>> {
+            assert!(!request.counterparty.as_str().is_empty());
+            Ok(Some(vec![PaymentEndpointReservation {
+                reservation_id: "reservation-1".into(),
+                receiving_detail: ReceivingDetail {
+                    identifier: "btc-lightning-bolt11".into(),
+                    payload: "ln-reserved".into(),
+                },
+                expires_at: None,
+                attribution: HashMap::from([("contact".into(), "alice".into())]),
+            }]))
+        }
+
+        async fn select_payment_endpoint(
+            &self,
+            request: &PaymentEndpointSelectionRequest,
+        ) -> Result<PaymentEndpointSelection> {
+            Ok(PaymentEndpointSelection {
+                selected: request.candidates.first().cloned(),
+                evaluations: Vec::new(),
+            })
+        }
+
+        async fn build_payment_target(
+            &self,
+            endpoint: &PaymentEndpointCandidate,
+        ) -> Result<PaymentTarget> {
+            Ok(PaymentTarget {
+                payload: endpoint.payload.clone(),
+            })
+        }
+    }
+
+    struct InvalidReservedPrivateListPaymentAdapter {
+        released: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl PaymentAdapter for InvalidReservedPrivateListPaymentAdapter {
+        async fn current_receiving_details(
+            &self,
+            _scope: ReceivingDetailScope,
+        ) -> Result<Vec<ReceivingDetail>> {
+            panic!("reservation-capable adapter should not use fallback details");
+        }
+
+        async fn reserve_receiving_details(
+            &self,
+            _request: &PaymentEndpointReservationRequest,
+        ) -> Result<Option<Vec<PaymentEndpointReservation>>> {
+            Ok(Some(vec![
+                PaymentEndpointReservation {
+                    reservation_id: "reservation-1".into(),
+                    receiving_detail: ReceivingDetail {
+                        identifier: "btc-lightning-bolt11".into(),
+                        payload: "one".into(),
+                    },
+                    expires_at: None,
+                    attribution: HashMap::new(),
+                },
+                PaymentEndpointReservation {
+                    reservation_id: "reservation-2".into(),
+                    receiving_detail: ReceivingDetail {
+                        identifier: "btc-lightning-bolt11".into(),
+                        payload: "two".into(),
+                    },
+                    expires_at: None,
+                    attribution: HashMap::new(),
+                },
+            ]))
+        }
+
+        async fn release_receiving_detail_reservation(
+            &self,
+            release: &PaymentEndpointReservationRelease,
+        ) -> Result<()> {
+            self.released
+                .lock()
+                .unwrap()
+                .push(release.reservation_id.clone());
+            Ok(())
+        }
+
+        async fn select_payment_endpoint(
+            &self,
+            _request: &PaymentEndpointSelectionRequest,
+        ) -> Result<PaymentEndpointSelection> {
+            Ok(PaymentEndpointSelection {
+                selected: None,
+                evaluations: Vec::new(),
+            })
+        }
+
+        async fn build_payment_target(
+            &self,
+            endpoint: &PaymentEndpointCandidate,
+        ) -> Result<PaymentTarget> {
+            Ok(PaymentTarget {
+                payload: endpoint.payload.clone(),
+            })
+        }
+    }
+
+    struct MixedExistingReservedPrivateListPaymentAdapter {
+        released: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl PaymentAdapter for MixedExistingReservedPrivateListPaymentAdapter {
+        async fn current_receiving_details(
+            &self,
+            _scope: ReceivingDetailScope,
+        ) -> Result<Vec<ReceivingDetail>> {
+            panic!("reservation-capable adapter should not use fallback details");
+        }
+
+        async fn reserve_receiving_details(
+            &self,
+            _request: &PaymentEndpointReservationRequest,
+        ) -> Result<Option<Vec<PaymentEndpointReservation>>> {
+            Ok(Some(vec![
+                PaymentEndpointReservation {
+                    reservation_id: "existing-reservation".into(),
+                    receiving_detail: ReceivingDetail {
+                        identifier: "btc-lightning-bolt11".into(),
+                        payload: "existing".into(),
+                    },
+                    expires_at: None,
+                    attribution: HashMap::new(),
+                },
+                PaymentEndpointReservation {
+                    reservation_id: "conflicting-reservation".into(),
+                    receiving_detail: ReceivingDetail {
+                        identifier: "btc-lightning-bolt11".into(),
+                        payload: "conflict".into(),
+                    },
+                    expires_at: None,
+                    attribution: HashMap::new(),
+                },
+            ]))
+        }
+
+        async fn release_receiving_detail_reservation(
+            &self,
+            release: &PaymentEndpointReservationRelease,
+        ) -> Result<()> {
+            self.released
+                .lock()
+                .unwrap()
+                .push(release.reservation_id.clone());
+            Ok(())
         }
 
         async fn select_payment_endpoint(
@@ -2357,6 +2719,157 @@ mod tests {
         let result = sdk.enqueue_private_payment_list(counterparty).await;
 
         assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_private_payment_list_uses_fallback_details() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            PrivateListPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let outbound = sdk
+            .enqueue_private_payment_list_from_receiving_details(counterparty)
+            .await
+            .unwrap();
+
+        let list = paykit_lib::parse_private_payment_list_json(&outbound.raw_json).unwrap();
+        assert_eq!(
+            list.get(&PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap())
+                .unwrap()
+                .as_str(),
+            "ln-private"
+        );
+        assert!(storage
+            .snapshot()
+            .unwrap()
+            .payment_endpoint_reservations
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_private_payment_list_uses_reserved_details() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            ReservedPrivateListPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let outbound = sdk
+            .enqueue_private_payment_list_from_receiving_details(counterparty.clone())
+            .await
+            .unwrap();
+
+        let list = paykit_lib::parse_private_payment_list_json(&outbound.raw_json).unwrap();
+        assert_eq!(
+            list.get(&PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap())
+                .unwrap()
+                .as_str(),
+            "ln-reserved"
+        );
+        let reservations = storage
+            .snapshot()
+            .unwrap()
+            .payment_endpoint_reservations
+            .into_values()
+            .collect::<Vec<_>>();
+        assert_eq!(reservations.len(), 1);
+        assert_eq!(
+            reservations[0].outbound_message_id,
+            outbound.outbound_message_id
+        );
+        assert_ne!(reservations[0].payload_hash, "ln-reserved");
+        assert!(!format!("{:?}", reservations[0]).contains("ln-reserved"));
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_private_payment_list_releases_invalid_reservations() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let released = Arc::new(Mutex::new(Vec::new()));
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            InvalidReservedPrivateListPaymentAdapter {
+                released: released.clone(),
+            },
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let result = sdk
+            .enqueue_private_payment_list_from_receiving_details(counterparty)
+            .await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+        assert_eq!(
+            *released.lock().unwrap(),
+            vec!["reservation-1".to_string(), "reservation-2".to_string()]
+        );
+        let snapshot = storage.snapshot().unwrap();
+        assert!(snapshot.payment_endpoint_reservations.is_empty());
+        assert!(snapshot.outbound_private_messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_private_payment_list_keeps_existing_reservation_on_error() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        queue_private_payment_list_with_reservations(
+            &storage,
+            &PaymentEndpointReservationRequest {
+                counterparty: counterparty.clone(),
+            },
+            vec![PaymentEndpointReservation {
+                reservation_id: "existing-reservation".into(),
+                receiving_detail: ReceivingDetail {
+                    identifier: "btc-lightning-bolt11".into(),
+                    payload: "existing".into(),
+                },
+                expires_at: None,
+                attribution: HashMap::new(),
+            }],
+            FixedClock.now(),
+        )
+        .await
+        .unwrap();
+        let released = Arc::new(Mutex::new(Vec::new()));
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            MixedExistingReservedPrivateListPaymentAdapter {
+                released: released.clone(),
+            },
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let result = sdk
+            .enqueue_private_payment_list_from_receiving_details(counterparty)
+            .await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+        assert_eq!(
+            *released.lock().unwrap(),
+            vec!["conflicting-reservation".to_string()]
+        );
+        assert_eq!(
+            storage
+                .snapshot()
+                .unwrap()
+                .payment_endpoint_reservations
+                .len(),
+            1
+        );
     }
 
     #[tokio::test]
@@ -2831,10 +3344,91 @@ mod tests {
         assert!(report.attempted.is_empty());
         assert!(report.sent.is_empty());
         assert!(report.failed.is_empty());
-        let queued = crate::queued_outbound_private_messages(&storage, &counterparty)
-            .await
-            .unwrap();
+        let queued =
+            crate::outbound_private::queued_outbound_private_messages(&storage, &counterparty)
+                .await
+                .unwrap();
         assert!(queued.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_process_outbound_private_messages_blocks_recovery_required_peer() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        crate::linked_peers::save_linked_peer_state(
+            &storage,
+            counterparty.clone(),
+            LinkedPeerState::RecoveryRequired,
+            FixedClock.now(),
+        )
+        .await
+        .unwrap();
+        crate::outbound_private::enqueue_private_message(
+            &storage,
+            counterparty.clone(),
+            private_list_json(),
+            FixedClock.now(),
+        )
+        .await
+        .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let result = sdk
+            .process_outbound_private_messages(counterparty.clone())
+            .await;
+
+        assert!(matches!(result, Err(PaykitSdkError::RecoveryRequired(_))));
+        let queued =
+            crate::outbound_private::queued_outbound_private_messages(&storage, &counterparty)
+                .await
+                .unwrap();
+        assert_eq!(queued.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_requires_active_identity() {
+        let storage = InMemoryStorage::new();
+        let backup_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let backup = SdkBackupState {
+            version: crate::SDK_BACKUP_VERSION,
+            identity_state: Some(IdentityState {
+                public_key: Some(backup_public_key),
+                capability: PubkyIdentityCapability::PrivateLinkCapable,
+                local_secret_available: true,
+                initialized_at: FixedClock.now(),
+                sign_out_generation: 0,
+            }),
+            linked_peers: Vec::new(),
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: Vec::new(),
+            outbound_private_messages: Vec::new(),
+            private_stream_items: Vec::new(),
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 0,
+            next_private_stream_item_id: 0,
+        };
+        let sdk = PaykitSdk::with_clock(
+            storage,
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let result = sdk.restore_backup_state(backup).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
     }
 
     #[tokio::test]

--- a/paykit-sdk/src/storage.rs
+++ b/paykit-sdk/src/storage.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    backup::ValidatedStorageState,
     endpoints::EndpointPublicationStatus,
     identity::{IdentityState, PubkyPublicKey},
     linked_peers::LinkedPeerState,
@@ -44,6 +45,12 @@ pub trait StorageAdapter: Send + Sync {
 
 /// Mutable operations available inside one storage transaction.
 pub trait StorageTransaction {
+    /// Export the full logical SDK storage state.
+    fn export_storage_state(&self) -> StorageState;
+
+    /// Replace the full logical SDK storage state after backup validation.
+    fn replace_storage_state(&mut self, state: ValidatedStorageState);
+
     /// Load the current identity state.
     fn load_identity_state(&self) -> Option<IdentityState>;
 
@@ -67,6 +74,22 @@ pub trait StorageTransaction {
 
     /// Save one SDK-managed public Payment Endpoint record.
     fn save_public_endpoint_record(&mut self, record: PublicEndpointRecord);
+
+    /// List Payment Endpoint Reservation records for one counterparty.
+    fn payment_endpoint_reservations(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Vec<PaymentEndpointReservationRecord>;
+
+    /// Load one Payment Endpoint Reservation record.
+    fn payment_endpoint_reservation(
+        &self,
+        counterparty: &PubkyPublicKey,
+        reservation_id: &str,
+    ) -> Option<PaymentEndpointReservationRecord>;
+
+    /// Save one Payment Endpoint Reservation record.
+    fn save_payment_endpoint_reservation(&mut self, record: PaymentEndpointReservationRecord);
 
     /// Load one Encrypted Link state record.
     fn encrypted_link_state(
@@ -190,6 +213,27 @@ pub struct PublicEndpointRecord {
     pub updated_at: DateTime<Utc>,
     /// Last sync error, when available.
     pub last_error: Option<String>,
+}
+
+/// Durable SDK-managed Payment Endpoint Reservation record.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentEndpointReservationRecord {
+    /// Adapter-stable reservation id.
+    pub reservation_id: String,
+    /// Counterparty the reserved endpoint is intended for.
+    pub counterparty: PubkyPublicKey,
+    /// Payment Endpoint Identifier.
+    pub identifier: String,
+    /// Hash of the reserved endpoint payload.
+    pub payload_hash: String,
+    /// Latest outbound message id that queued this reservation for sharing.
+    pub outbound_message_id: u64,
+    /// Adapter-provided attribution metadata.
+    pub attribution: HashMap<String, String>,
+    /// Optional reservation expiry.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Creation time.
+    pub created_at: DateTime<Utc>,
 }
 
 /// Durable Encrypted Link snapshot state.
@@ -581,7 +625,7 @@ pub struct EventDedupRecord {
     pub conflicting_stream_item_ids: Vec<u64>,
 }
 
-/// In-memory storage state used for tests and examples.
+/// Logical SDK storage state used by snapshots, tests, and backup/restore.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct StorageState {
     /// Current identity state.
@@ -590,6 +634,9 @@ pub struct StorageState {
     pub linked_peers: HashMap<PubkyPublicKey, LinkedPeerRecord>,
     /// SDK-managed public endpoint records by identifier.
     pub public_endpoint_records: HashMap<String, PublicEndpointRecord>,
+    /// SDK-managed Payment Endpoint Reservation records by counterparty and reservation id.
+    pub payment_endpoint_reservations:
+        HashMap<(PubkyPublicKey, String), PaymentEndpointReservationRecord>,
     /// Encrypted Link state records by counterparty.
     pub encrypted_link_states: HashMap<PubkyPublicKey, EncryptedLinkStateRecord>,
     /// Active peer link operation leases by counterparty.
@@ -667,6 +714,14 @@ struct InMemoryStorageTransaction {
 }
 
 impl StorageTransaction for InMemoryStorageTransaction {
+    fn export_storage_state(&self) -> StorageState {
+        self.state.clone()
+    }
+
+    fn replace_storage_state(&mut self, state: ValidatedStorageState) {
+        self.state = state.into_storage_state();
+    }
+
     fn load_identity_state(&self) -> Option<IdentityState> {
         self.state.identity_state.clone()
     }
@@ -684,6 +739,7 @@ impl StorageTransaction for InMemoryStorageTransaction {
         self.state.linked_peers.clear();
         self.state.encrypted_link_states.clear();
         self.state.peer_link_operation_leases.clear();
+        self.state.payment_endpoint_reservations.clear();
         self.state.outbound_private_messages.clear();
         self.state.private_stream_items.clear();
         self.state.event_dedup_records.clear();
@@ -713,6 +769,39 @@ impl StorageTransaction for InMemoryStorageTransaction {
         self.state
             .public_endpoint_records
             .insert(record.identifier.clone(), record);
+    }
+
+    fn payment_endpoint_reservations(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Vec<PaymentEndpointReservationRecord> {
+        let mut records = self
+            .state
+            .payment_endpoint_reservations
+            .values()
+            .filter(|record| &record.counterparty == counterparty)
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by_key(|record| record.created_at);
+        records
+    }
+
+    fn payment_endpoint_reservation(
+        &self,
+        counterparty: &PubkyPublicKey,
+        reservation_id: &str,
+    ) -> Option<PaymentEndpointReservationRecord> {
+        self.state
+            .payment_endpoint_reservations
+            .get(&(counterparty.clone(), reservation_id.to_owned()))
+            .cloned()
+    }
+
+    fn save_payment_endpoint_reservation(&mut self, record: PaymentEndpointReservationRecord) {
+        self.state.payment_endpoint_reservations.insert(
+            (record.counterparty.clone(), record.reservation_id.clone()),
+            record,
+        );
     }
 
     fn encrypted_link_state(
@@ -979,12 +1068,9 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use super::*;
-    use crate::{
-        outbound_private::{
-            claim_next_outbound_private_message, mark_outbound_failed, mark_outbound_invalid,
-            mark_outbound_sent,
-        },
-        queued_outbound_private_messages,
+    use crate::outbound_private::{
+        claim_next_outbound_private_message, mark_outbound_failed, mark_outbound_invalid,
+        mark_outbound_sent, queued_outbound_private_messages,
     };
 
     fn timestamp() -> DateTime<Utc> {
@@ -1054,6 +1140,21 @@ mod tests {
         }
     }
 
+    fn payment_endpoint_reservation_record(
+        counterparty: PubkyPublicKey,
+    ) -> PaymentEndpointReservationRecord {
+        PaymentEndpointReservationRecord {
+            reservation_id: "reservation-1".into(),
+            counterparty,
+            identifier: "btc-lightning-bolt11".into(),
+            payload_hash: "reserved-payload-hash".into(),
+            outbound_message_id: 7,
+            attribution: HashMap::from([("contact".into(), "alice".into())]),
+            expires_at: None,
+            created_at: timestamp(),
+        }
+    }
+
     #[test]
     fn test_sensitive_storage_debug_is_redacted() {
         let counterparty = counterparty();
@@ -1085,12 +1186,15 @@ mod tests {
         );
         let receipt_access = receipt_access_record(stream.counterparty.clone());
         let receipt = receipt_record(receipt_access.counterparty.clone());
+        let reservation = payment_endpoint_reservation_record(receipt_access.counterparty.clone());
 
-        let debug =
-            format!("{link_state:?} {outbound:?} {stream:?} {receipt_access:?} {receipt:?}");
+        let debug = format!(
+            "{link_state:?} {outbound:?} {stream:?} {receipt_access:?} {receipt:?} {reservation:?}"
+        );
         assert!(debug.contains("<redacted:"));
         assert!(!debug.contains("secret"));
         assert!(!debug.contains("receipt-secret"));
+        assert!(!debug.contains("alice"));
         assert!(!debug.contains("[1, 2, 3]"));
     }
 
@@ -1111,6 +1215,9 @@ mod tests {
                         failure_count: 0,
                     });
                     tx.save_public_endpoint_record(public_endpoint_record("btc-lightning-bolt11"));
+                    tx.save_payment_endpoint_reservation(payment_endpoint_reservation_record(
+                        counterparty.clone(),
+                    ));
                     tx.insert_outbound_private_message(outbound_private_message(
                         counterparty.clone(),
                     ));
@@ -1155,6 +1262,7 @@ mod tests {
             LinkedPeerState::Linked
         );
         assert_eq!(snapshot.public_endpoint_records.len(), 1);
+        assert_eq!(snapshot.payment_endpoint_reservations.len(), 1);
         assert_eq!(snapshot.outbound_private_messages.len(), 1);
         assert_eq!(snapshot.private_stream_items.len(), 1);
         assert_eq!(snapshot.event_dedup_records.len(), 1);
@@ -1341,6 +1449,9 @@ mod tests {
                         failure_count: 0,
                     });
                     tx.save_public_endpoint_record(public_endpoint_record("btc-lightning-bolt11"));
+                    tx.save_payment_endpoint_reservation(payment_endpoint_reservation_record(
+                        counterparty.clone(),
+                    ));
                     tx.insert_outbound_private_message(outbound_private_message(
                         counterparty.clone(),
                     ));
@@ -1370,6 +1481,7 @@ mod tests {
         assert_eq!(snapshot.identity_state, Some(identity));
         assert!(snapshot.linked_peers.is_empty());
         assert!(snapshot.public_endpoint_records.is_empty());
+        assert!(snapshot.payment_endpoint_reservations.is_empty());
         assert!(snapshot.encrypted_link_states.is_empty());
         assert!(snapshot.outbound_private_messages.is_empty());
         assert!(snapshot.private_stream_items.is_empty());
@@ -1404,6 +1516,9 @@ mod tests {
                         failure_count: 0,
                     });
                     tx.save_public_endpoint_record(public_endpoint_record("btc-lightning-bolt11"));
+                    tx.save_payment_endpoint_reservation(payment_endpoint_reservation_record(
+                        counterparty.clone(),
+                    ));
                     tx.claim_peer_link_operation(
                         &counterparty,
                         timestamp(),
@@ -1438,6 +1553,7 @@ mod tests {
         let snapshot = storage.snapshot().unwrap();
         assert_eq!(snapshot.identity_state, Some(identity));
         assert_eq!(snapshot.public_endpoint_records.len(), 1);
+        assert!(snapshot.payment_endpoint_reservations.is_empty());
         assert!(snapshot.linked_peers.is_empty());
         assert!(snapshot.encrypted_link_states.is_empty());
         assert!(snapshot.outbound_private_messages.is_empty());

--- a/specs/paykit-sdk.md
+++ b/specs/paykit-sdk.md
@@ -82,6 +82,8 @@ paykit-sdk/
     linked_peers.rs
     private_stream.rs
     private_lists.rs
+    endpoint_reservations.rs
+    backup.rs
 ```
 
 Suggested module responsibilities:
@@ -107,16 +109,16 @@ Suggested module responsibilities:
   parsing, dedupe, and current derived view rebuilds.
 - `private_lists`: local and remote Private Payment List publication, caching,
   latest-state derivation, and size policy.
+- `endpoint_reservations`: optional receiving-detail reservation records for
+  Private Payment List sharing.
 - `receipts`: Receipt Access event indexing, Encrypted Receipt retrieval,
   decryption, and retrieval state.
+- `backup`: versioned export/import of SDK-managed state.
 
 Future modules should be added only when they have concrete implementation:
 
 - `payment_requests`: Payment Request event state machine, outbound event
   queueing, proof correlation, and scheduling hooks.
-- `reservations`: optional contact-scoped or single-use receiving-detail
-  reservation records.
-- `backup`: versioned export/import of SDK-managed state.
 - `scheduler`: optional recurring Payment Request scheduling integration.
 - `telemetry`: structured logs and redaction helpers.
 
@@ -185,16 +187,11 @@ The current Rust SDK foundation supports records for:
 - linked peer state
 - Encrypted Link snapshots and handshake snapshots
 - endpoint publication records
+- endpoint reservation records
 - outbound Private Application Message records and retry state
 - raw Private Application Message stream items
 - Event Message dedupe indexes
-
-Future SDK storage should add records for:
-
-- parsed event records and derived current views
-- endpoint reservations
 - receipt records
-- backup metadata
 - recovery/fail-closed markers
 
 The SDK should ship an in-memory storage implementation for tests and examples.
@@ -297,6 +294,16 @@ pub trait PaymentAdapter {
         scope: ReceivingDetailScope,
     ) -> Result<Vec<ReceivingDetail>>;
 
+    async fn reserve_receiving_details(
+        &self,
+        request: &PaymentEndpointReservationRequest,
+    ) -> Result<Option<Vec<PaymentEndpointReservation>>>;
+
+    async fn release_receiving_detail_reservation(
+        &self,
+        release: &PaymentEndpointReservationRelease,
+    ) -> Result<()>;
+
     async fn select_payment_endpoint(
         &self,
         request: &PaymentEndpointSelectionRequest,
@@ -324,12 +331,32 @@ Payment execution and settlement detection stay with the integrating
 application or payment provider. Future SDK APIs may accept execution results
 from those systems.
 
-### Future Endpoint Reservations
+### Payment Endpoint Reservations
 
-Some payment methods need contact-scoped or single-use receiving details. The
-current SDK keeps this out of the public adapter surface. A future reservation
-module can add durable records and adapter hooks once the first product
-integration proves the exact shape.
+Some payment methods need contact-scoped receiving details. The current SDK lets
+payment adapters reserve receiving details for Private Payment List sharing. The
+SDK queues the Private Payment List and stores linked reservation records in one
+storage transaction. Reservation records keep lifecycle metadata and a payload
+hash; they do not store the raw reserved endpoint payload.
+
+When an adapter returns reservations, those reservations are the complete
+Private Payment List to share for that counterparty. Adapters that need mixed
+reserved and ordinary entries should include both as returned reservations.
+
+The payment adapter creates reservations before the SDK can persist linked
+records. Adapters should make reserved details idempotent, expiring, or safe to
+abandon if the process stops before durable queueing. The SDK releases returned
+reservations on SDK-side validation or queueing failure.
+
+Reservation IDs are counterparty-scoped idempotency keys for SDK reservation
+records, not for Private Payment List delivery. Requeueing the same reservation
+details may queue another latest-state Private Payment List and update the
+record to the latest outbound message id. Idempotent repeats preserve the
+original reservation attribution, expiry, and creation time; adapters that want
+new metadata should use a new reservation id.
+
+Single-use Payment Request reservations are not part of the current SDK shape.
+They need more request-specific context before they should be exposed.
 
 ### Future Scheduling
 
@@ -356,7 +383,6 @@ Tracks local Pubky identity state:
 
 - local public key
 - capability state
-- session backup metadata
 - whether local secret key is available
 - last successful initialization time
 - sign-out generation
@@ -452,11 +478,10 @@ Tracks optional contact-scoped receiving details:
 - reservation id
 - counterparty public key
 - Payment Endpoint Identifier
-- adapter-provided receiving detail id
 - payload hash
-- state: active, used, rotated, retired
+- latest outbound message id used to queue the reservation for sharing
 - attribution metadata
-- backup generation
+- reservation expiry, when provided by the payment adapter
 
 ### PaymentRequestRecord
 
@@ -578,8 +603,12 @@ Recommended locks:
 - storage-backed peer link operation lease: serializes Encrypted Link restore,
   handshake, send, receive, and snapshot updates per counterparty.
 - outbound queue claim/lock: serializes retry workers per counterparty.
-- reservation lock: serializes contact-scoped receiving-detail reservation and
-  rotation per counterparty/Payment Endpoint Identifier.
+- reservation transaction: stores reservation records and the outbound message
+  that shares them atomically. Existing reservation IDs with the same
+  counterparty, Payment Endpoint Identifier, and payload hash are idempotent;
+  conflicting existing details and duplicate IDs in the same batch are rejected.
+  The idempotency applies to reservation records, while Private Payment List
+  delivery remains latest-state and may queue another outbound message.
 
 These are local SDK/runtime locks, not protocol messages. They can be in-memory
 with durable recovery markers where needed. If a platform can run multiple
@@ -642,14 +671,16 @@ configured to manage the whole Paykit public namespace.
 
 1. Ensure the identity is private-link-capable.
 2. Ensure the counterparty has an active Encrypted Link snapshot.
-3. Ask `PaymentAdapter` for private receiving details scoped to the counterparty.
-4. Apply reservation policy if enabled.
-5. Build a complete Private Payment List.
-6. Enforce the pubky-noise message size limit.
-7. Persist outbound record and exact payload.
-8. Let the outbound Private Application Message worker send through Encrypted
+3. Ask `PaymentAdapter` for Private Payment List reservations.
+4. If reservations are returned, build the complete Private Payment List and
+   persist the outbound record plus linked reservation records atomically.
+5. If reservations are not returned, ask `PaymentAdapter` for private receiving
+   details scoped to the counterparty and queue the list normally.
+6. Release adapter reservations when SDK-side validation or queueing fails
+   before durable queueing.
+7. Let the outbound Private Application Message worker send through Encrypted
    Link.
-9. Persist send result and updated link snapshot.
+8. Persist send result and updated link snapshot.
 
 Private Payment Lists publish endpoints only. Payment References come from
 Payment Requests, Payment Proofs, and Receipts.
@@ -760,7 +791,7 @@ settlement confirmation.
 
 Backup should include SDK-managed state:
 
-- identity backup metadata, when safe
+- public identity/capability state
 - peer records
 - Encrypted Link snapshots
 - handshake snapshots
@@ -780,10 +811,10 @@ Backup should not include:
 
 Restore flow:
 
-1. Load backup into storage under a restore transaction.
-2. Validate local identity compatibility.
-3. Validate every link snapshot recipient.
-4. Mark peers requiring resync.
+1. Validate local identity compatibility before replacing storage state.
+2. Validate backup record shape and every link snapshot recipient.
+3. Load backup into storage under a restore transaction.
+4. Mark peers requiring resync before committing restored private state.
 5. Do not execute automatic payments until private stream and request state are
    consistent.
 
@@ -791,10 +822,11 @@ Restore flow:
 
 The current Rust SDK exposes initialization, identity status, public endpoint
 sync, linked peer handshakes, private stream receive, Private Payment List
-derivation/publication, contact payment resolution, and outbound Private
-Application Message processing, Receipt Access indexing/retrieval, and Payment
-Request lifecycle derivation plus checked outbound lifecycle queueing. Use
-`paykit-sdk` rustdoc for the exact current signatures.
+derivation/publication, contact payment resolution, outbound Private
+Application Message processing, Receipt Access indexing/retrieval, Payment
+Request lifecycle derivation plus checked outbound lifecycle queueing, optional
+Payment Endpoint Reservation records, and backup/export/restore for
+SDK-managed state. Use `paykit-sdk` rustdoc for the exact current signatures.
 
 Future SDK versions should extend the current surface with operations like:
 
@@ -818,13 +850,7 @@ impl PaykitSdk {
         filter: ReceiptAccessFilter,
     ) -> Result<Vec<ReceiptAccessRecord>>;
 
-    async fn retrieve_receipt(
-        &mut self,
-        receipt_id: ReceiptId,
-    ) -> Result<ReceiptRecord>;
-
-    async fn export_backup_state(&self) -> Result<SdkBackupState>;
-    async fn restore_backup_state(&mut self, backup: SdkBackupState) -> Result<RestoreReport>;
+    async fn retrieve_receipt(&self, receipt_id: ReceiptId) -> Result<ReceiptRecord>;
 }
 ```
 
@@ -930,14 +956,13 @@ sync, Encrypted Link runtime records, private stream intake, Private Payment
 List latest-state derivation, contact payment resolution, outbound Private
 Application Message delivery, Receipt Access indexing, receipt retrieval,
 Payment Request lifecycle derivation, and checked outbound Payment Request
-lifecycle queueing.
+lifecycle queueing, optional Payment Endpoint Reservation storage for reserved
+private receiving details, and backup/export/restore for SDK-managed state.
 
 Next work:
 
-1. Add optional endpoint reservation support.
-2. Add backup/export/restore for SDK-managed state.
-3. Add SDK FFI and platform wrappers.
-4. Migrate one existing app integration behind the SDK and use that to refine
+1. Add SDK FFI and platform wrappers.
+2. Migrate one existing app integration behind the SDK and use that to refine
    adapters.
 
 Each step should include unit tests for storage invariants and at least one
@@ -978,7 +1003,8 @@ Platform tests:
    under `/pub/paykit/`?
 3. Should the current default public fallback and private recovery timeouts
    differ for saved contacts versus one-off counterparties?
-4. How much endpoint reservation should be generalized in the first SDK version?
+4. Which reservation lifecycle hooks should be standardized beyond private-list
+   queueing?
 5. How much recurring Payment Request scheduling should the SDK own versus
    delegating to app/runtime schedulers?
 6. What unknown Private Application Message retention defaults are appropriate


### PR DESCRIPTION
## Summary

Stack PR 4/6 for the Paykit SDK split.

Adds endpoint reservations and SDK backup/restore: contact-scoped receiving detail reservations, reservation cleanup state, SDK backup export, restore validation, and cross-record consistency checks.

## Review Notes

- Base: `codex/sdk-stack-requests-receipts`
- Head: `codex/sdk-stack-backup-reservations`
- This builds on the Payment Request and Receipt PR.
- The final stack branch was verified to have the same tree as #55's head.

## Verification

The final stacked branch matches #55's final tree exactly.
