### PR TITLE
Add SDK profiles and recovery markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,16 +201,17 @@ before executing a payment through their existing infrastructure.
 
 `paykit-sdk` is the Rust runtime layer for SDK-managed local
 state such as endpoint sync, Encrypted Link snapshots, private stream intake,
-Private Payment Lists, and contact payment resolution. Payment execution,
-settlement detection, product UI, and platform session storage remain with the
-integrating application and its adapters.
+Private Payment Lists, Paykit Profiles, local Contact Records, and contact
+payment resolution. Payment execution, settlement detection, product UI, and
+platform session storage remain with the integrating application and its
+adapters.
 
 ## Library Crates
 
 - [`paykit-lib`](paykit-lib/) is the canonical Rust Paykit Library. It consumes
   concrete Pubky SDK handles and keeps no global application state.
 - [`paykit-sdk`](paykit-sdk/) is the Rust SDK runtime for stateful Paykit
-  workflows. SDK platform bindings are planned separately.
+  workflows.
 - [`paykit-ffi`](paykit-ffi/) exposes UniFFI bindings for Swift and Kotlin.
 - [`paykit-react-native`](paykit-react-native/) wraps the generated bindings for
   React Native.

--- a/THESAURUS.md
+++ b/THESAURUS.md
@@ -25,7 +25,7 @@
 - **Related terms**: Paykit Protocol, Paykit SDK, Language Bindings
 
 ### Paykit SDK
-- **Definition**: The stateful integration layer above Paykit Library for durable Encrypted Link state, private stream routing, event logs, recovery behavior, Payment Request lifecycle state, receipt indexing, and ergonomic wallet/payment-processor workflows. Current implementation starts as a Rust SDK runtime foundation.
+- **Definition**: The stateful integration layer above Paykit Library for durable Encrypted Link state, private stream routing, event logs, recovery behavior, Payment Request lifecycle state, receipt indexing, and ergonomic wallet/payment-processor workflows.
 - **NOT**: Paykit Library, Paykit Protocol, or payment execution/settlement logic.
 - **Synonyms to AVOID**: Paykit core, Paykit runtime core, Pubky SDK
 - **Related terms**: Paykit, Paykit Library, Language Bindings
@@ -35,6 +35,26 @@
 - **NOT**: First-class Paykit architecture components.
 - **Synonyms to AVOID**: Paykit SDK
 - **Related terms**: Paykit Library
+
+## SDK Terms
+
+### Paykit Profile
+- **Definition**: Public Paykit-facing display metadata published by a Pubky identity, such as display name and image pointer, under the SDK default profile path.
+- **NOT**: A product-specific profile page, app account record, or Payment Endpoint.
+- **Synonyms to AVOID**: Payment Profile when referring to SDK display metadata
+- **Related terms**: Paykit SDK, Pubky Routing, Contact Record
+
+### Contact Record
+- **Definition**: A local SDK record for a saved Pubky public key, optional local label, cached Paykit Profile, and contact-related SDK state.
+- **NOT**: A public social graph requirement or a Payment List.
+- **Synonyms to AVOID**: contact payment option
+- **Related terms**: Paykit SDK, Paykit Profile, Public Contact Marker
+
+### Public Contact Marker
+- **Definition**: An optional public Pubky marker published by explicit SDK policy to indicate a saved contact in the shared Paykit namespace.
+- **NOT**: The default Contact Record storage model or proof of an active Encrypted Link.
+- **Synonyms to AVOID**: public contact record when referring to the marker only
+- **Related terms**: Contact Record, Paykit Profile, Paykit SDK
 
 ## Core Protocol Terms
 
@@ -58,7 +78,7 @@
 
 ### Payment Endpoint Identifier
 - **Definition**: The canonical machine-readable identifier for a payment endpoint type, such as `btc-lightning-bolt12` or `eur-sepa-iban`.
-- **NOT**: The full Payment Endpoint or the payload/credential itself.
+- **NOT**: The full Payment Endpoint, the payload/credential itself, or reserved Paykit storage path segments such as `private` or `encrypted-link-recovery`.
 - **Synonyms to AVOID**: method id, payment method id
 - **Related terms**: Payment Endpoint, Payment Method, Asset, Rail, Endpoint Format
 
@@ -129,6 +149,12 @@
 - **NOT**: A Payment Request ID, Payment Reference, relationship identifier, or a hash of the Event Message payload.
 - **Synonyms to AVOID**: event reference, message reference when naming the protocol identifier
 - **Related terms**: Event Message, Payment Request, Payment Request ID
+
+### Encrypted Link Recovery Marker
+- **Definition**: A minimal public Pubky marker that one peer publishes to signal that a counterparty should relink an Encrypted Link. Marker paths are pairwise-derived; marker payloads carry only version, kind, recovery attempt ID, and creation time.
+- **NOT**: A Private Application Message, payment message, recovery transcript, or proof that the counterparty received the marker.
+- **Synonyms to AVOID**: private recovery marker, recovery message when naming the public marker concept
+- **Related terms**: Encrypted Link, Linked Peer, Paykit SDK
 
 ### Private Payment List
 - **Definition**: A versioned encrypted Paykit message carrying a complete Payment List shared with a Linked Peer. Latest-State Message semantics apply; a newer Private Payment List supersedes older queued Private Payment List messages.

--- a/paykit-ffi/README.md
+++ b/paykit-ffi/README.md
@@ -3,8 +3,8 @@
 UniFFI bindings for [paykit-lib](../paykit-lib/), exposing Paykit's payment routing functionality to iOS (Swift) and Android (Kotlin).
 
 These bindings expose the low-level, stateless Paykit Library API. The
-stateful `paykit-sdk` runtime is a separate Rust crate and does not have
-platform bindings yet.
+stateful `paykit-sdk` runtime is a separate Rust crate with a separate
+integration surface.
 
 ## Exported API
 
@@ -227,7 +227,7 @@ paykitSignIn(secretKeyHex)
 paykit-ffi/
 ├── Cargo.toml              # Crate config (lib name = "paykit")
 ├── src/
-│   ├── lib.rs              # UniFFI scaffolding, types, exported functions
+│   ├── lib.rs              # UniFFI exports, types, and functions
 │   └── bin/
 │       └── uniffi-bindgen.rs
 ├── uniffi.toml             # Swift binding config

--- a/paykit-lib/README.md
+++ b/paykit-lib/README.md
@@ -57,7 +57,7 @@ assert_eq!(identifier.as_str(), "btc-lightning-bolt11");
 assert!(PaymentEndpointIdentifier::new("../etc/passwd").is_err());
 ```
 
-**Allowed values:** 1-64 ASCII characters from the set `[a-zA-Z0-9_-.]`. The value must not consist solely of dots (`.` and `..` are rejected as path traversal components), and must not be the reserved identifier `private` (used by private Paykit storage). Slashes, null bytes, spaces, and other special characters are rejected.
+**Allowed values:** 1-64 ASCII characters from the set `[a-zA-Z0-9_-.]`. The value must not consist solely of dots (`.` and `..` are rejected as path traversal components), and must not be a reserved storage identifier such as `private` or `encrypted-link-recovery`. Slashes, null bytes, spaces, and other special characters are rejected.
 
 `PaymentEndpointIdentifier::new()` returns `Err(PaykitError::Validation(...))` for invalid input.
 
@@ -455,6 +455,13 @@ Snapshots produced by `pubky-noise` `0.1.0-rc3` used the older 189-byte format a
   In-process restore. Reuses an existing `Arc<PubkyNoiseConfig>` (obtainable via `EncryptedLink::config()`) when the link needs rebuilding without an app restart.
 
 After link restore, `max_send_retries` resets to `DEFAULT_MAX_SEND_RETRIES`. Call `EncryptedLink::set_max_send_retries` after restore if you need a non-default value.
+
+**Recovery markers:**
+
+`EncryptedLinkRecoveryMarker` is a minimal public Pubky marker for relink
+coordination when an Encrypted Link can no longer be trusted. `paykit-lib`
+provides stateless marker parsing, serialization, path derivation, and
+publish/fetch/remove helpers. SDKs decide when to publish or act on markers.
 
 **When to snapshot:**
 

--- a/paykit-lib/src/encrypted_link_recovery.rs
+++ b/paykit-lib/src/encrypted_link_recovery.rs
@@ -1,0 +1,255 @@
+//! Stateless Encrypted Link recovery marker helpers.
+
+use pubky::{
+    errors::RequestError, Error as PubkyError, PubkySession, PublicKey, PublicStorage, StatusCode,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    validation::{invalid_data, invalid_wire, parse_utc_timestamp, validate_uuid_v4},
+    PaykitError, Result, PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX,
+};
+
+const RECOVERY_MARKER_KIND: &str = "paykit.encrypted_link_recovery";
+const RECOVERY_MARKER_PATH_DOMAIN: &[u8] = b"paykit-link-recovery-v0";
+
+/// Minimal public marker that asks a counterparty to relink an Encrypted Link.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EncryptedLinkRecoveryMarker {
+    attempt_id: String,
+    created_at: String,
+}
+
+impl EncryptedLinkRecoveryMarker {
+    /// Create a marker from a UUID-v4 attempt id and RFC3339 UTC timestamp.
+    pub fn new(attempt_id: impl Into<String>, created_at: impl Into<String>) -> Result<Self> {
+        let attempt_id = validate_uuid_v4(attempt_id.into(), "Encrypted Link recovery attempt ID")?;
+        let created_at = created_at.into();
+        parse_utc_timestamp(&created_at, "Encrypted Link recovery marker created_at")?;
+        Ok(Self {
+            attempt_id,
+            created_at,
+        })
+    }
+
+    /// Generate a marker with a fresh UUID-v4 attempt id.
+    pub fn new_v4(created_at: impl Into<String>) -> Result<Self> {
+        Self::new(uuid::Uuid::new_v4().to_string(), created_at)
+    }
+
+    /// Stable recovery attempt id.
+    pub fn attempt_id(&self) -> &str {
+        &self.attempt_id
+    }
+
+    /// Marker creation time as an RFC3339 UTC timestamp.
+    pub fn created_at(&self) -> &str {
+        &self.created_at
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RecoveryMarkerWire {
+    version: u8,
+    kind: String,
+    attempt_id: String,
+    created_at: String,
+}
+
+impl From<&EncryptedLinkRecoveryMarker> for RecoveryMarkerWire {
+    fn from(marker: &EncryptedLinkRecoveryMarker) -> Self {
+        Self {
+            version: 1,
+            kind: RECOVERY_MARKER_KIND.into(),
+            attempt_id: marker.attempt_id.clone(),
+            created_at: marker.created_at.clone(),
+        }
+    }
+}
+
+impl TryFrom<RecoveryMarkerWire> for EncryptedLinkRecoveryMarker {
+    type Error = PaykitError;
+
+    fn try_from(wire: RecoveryMarkerWire) -> Result<Self> {
+        if wire.version != 1 || wire.kind != RECOVERY_MARKER_KIND {
+            return Err(invalid_data(
+                format!(
+                    "unsupported Encrypted Link recovery marker version/kind: {}/{}",
+                    wire.version, wire.kind
+                ),
+                None,
+            ));
+        }
+        Self::new(wire.attempt_id, wire.created_at)
+            .map_err(|err| invalid_wire(err, "Encrypted Link recovery marker"))
+    }
+}
+
+/// Serialize an Encrypted Link Recovery Marker to canonical JSON.
+pub fn serialize_encrypted_link_recovery_marker(
+    marker: &EncryptedLinkRecoveryMarker,
+) -> Result<String> {
+    serde_json::to_string(&RecoveryMarkerWire::from(marker)).map_err(|err| {
+        PaykitError::Validation(format!(
+            "failed to serialize Encrypted Link recovery marker: {err}"
+        ))
+    })
+}
+
+/// Parse an Encrypted Link Recovery Marker JSON payload.
+pub fn parse_encrypted_link_recovery_marker_json(
+    raw_json: &str,
+) -> Result<EncryptedLinkRecoveryMarker> {
+    let wire = serde_json::from_str::<RecoveryMarkerWire>(raw_json).map_err(|err| {
+        invalid_data(
+            format!("Encrypted Link recovery marker JSON is invalid: {err}"),
+            Some(err.into()),
+        )
+    })?;
+    wire.try_into()
+}
+
+/// Compute local write and remote read paths for recovery markers.
+pub fn encrypted_link_recovery_marker_paths(
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+) -> (String, String) {
+    pubky_noise::path_derivation::derive_asymmetric_paths(
+        local_secret_key,
+        remote_pubkey,
+        RECOVERY_MARKER_PATH_DOMAIN,
+        PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX,
+    )
+}
+
+/// Publish a local recovery marker and return the path written.
+pub async fn publish_encrypted_link_recovery_marker(
+    session: &PubkySession,
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+    marker: &EncryptedLinkRecoveryMarker,
+) -> Result<String> {
+    let (write_path, _) = encrypted_link_recovery_marker_paths(local_secret_key, remote_pubkey);
+    let payload = serialize_encrypted_link_recovery_marker(marker)?;
+    session
+        .storage()
+        .put(write_path.clone(), payload)
+        .await
+        .map_err(|err| PaykitError::Transport {
+            context: "publish Encrypted Link recovery marker".into(),
+            source: err.into(),
+        })?;
+    Ok(write_path)
+}
+
+/// Remove the local recovery marker for a counterparty.
+pub async fn remove_encrypted_link_recovery_marker(
+    session: &PubkySession,
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+) -> Result<String> {
+    let (write_path, _) = encrypted_link_recovery_marker_paths(local_secret_key, remote_pubkey);
+    match session.storage().delete(write_path.clone()).await {
+        Ok(_) => Ok(write_path),
+        Err(err) if is_not_found(&err) => Ok(write_path),
+        Err(err) => Err(PaykitError::Transport {
+            context: "remove Encrypted Link recovery marker".into(),
+            source: err.into(),
+        }),
+    }
+}
+
+/// Fetch a counterparty's recovery marker, if one is present.
+pub async fn fetch_encrypted_link_recovery_marker(
+    storage: &PublicStorage,
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+) -> Result<Option<EncryptedLinkRecoveryMarker>> {
+    let (_, read_path) = encrypted_link_recovery_marker_paths(local_secret_key, remote_pubkey);
+    let addr = format!("{remote_pubkey}{read_path}");
+    match storage.get(&addr).await {
+        Ok(resp) => {
+            let bytes = resp.bytes().await.map_err(|err| PaykitError::Transport {
+                context: "fetch Encrypted Link recovery marker".into(),
+                source: err.into(),
+            })?;
+            if bytes.is_empty() {
+                return Ok(None);
+            }
+            let raw_json = String::from_utf8(bytes.to_vec()).map_err(|err| {
+                let pos = err.utf8_error().valid_up_to();
+                invalid_data(
+                    format!("Encrypted Link recovery marker is invalid UTF-8 at byte {pos}"),
+                    Some(err.into()),
+                )
+            })?;
+            parse_encrypted_link_recovery_marker_json(&raw_json).map(Some)
+        }
+        Err(err) if is_not_found(&err) => Ok(None),
+        Err(err) => Err(PaykitError::Transport {
+            context: "fetch Encrypted Link recovery marker".into(),
+            source: err.into(),
+        }),
+    }
+}
+
+fn is_not_found(err: &PubkyError) -> bool {
+    matches!(
+        err,
+        PubkyError::Request(RequestError::Server { status, .. })
+            if *status == StatusCode::NOT_FOUND || *status == StatusCode::GONE
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use pubky::Keypair;
+
+    use super::*;
+
+    fn secret_pair() -> ([u8; 32], PublicKey) {
+        let keypair = Keypair::random();
+        (keypair.secret_key(), keypair.public_key())
+    }
+
+    #[test]
+    fn test_recovery_marker_json_round_trips() {
+        let marker = EncryptedLinkRecoveryMarker::new(
+            "650e8400-e29b-41d4-a716-446655440000",
+            "2026-06-03T12:00:00Z",
+        )
+        .unwrap();
+
+        let raw = serialize_encrypted_link_recovery_marker(&marker).unwrap();
+        let parsed = parse_encrypted_link_recovery_marker_json(&raw).unwrap();
+
+        assert_eq!(parsed, marker);
+        assert!(raw.contains("\"kind\":\"paykit.encrypted_link_recovery\""));
+    }
+
+    #[test]
+    fn test_recovery_marker_rejects_extra_fields() {
+        let raw = r#"{"version":1,"kind":"paykit.encrypted_link_recovery","attempt_id":"650e8400-e29b-41d4-a716-446655440000","created_at":"2026-06-03T12:00:00Z","peer":"extra"}"#;
+
+        let result = parse_encrypted_link_recovery_marker_json(raw);
+
+        assert!(matches!(result, Err(PaykitError::InvalidData { .. })));
+    }
+
+    #[test]
+    fn test_recovery_marker_paths_are_pairwise_symmetric() {
+        let (alice_secret, alice_public) = secret_pair();
+        let (bob_secret, bob_public) = secret_pair();
+
+        let (alice_write, alice_read) =
+            encrypted_link_recovery_marker_paths(&alice_secret, &bob_public);
+        let (bob_write, bob_read) =
+            encrypted_link_recovery_marker_paths(&bob_secret, &alice_public);
+
+        assert_eq!(alice_write, bob_read);
+        assert_eq!(alice_read, bob_write);
+        assert!(alice_write.starts_with(PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX));
+        assert_ne!(alice_write, alice_read);
+    }
+}

--- a/paykit-lib/src/lib.rs
+++ b/paykit-lib/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 mod encrypted_link;
+mod encrypted_link_recovery;
 mod error;
 mod event;
 mod payment_amount;
@@ -22,6 +23,13 @@ pub use encrypted_link::{
     EncryptedLinkHandshakeSnapshot, EncryptedLinkSnapshot, HandshakeProgress,
     PrivateApplicationMessage, PrivateMessageKind, DEFAULT_MAX_RECOVERY_ATTEMPTS,
     DEFAULT_MAX_SEND_RETRIES,
+};
+#[doc(inline)]
+pub use encrypted_link_recovery::{
+    encrypted_link_recovery_marker_paths, fetch_encrypted_link_recovery_marker,
+    parse_encrypted_link_recovery_marker_json, publish_encrypted_link_recovery_marker,
+    remove_encrypted_link_recovery_marker, serialize_encrypted_link_recovery_marker,
+    EncryptedLinkRecoveryMarker,
 };
 #[doc(inline)]
 pub use error::PaykitError;
@@ -54,7 +62,9 @@ pub use private_payment_list::{
 pub use pubky::PublicKey;
 pub use pubky_noise;
 #[doc(inline)]
-pub use pubky_routing::{PAYKIT_PATH_PREFIX, PAYKIT_PRIVATE_PATH_PREFIX};
+pub use pubky_routing::{
+    PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX, PAYKIT_PATH_PREFIX, PAYKIT_PRIVATE_PATH_PREFIX,
+};
 #[doc(inline)]
 pub use receipt::{
     decrypt_receipt, parse_receipt_access_event_message, parse_receipt_access_json,

--- a/paykit-lib/src/payment_endpoint.rs
+++ b/paykit-lib/src/payment_endpoint.rs
@@ -18,7 +18,7 @@ use crate::{error::map_error, pubky_routing, PaykitError, PublicKey, Result};
 /// # Limits
 /// - Must not be empty.
 /// - Must not exceed 64 characters.
-/// - Must not be the reserved value `"private"`.
+/// - Must not be a reserved Paykit storage value.
 ///
 /// # Examples
 /// ```
@@ -36,6 +36,8 @@ pub struct PaymentEndpointIdentifier(String);
 const PAYMENT_ENDPOINT_IDENTIFIER_MAX_LEN: usize = 64;
 /// Reserved [`PaymentEndpointIdentifier`] value used by private Paykit storage.
 const PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE: &str = "private";
+/// Reserved [`PaymentEndpointIdentifier`] value used by recovery marker storage.
+const PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_RECOVERY: &str = "encrypted-link-recovery";
 
 impl PaymentEndpointIdentifier {
     /// Create a new `PaymentEndpointIdentifier` after validating the identifier.
@@ -59,9 +61,11 @@ impl PaymentEndpointIdentifier {
             )));
         }
 
-        if id == PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE {
+        if id == PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE
+            || id == PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_RECOVERY
+        {
             return Err(PaykitError::Validation(format!(
-                "PaymentEndpointIdentifier '{PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE}' is reserved for Private Payment Lists"
+                "PaymentEndpointIdentifier '{id}' is reserved for Paykit storage"
             )));
         }
 
@@ -398,9 +402,11 @@ mod validation_tests {
     }
 
     #[test]
-    fn test_payment_endpoint_identifier_reject_reserved_private() {
-        let err = PaymentEndpointIdentifier::new("private").unwrap_err();
-        assert!(matches!(err, PaykitError::Validation(msg) if msg.contains("reserved")));
+    fn test_payment_endpoint_identifier_reject_reserved_values() {
+        for reserved in ["private", "encrypted-link-recovery"] {
+            let err = PaymentEndpointIdentifier::new(reserved).unwrap_err();
+            assert!(matches!(err, PaykitError::Validation(msg) if msg.contains("reserved")));
+        }
     }
 
     // ── PaymentEndpointPayload: basic accessors ───────────────────────────────────

--- a/paykit-lib/src/pubky_routing.rs
+++ b/paykit-lib/src/pubky_routing.rs
@@ -29,6 +29,13 @@ pub const PAYKIT_PATH_PREFIX: &str = "/pub/paykit/v0/";
 /// individual file slots within the derived folders using a counter-based scheme.
 pub const PAYKIT_PRIVATE_PATH_PREFIX: &str = "/pub/paykit/v0/private";
 
+/// Conventional prefix for Encrypted Link recovery markers.
+///
+/// Marker paths are derived per-counterparty pair before being appended below
+/// this prefix, so the prefix itself does not identify the counterparty pair.
+pub const PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX: &str =
+    "/pub/paykit/v0/encrypted-link-recovery";
+
 /// Writes or updates a payment endpoint document in the authenticated Pubky session.
 #[instrument(skip(session, payload), fields(identifier = %identifier))]
 pub async fn upsert_payment_endpoint(

--- a/paykit-sdk/README.md
+++ b/paykit-sdk/README.md
@@ -7,12 +7,11 @@ identity status, public Payment Endpoint sync, Encrypted Link state, private
 stream intake, Private Payment List derivation, contact payment resolution, and
 outbound Private Application Message delivery. It also derives Payment Request
 state, indexes Receipt Access events, retrieves/decrypts Encrypted Receipts,
-tracks optional Payment Endpoint Reservations, and exports/restores
-SDK-managed backup state.
+tracks optional Payment Endpoint Reservations, manages Paykit-facing profile
+and local contact records, and exports/restores SDK-managed backup state.
 
-The crate is currently Rust-only. Existing Swift, Kotlin, and React Native
-bindings continue to expose low-level `paykit-lib` APIs until SDK bindings are
-added.
+This crate is Rust-only. Platform bindings expose low-level `paykit-lib` APIs;
+SDK bindings are a separate integration surface.
 
 Payment execution, settlement detection, balances, route policy, product UI,
 and app backup transport stay outside the SDK and are provided by application

--- a/paykit-sdk/src/adapters.rs
+++ b/paykit-sdk/src/adapters.rs
@@ -16,12 +16,7 @@ pub trait PubkySessionProvider: Send + Sync {
     async fn load_session_access(&self) -> Result<Option<PubkySessionAccess>>;
 
     /// Load public Pubky storage for unauthenticated counterparty reads.
-    async fn load_public_storage(&self) -> Result<Option<pubky::PublicStorage>> {
-        let Some(session_access) = self.load_session_access().await? else {
-            return Ok(None);
-        };
-        Ok(Some(session_access.outbox_client.public_storage()))
-    }
+    async fn load_public_storage(&self) -> Result<Option<pubky::PublicStorage>>;
 
     /// Clear local Pubky session access during sign-out.
     async fn clear_session_access(&self) -> Result<()>;

--- a/paykit-sdk/src/backup.rs
+++ b/paykit-sdk/src/backup.rs
@@ -8,6 +8,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    contacts::ContactRecord,
     identity::{IdentityState, PubkyPublicKey},
     linked_peers::LinkedPeerState,
     outbound_private::validate_queued_outbound_private_message,
@@ -40,6 +41,8 @@ pub struct SdkBackupState {
     pub identity_state: Option<IdentityState>,
     /// Linked Peer records.
     pub linked_peers: Vec<LinkedPeerRecord>,
+    /// Local contact records.
+    pub contact_records: Vec<ContactRecord>,
     /// Public Payment Endpoint records.
     pub public_endpoint_records: Vec<PublicEndpointRecord>,
     /// Payment Endpoint Reservation records.
@@ -70,6 +73,7 @@ impl fmt::Debug for SdkBackupState {
             .field("version", &self.version)
             .field("identity_state", &self.identity_state)
             .field("linked_peers", &self.linked_peers.len())
+            .field("contact_records", &self.contact_records.len())
             .field(
                 "public_endpoint_records",
                 &self.public_endpoint_records.len(),
@@ -109,6 +113,8 @@ pub struct RestoreReport {
     pub restored_identity: bool,
     /// Number of restored Linked Peer records.
     pub linked_peers: usize,
+    /// Number of restored local contact records.
+    pub contact_records: usize,
     /// Number of restored public Payment Endpoint records.
     pub public_endpoint_records: usize,
     /// Number of restored Payment Endpoint Reservation records.
@@ -173,7 +179,12 @@ where
     storage
         .transaction(move |tx| {
             let current_identity = tx.load_identity_state();
-            let (state, report) = backup.into_storage_state(current_identity.as_ref())?;
+            let current_next_peer_link_operation_lease_id =
+                tx.export_storage_state().next_peer_link_operation_lease_id;
+            let (state, report) = backup.into_storage_state(
+                current_identity.as_ref(),
+                current_next_peer_link_operation_lease_id,
+            )?;
             tx.replace_storage_state(state);
             Ok(report)
         })
@@ -185,6 +196,10 @@ impl SdkBackupState {
         let mut linked_peers = state.linked_peers.into_values().collect::<Vec<_>>();
         linked_peers
             .sort_by(|left, right| left.counterparty.as_str().cmp(right.counterparty.as_str()));
+
+        let mut contact_records = state.contact_records.into_values().collect::<Vec<_>>();
+        contact_records
+            .sort_by(|left, right| left.public_key.as_str().cmp(right.public_key.as_str()));
 
         let mut public_endpoint_records = state
             .public_endpoint_records
@@ -241,6 +256,7 @@ impl SdkBackupState {
             version: SDK_BACKUP_VERSION,
             identity_state: state.identity_state,
             linked_peers,
+            contact_records,
             public_endpoint_records,
             payment_endpoint_reservations,
             encrypted_link_states,
@@ -258,10 +274,17 @@ impl SdkBackupState {
     fn into_storage_state(
         self,
         current_identity: Option<&IdentityState>,
+        next_peer_link_operation_lease_id: u64,
     ) -> Result<(ValidatedStorageState, RestoreReport)> {
         self.validate(current_identity)?;
 
         let mut linked_peers = keyed_by_counterparty(self.linked_peers, "Linked Peer")?;
+        let contact_records = keyed_by_tuple(
+            self.contact_records,
+            |record| record.public_key.clone(),
+            "local contact",
+        )?;
+        validate_contact_records(&contact_records)?;
         let public_endpoint_records = keyed_by_string(
             self.public_endpoint_records,
             |record| record.identifier.clone(),
@@ -327,6 +350,7 @@ impl SdkBackupState {
             version: self.version,
             restored_identity: self.identity_state.is_some(),
             linked_peers: linked_peers.len(),
+            contact_records: contact_records.len(),
             public_endpoint_records: public_endpoint_records.len(),
             payment_endpoint_reservations: payment_endpoint_reservations.len(),
             encrypted_link_states: encrypted_link_states.len(),
@@ -341,11 +365,12 @@ impl SdkBackupState {
         let state = StorageState {
             identity_state: self.identity_state,
             linked_peers,
+            contact_records,
             public_endpoint_records,
             payment_endpoint_reservations,
             encrypted_link_states,
             peer_link_operation_leases: HashMap::new(),
-            next_peer_link_operation_lease_id: 0,
+            next_peer_link_operation_lease_id,
             outbound_private_messages,
             next_outbound_private_message_id,
             private_stream_items,
@@ -403,6 +428,7 @@ impl SdkBackupState {
 
     pub(crate) fn has_identity_scoped_state(&self) -> bool {
         !self.linked_peers.is_empty()
+            || !self.contact_records.is_empty()
             || !self.public_endpoint_records.is_empty()
             || !self.payment_endpoint_reservations.is_empty()
             || !self.encrypted_link_states.is_empty()
@@ -541,6 +567,10 @@ fn mark_restored_peers_recovery_required(
                 last_sync_at: None,
                 last_private_receive_at: None,
                 failure_count: 0,
+                local_recovery_attempt_id: None,
+                local_recovery_marker_created_at: None,
+                remote_recovery_attempt_id: None,
+                remote_recovery_marker_observed_at: None,
             });
     }
 
@@ -655,6 +685,68 @@ fn validate_encrypted_link_snapshots(
 fn validate_public_endpoint_records(records: &HashMap<String, PublicEndpointRecord>) -> Result<()> {
     for record in records.values() {
         PaymentEndpointIdentifier::new(&record.identifier)?;
+    }
+    Ok(())
+}
+
+fn validate_contact_records(records: &HashMap<PubkyPublicKey, ContactRecord>) -> Result<()> {
+    for record in records.values() {
+        if let Some(profile) = record.profile.as_ref() {
+            profile.validate()?;
+        }
+        if let Some(label) = record.label.as_deref() {
+            crate::ContactUpdate {
+                public_key: record.public_key.clone(),
+                label: Some(label.to_owned()),
+            }
+            .validate()?;
+        }
+        validate_contact_marker_state(record)?;
+    }
+    Ok(())
+}
+
+fn validate_contact_marker_state(record: &ContactRecord) -> Result<()> {
+    use crate::PublicContactMarkerStatus::{
+        Failed, NotPublished, PendingPublication, PendingRemoval, Published, Removed,
+    };
+
+    if record.public_contact_published_at.is_some() && record.public_contact_removed_at.is_some() {
+        return Err(PaykitSdkError::Protocol(format!(
+            "local contact {} has inconsistent public contact marker timestamps",
+            record.public_key
+        )));
+    }
+
+    let invalid = match record.public_contact_marker_status {
+        NotPublished => {
+            record.public_contact_published_at.is_some()
+                || record.public_contact_removed_at.is_some()
+                || record.public_contact_last_error.is_some()
+        }
+        PendingPublication => record.public_contact_last_error.is_some(),
+        Published => {
+            record.public_contact_published_at.is_none()
+                || record.public_contact_removed_at.is_some()
+                || record.public_contact_last_error.is_some()
+        }
+        PendingRemoval => {
+            record.public_contact_published_at.is_none()
+                || record.public_contact_removed_at.is_some()
+                || record.public_contact_last_error.is_some()
+        }
+        Removed => {
+            record.public_contact_published_at.is_some()
+                || record.public_contact_removed_at.is_none()
+                || record.public_contact_last_error.is_some()
+        }
+        Failed => record.public_contact_last_error.is_none(),
+    };
+    if invalid {
+        return Err(PaykitSdkError::Protocol(format!(
+            "local contact {} has inconsistent public contact marker state",
+            record.public_key
+        )));
     }
     Ok(())
 }
@@ -957,6 +1049,21 @@ mod tests {
         }
     }
 
+    fn contact_record(public_key: PubkyPublicKey) -> ContactRecord {
+        ContactRecord {
+            public_key,
+            label: Some("Alice".into()),
+            profile: None,
+            profile_fetched_at: None,
+            created_at: timestamp(),
+            updated_at: timestamp(),
+            public_contact_marker_status: crate::PublicContactMarkerStatus::NotPublished,
+            public_contact_published_at: None,
+            public_contact_removed_at: None,
+            public_contact_last_error: None,
+        }
+    }
+
     #[tokio::test]
     async fn test_export_backup_state_redacts_debug() {
         let storage = InMemoryStorage::new();
@@ -1007,7 +1114,12 @@ mod tests {
                 last_sync_at: Some(timestamp()),
                 last_private_receive_at: None,
                 failure_count: 0,
+                local_recovery_attempt_id: None,
+                local_recovery_marker_created_at: None,
+                remote_recovery_attempt_id: None,
+                remote_recovery_marker_observed_at: None,
             }],
+            contact_records: Vec::new(),
             public_endpoint_records: Vec::new(),
             payment_endpoint_reservations: Vec::new(),
             encrypted_link_states: vec![EncryptedLinkStateRecord {
@@ -1040,6 +1152,182 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_backup_state_round_trips_contact_records() {
+        let storage = InMemoryStorage::new();
+        let local_public_key = public_key();
+        let contact_public_key = public_key();
+        storage
+            .transaction({
+                let local_public_key = local_public_key.clone();
+                let contact_public_key = contact_public_key.clone();
+                move |tx| {
+                    tx.save_identity_state(identity(local_public_key));
+                    tx.save_contact_record(contact_record(contact_public_key));
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+
+        let backup = export_backup_state(&storage).await.unwrap();
+        let restore_storage = InMemoryStorage::new();
+        let report = restore_backup_state(&restore_storage, backup)
+            .await
+            .unwrap();
+        let restored = restore_storage.snapshot().unwrap();
+
+        assert_eq!(report.contact_records, 1);
+        assert_eq!(
+            restored.contact_records[&contact_public_key]
+                .label
+                .as_deref(),
+            Some("Alice")
+        );
+        assert!(report.recovery_required_peers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_rejects_inconsistent_contact_marker_state() {
+        let storage = InMemoryStorage::new();
+        let local_public_key = public_key();
+        let contact_public_key = public_key();
+        let mut contact = contact_record(contact_public_key);
+        contact.public_contact_published_at = Some(timestamp());
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: Some(identity(local_public_key)),
+            linked_peers: Vec::new(),
+            contact_records: vec![contact],
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: Vec::new(),
+            outbound_private_messages: Vec::new(),
+            private_stream_items: Vec::new(),
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 0,
+            next_private_stream_item_id: 0,
+        };
+
+        let result = restore_backup_state(&storage, backup).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_rejects_dual_contact_marker_timestamps() {
+        let storage = InMemoryStorage::new();
+        let local_public_key = public_key();
+        let contact_public_key = public_key();
+        let mut contact = contact_record(contact_public_key)
+            .mark_public_contact_published(timestamp())
+            .mark_public_contact_removed(timestamp());
+        contact.public_contact_published_at = Some(timestamp());
+        contact.public_contact_marker_status = crate::PublicContactMarkerStatus::Failed;
+        contact.public_contact_last_error = Some("failed".into());
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: Some(identity(local_public_key)),
+            linked_peers: Vec::new(),
+            contact_records: vec![contact],
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: Vec::new(),
+            outbound_private_messages: Vec::new(),
+            private_stream_items: Vec::new(),
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 0,
+            next_private_stream_item_id: 0,
+        };
+
+        let result = restore_backup_state(&storage, backup).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_accepts_pending_contact_marker_removal() {
+        let storage = InMemoryStorage::new();
+        let local_public_key = public_key();
+        let contact_public_key = public_key();
+        let contact = contact_record(contact_public_key)
+            .mark_public_contact_published(timestamp())
+            .mark_public_contact_removal_pending(timestamp());
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: Some(identity(local_public_key)),
+            linked_peers: Vec::new(),
+            contact_records: vec![contact],
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: Vec::new(),
+            outbound_private_messages: Vec::new(),
+            private_stream_items: Vec::new(),
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 0,
+            next_private_stream_item_id: 0,
+        };
+
+        let report = restore_backup_state(&storage, backup).await.unwrap();
+
+        assert_eq!(report.contact_records, 1);
+    }
+
+    #[tokio::test]
+    async fn test_restore_backup_state_preserves_next_peer_lease_id() {
+        let storage = InMemoryStorage::new();
+        let counterparty = public_key();
+        storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| {
+                    let lease = tx
+                        .claim_peer_link_operation(
+                            &counterparty,
+                            timestamp(),
+                            timestamp() + chrono::Duration::seconds(60),
+                        )
+                        .unwrap();
+                    assert_eq!(lease.lease_id, 0);
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+        let backup = SdkBackupState {
+            version: SDK_BACKUP_VERSION,
+            identity_state: None,
+            linked_peers: Vec::new(),
+            contact_records: Vec::new(),
+            public_endpoint_records: Vec::new(),
+            payment_endpoint_reservations: Vec::new(),
+            encrypted_link_states: Vec::new(),
+            outbound_private_messages: Vec::new(),
+            private_stream_items: Vec::new(),
+            event_dedup_records: Vec::new(),
+            receipt_access_records: Vec::new(),
+            receipt_records: Vec::new(),
+            next_outbound_private_message_id: 0,
+            next_receive_batch_id: 0,
+            next_private_stream_item_id: 0,
+        };
+
+        restore_backup_state(&storage, backup).await.unwrap();
+        let snapshot = storage.snapshot().unwrap();
+
+        assert!(snapshot.peer_link_operation_leases.is_empty());
+        assert_eq!(snapshot.next_peer_link_operation_lease_id, 1);
+    }
+
+    #[tokio::test]
     async fn test_restore_backup_state_marks_link_state_without_peer_recovery_required() {
         let storage = InMemoryStorage::new();
         let counterparty = public_key();
@@ -1047,6 +1335,7 @@ mod tests {
             version: SDK_BACKUP_VERSION,
             identity_state: Some(identity(counterparty.clone())),
             linked_peers: Vec::new(),
+            contact_records: Vec::new(),
             public_endpoint_records: Vec::new(),
             payment_endpoint_reservations: Vec::new(),
             encrypted_link_states: vec![EncryptedLinkStateRecord {
@@ -1084,6 +1373,7 @@ mod tests {
             version: SDK_BACKUP_VERSION,
             identity_state: Some(identity(counterparty.clone())),
             linked_peers: Vec::new(),
+            contact_records: Vec::new(),
             public_endpoint_records: Vec::new(),
             payment_endpoint_reservations: Vec::new(),
             encrypted_link_states: Vec::new(),
@@ -1127,6 +1417,7 @@ mod tests {
             version: SDK_BACKUP_VERSION,
             identity_state: Some(identity(counterparty.clone())),
             linked_peers: Vec::new(),
+            contact_records: Vec::new(),
             public_endpoint_records: Vec::new(),
             payment_endpoint_reservations: Vec::new(),
             encrypted_link_states: vec![EncryptedLinkStateRecord {
@@ -1159,6 +1450,7 @@ mod tests {
             version: SDK_BACKUP_VERSION,
             identity_state: None,
             linked_peers: Vec::new(),
+            contact_records: Vec::new(),
             public_endpoint_records: vec![PublicEndpointRecord {
                 identifier: "btc-lightning-bolt11".into(),
                 payload: Some("ln".into()),
@@ -1191,6 +1483,7 @@ mod tests {
             version: SDK_BACKUP_VERSION,
             identity_state: Some(identity(local_public_key)),
             linked_peers: Vec::new(),
+            contact_records: Vec::new(),
             public_endpoint_records: vec![PublicEndpointRecord {
                 identifier: "private".into(),
                 payload: Some("ln".into()),
@@ -1223,6 +1516,7 @@ mod tests {
             version: SDK_BACKUP_VERSION,
             identity_state: Some(identity(counterparty.clone())),
             linked_peers: Vec::new(),
+            contact_records: Vec::new(),
             public_endpoint_records: Vec::new(),
             payment_endpoint_reservations: Vec::new(),
             encrypted_link_states: Vec::new(),
@@ -1268,6 +1562,7 @@ mod tests {
             version: SDK_BACKUP_VERSION,
             identity_state: Some(identity(backup_public_key)),
             linked_peers: Vec::new(),
+            contact_records: Vec::new(),
             public_endpoint_records: Vec::new(),
             payment_endpoint_reservations: Vec::new(),
             encrypted_link_states: Vec::new(),
@@ -1294,6 +1589,7 @@ mod tests {
             version: SDK_BACKUP_VERSION,
             identity_state: Some(identity(counterparty.clone())),
             linked_peers: Vec::new(),
+            contact_records: Vec::new(),
             public_endpoint_records: Vec::new(),
             payment_endpoint_reservations: Vec::new(),
             encrypted_link_states: Vec::new(),

--- a/paykit-sdk/src/config.rs
+++ b/paykit-sdk/src/config.rs
@@ -30,6 +30,24 @@ pub enum PublicFallbackPolicy {
     AfterPrivateRecoveryTimeout,
 }
 
+/// Policy for public Encrypted Link recovery markers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EncryptedLinkRecoveryMarkerPolicy {
+    /// Publish and observe minimal public recovery markers.
+    Enabled,
+    /// Do not use public recovery markers.
+    Disabled,
+}
+
+/// Policy for publishing saved contacts to public Pubky storage.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PublicContactSharingPolicy {
+    /// Keep saved contacts only in local SDK storage. This is the default.
+    LocalOnly,
+    /// Allow explicit public contact marker publication under `/pub/paykit/contacts/`.
+    PublicPaykitNamespace,
+}
+
 /// Runtime configuration for Paykit SDK.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PaykitSdkConfig {
@@ -41,6 +59,12 @@ pub struct PaykitSdkConfig {
     pub public_fallback: PublicFallbackPolicy,
     /// Maximum time to spend on private recovery before returning/falling back.
     pub private_recovery_timeout: Duration,
+    /// Public recovery marker behavior.
+    #[serde(default = "default_encrypted_link_recovery_marker_policy")]
+    pub encrypted_link_recovery_markers: EncryptedLinkRecoveryMarkerPolicy,
+    /// Public contact marker behavior.
+    #[serde(default = "default_public_contact_sharing_policy")]
+    pub public_contact_sharing: PublicContactSharingPolicy,
     /// Time after which an in-progress peer link operation can be retried.
     pub peer_link_operation_lease_timeout: Duration,
     /// Time after which an in-progress outbound private send can be retried.
@@ -54,8 +78,18 @@ impl Default for PaykitSdkConfig {
             private_sharing: PrivateSharingPolicy::Enabled,
             public_fallback: PublicFallbackPolicy::AfterPrivateRecoveryTimeout,
             private_recovery_timeout: Duration::from_secs(3),
+            encrypted_link_recovery_markers: EncryptedLinkRecoveryMarkerPolicy::Enabled,
+            public_contact_sharing: PublicContactSharingPolicy::LocalOnly,
             peer_link_operation_lease_timeout: Duration::from_secs(60),
             outbound_private_send_lease_timeout: Duration::from_secs(60),
         }
     }
+}
+
+fn default_encrypted_link_recovery_marker_policy() -> EncryptedLinkRecoveryMarkerPolicy {
+    EncryptedLinkRecoveryMarkerPolicy::Enabled
+}
+
+fn default_public_contact_sharing_policy() -> PublicContactSharingPolicy {
+    PublicContactSharingPolicy::LocalOnly
 }

--- a/paykit-sdk/src/contacts.rs
+++ b/paykit-sdk/src/contacts.rs
@@ -1,11 +1,339 @@
-//! Contact payment resolution types.
+//! Contact, profile, and contact payment resolution types.
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use crate::{
-    PaymentAmountContext, PaymentEndpointCandidate, PaymentEndpointEvaluation, PubkyPublicKey,
+    PaykitSdkError, PaymentAmountContext, PaymentEndpointCandidate, PaymentEndpointEvaluation,
+    PubkyPublicKey, Result,
 };
+
+/// Default public Paykit profile path.
+pub const PAYKIT_PROFILE_PATH: &str = "/pub/paykit/profile.json";
+/// Default public Paykit profile blob prefix.
+///
+/// Profile image blob upload/delete helpers are caller-managed.
+pub const PAYKIT_PROFILE_BLOB_PATH_PREFIX: &str = "/pub/paykit/blobs/";
+/// Default public Paykit contact marker prefix.
+pub const PAYKIT_PUBLIC_CONTACT_PATH_PREFIX: &str = "/pub/paykit/contacts/";
+
+const PROFILE_KIND: &str = "paykit.profile";
+const PUBLIC_CONTACT_KIND: &str = "paykit.contact";
+const PROFILE_VERSION: u32 = 1;
+const PUBLIC_CONTACT_VERSION: u32 = 1;
+const MAX_DISPLAY_NAME_CHARS: usize = 128;
+const MAX_IMAGE_URI_CHARS: usize = 2048;
+const MAX_LOCAL_LABEL_CHARS: usize = 128;
+
+/// Public Paykit-facing profile metadata.
+///
+/// This record is intentionally small and public. Keep product-specific profile
+/// data outside this SDK profile unless it is safe to publish.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaykitProfile {
+    /// Public display name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// Public image pointer such as a Pubky path or URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_uri: Option<String>,
+}
+
+impl PaykitProfile {
+    /// Validate profile field bounds.
+    pub fn validate(&self) -> Result<()> {
+        validate_optional_text(
+            self.display_name.as_deref(),
+            "profile display name",
+            MAX_DISPLAY_NAME_CHARS,
+            false,
+        )?;
+        validate_optional_text(
+            self.image_uri.as_deref(),
+            "profile image URI",
+            MAX_IMAGE_URI_CHARS,
+            false,
+        )?;
+        Ok(())
+    }
+}
+
+/// Profile record fetched or published through the SDK.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaykitProfileRecord {
+    /// Profile owner.
+    pub public_key: PubkyPublicKey,
+    /// Public profile metadata.
+    pub profile: PaykitProfile,
+    /// Pubky path used for the profile.
+    pub path: String,
+    /// Local observation/publication time.
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Local SDK contact update.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContactUpdate {
+    /// Contact public key.
+    pub public_key: PubkyPublicKey,
+    /// Optional local display label.
+    pub label: Option<String>,
+}
+
+impl ContactUpdate {
+    /// Validate contact update fields.
+    pub fn validate(&self) -> Result<()> {
+        validate_optional_text(
+            self.label.as_deref(),
+            "contact label",
+            MAX_LOCAL_LABEL_CHARS,
+            true,
+        )
+    }
+}
+
+/// Local SDK contact record.
+///
+/// Contact Records are local/private SDK state by default. Publishing a Public
+/// Contact Marker requires explicit runtime policy and a separate method call.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContactRecord {
+    /// Contact public key.
+    pub public_key: PubkyPublicKey,
+    /// Optional local display label.
+    pub label: Option<String>,
+    /// Cached public profile, when fetched.
+    pub profile: Option<PaykitProfile>,
+    /// Time the cached public profile was fetched.
+    pub profile_fetched_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Time the contact was first saved locally.
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Time the local contact record last changed.
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    /// Public Contact Marker publication state.
+    pub public_contact_marker_status: PublicContactMarkerStatus,
+    /// Time the contact was last published publicly by explicit opt-in.
+    pub public_contact_published_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Time the public contact marker was last removed.
+    pub public_contact_removed_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Last public contact marker publication/removal error.
+    pub public_contact_last_error: Option<String>,
+}
+
+impl fmt::Debug for ContactRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContactRecord")
+            .field("public_key", &"<redacted>")
+            .field("label", &self.label.as_ref().map(|_| "<redacted>"))
+            .field("profile", &self.profile.as_ref().map(|_| "<redacted>"))
+            .field("profile_fetched_at", &self.profile_fetched_at)
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .field(
+                "public_contact_marker_status",
+                &self.public_contact_marker_status,
+            )
+            .field(
+                "public_contact_published_at",
+                &self.public_contact_published_at,
+            )
+            .field("public_contact_removed_at", &self.public_contact_removed_at)
+            .field(
+                "public_contact_last_error",
+                &self
+                    .public_contact_last_error
+                    .as_ref()
+                    .map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+/// Publication state for an optional Public Contact Marker.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PublicContactMarkerStatus {
+    /// No Public Contact Marker is known to be published.
+    #[default]
+    NotPublished,
+    /// Marker publication was recorded locally before the remote write.
+    PendingPublication,
+    /// Marker is known to be published.
+    Published,
+    /// Marker removal was recorded locally before the remote delete.
+    PendingRemoval,
+    /// Marker is known to be removed.
+    Removed,
+    /// Last marker publication/removal attempt failed.
+    Failed,
+}
+
+impl ContactRecord {
+    pub(crate) fn from_update(
+        update: ContactUpdate,
+        existing: Option<ContactRecord>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        let label = normalize_label(update.label);
+        match existing {
+            Some(mut existing) => {
+                existing.label = label;
+                existing.updated_at = now;
+                existing
+            }
+            None => Self {
+                public_key: update.public_key,
+                label,
+                profile: None,
+                profile_fetched_at: None,
+                created_at: now,
+                updated_at: now,
+                public_contact_marker_status: PublicContactMarkerStatus::NotPublished,
+                public_contact_published_at: None,
+                public_contact_removed_at: None,
+                public_contact_last_error: None,
+            },
+        }
+    }
+
+    pub(crate) fn with_profile(
+        mut self,
+        profile: Option<PaykitProfile>,
+        fetched_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.profile = profile;
+        self.profile_fetched_at = Some(fetched_at);
+        self.updated_at = fetched_at;
+        self
+    }
+
+    pub(crate) fn mark_public_contact_publication_pending(
+        mut self,
+        updated_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.public_contact_marker_status = PublicContactMarkerStatus::PendingPublication;
+        self.public_contact_last_error = None;
+        self.updated_at = updated_at;
+        self
+    }
+
+    pub(crate) fn mark_public_contact_published(
+        mut self,
+        published_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.public_contact_marker_status = PublicContactMarkerStatus::Published;
+        self.public_contact_published_at = Some(published_at);
+        self.public_contact_removed_at = None;
+        self.public_contact_last_error = None;
+        self.updated_at = published_at;
+        self
+    }
+
+    pub(crate) fn mark_public_contact_removal_pending(
+        mut self,
+        updated_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.public_contact_marker_status = PublicContactMarkerStatus::PendingRemoval;
+        self.public_contact_last_error = None;
+        self.updated_at = updated_at;
+        self
+    }
+
+    pub(crate) fn mark_public_contact_removed(
+        mut self,
+        removed_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.public_contact_marker_status = PublicContactMarkerStatus::Removed;
+        self.public_contact_published_at = None;
+        self.public_contact_removed_at = Some(removed_at);
+        self.public_contact_last_error = None;
+        self.updated_at = removed_at;
+        self
+    }
+
+    pub(crate) fn mark_public_contact_failed(
+        mut self,
+        error: String,
+        failed_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.public_contact_marker_status = PublicContactMarkerStatus::Failed;
+        self.public_contact_last_error = Some(error);
+        self.updated_at = failed_at;
+        self
+    }
+
+    pub(crate) fn can_remove_locally(&self) -> bool {
+        matches!(
+            self.public_contact_marker_status,
+            PublicContactMarkerStatus::NotPublished | PublicContactMarkerStatus::Removed
+        )
+    }
+
+    pub(crate) fn may_have_public_marker(&self) -> bool {
+        self.public_contact_published_at.is_some() && self.public_contact_removed_at.is_none()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PaykitProfileDocument {
+    version: u32,
+    kind: String,
+    #[serde(flatten)]
+    profile: PaykitProfile,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PublicContactDocument {
+    version: u32,
+    kind: String,
+    public_key: PubkyPublicKey,
+}
+
+pub(crate) fn profile_json(profile: &PaykitProfile) -> Result<String> {
+    profile.validate()?;
+    serde_json::to_string(&PaykitProfileDocument {
+        version: PROFILE_VERSION,
+        kind: PROFILE_KIND.into(),
+        profile: profile.clone(),
+    })
+    .map_err(|err| PaykitSdkError::Protocol(format!("failed to serialize Paykit profile: {err}")))
+}
+
+pub(crate) fn parse_profile_json(raw_json: &str) -> Result<PaykitProfile> {
+    let document = serde_json::from_str::<PaykitProfileDocument>(raw_json)
+        .map_err(|err| PaykitSdkError::Protocol(format!("invalid Paykit profile JSON: {err}")))?;
+    if document.version != PROFILE_VERSION {
+        return Err(PaykitSdkError::Protocol(format!(
+            "unsupported Paykit profile version {}",
+            document.version
+        )));
+    }
+    if document.kind != PROFILE_KIND {
+        return Err(PaykitSdkError::Protocol(format!(
+            "unexpected Paykit profile kind '{}'",
+            document.kind
+        )));
+    }
+    document.profile.validate()?;
+    Ok(document.profile)
+}
+
+pub(crate) fn public_contact_path(public_key: &PubkyPublicKey) -> String {
+    format!(
+        "{PAYKIT_PUBLIC_CONTACT_PATH_PREFIX}{}.json",
+        public_key.as_str()
+    )
+}
+
+pub(crate) fn public_contact_json(public_key: &PubkyPublicKey) -> Result<String> {
+    serde_json::to_string(&PublicContactDocument {
+        version: PUBLIC_CONTACT_VERSION,
+        kind: PUBLIC_CONTACT_KIND.into(),
+        public_key: public_key.clone(),
+    })
+    .map_err(|err| {
+        PaykitSdkError::Protocol(format!("failed to serialize Paykit public contact: {err}"))
+    })
+}
 
 /// Result category for contact payment resolution.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -52,5 +380,96 @@ impl fmt::Debug for ContactPaymentResolution {
             .field("evaluations", &self.evaluations)
             .field("used_public_fallback", &self.used_public_fallback)
             .finish()
+    }
+}
+
+fn validate_optional_text(
+    value: Option<&str>,
+    label: &str,
+    max_chars: usize,
+    allow_empty: bool,
+) -> Result<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    if !allow_empty && value.trim().is_empty() {
+        return Err(PaykitSdkError::Protocol(format!(
+            "{label} must not be empty"
+        )));
+    }
+    if value.chars().count() > max_chars {
+        return Err(PaykitSdkError::Protocol(format!(
+            "{label} must not exceed {max_chars} characters"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_label(label: Option<String>) -> Option<String> {
+    label.and_then(|label| if label.is_empty() { None } else { Some(label) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn public_key() -> PubkyPublicKey {
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+    }
+
+    #[test]
+    fn test_profile_json_round_trips() {
+        let profile = PaykitProfile {
+            display_name: Some("Alice".into()),
+            image_uri: Some("/pub/paykit/blobs/avatar.png".into()),
+        };
+
+        let json = profile_json(&profile).unwrap();
+        let parsed = parse_profile_json(&json).unwrap();
+
+        assert!(json.contains(r#""kind":"paykit.profile""#));
+        assert_eq!(parsed, profile);
+    }
+
+    #[test]
+    fn test_profile_json_rejects_wrong_kind() {
+        let result = parse_profile_json(
+            r#"{"version":1,"kind":"paykit.other","display_name":"Alice","image_uri":null}"#,
+        );
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    }
+
+    #[test]
+    fn test_profile_rejects_empty_display_name() {
+        let profile = PaykitProfile {
+            display_name: Some(" ".into()),
+            image_uri: None,
+        };
+
+        assert!(matches!(
+            profile.validate(),
+            Err(PaykitSdkError::Protocol(_))
+        ));
+    }
+
+    #[test]
+    fn test_contact_update_allows_empty_label_to_clear_display_text() {
+        let update = ContactUpdate {
+            public_key: public_key(),
+            label: Some(String::new()),
+        };
+
+        assert!(update.validate().is_ok());
+    }
+
+    #[test]
+    fn test_public_contact_path_is_under_paykit_namespace() {
+        let public_key = public_key();
+
+        assert_eq!(
+            public_contact_path(&public_key),
+            format!("/pub/paykit/contacts/{}.json", public_key.as_str())
+        );
     }
 }

--- a/paykit-sdk/src/lib.rs
+++ b/paykit-sdk/src/lib.rs
@@ -20,6 +20,7 @@ pub mod payment_requests;
 pub mod private_lists;
 pub mod private_stream;
 pub mod receipts;
+pub mod recovery;
 /// SDK runtime facade.
 pub mod runtime;
 /// Durable storage traits and in-memory test storage.
@@ -37,11 +38,14 @@ pub use adapters::{
 pub use backup::{export_backup_state, RestoreReport, SdkBackupState, SDK_BACKUP_VERSION};
 #[doc(inline)]
 pub use config::{
-    EndpointManagementScope, PaykitSdkConfig, PrivateSharingPolicy, PublicFallbackPolicy,
+    EncryptedLinkRecoveryMarkerPolicy, EndpointManagementScope, PaykitSdkConfig,
+    PrivateSharingPolicy, PublicContactSharingPolicy, PublicFallbackPolicy,
 };
 #[doc(inline)]
 pub use contacts::{
     ContactPaymentResolution, ContactPaymentResolutionRequest, ContactPaymentResolutionStatus,
+    ContactRecord, ContactUpdate, PaykitProfile, PaykitProfileRecord, PublicContactMarkerStatus,
+    PAYKIT_PROFILE_BLOB_PATH_PREFIX, PAYKIT_PROFILE_PATH, PAYKIT_PUBLIC_CONTACT_PATH_PREFIX,
 };
 #[doc(inline)]
 pub use endpoints::{
@@ -78,6 +82,8 @@ pub use receipts::{
     ReceiptAccessRecord, ReceiptAmountRecord, ReceiptBillingPeriodRecord, ReceiptRecord,
     ReceiptRetrievalStatus,
 };
+#[doc(inline)]
+pub use recovery::EncryptedLinkRecoveryMarkerReport;
 #[doc(inline)]
 pub use runtime::{Clock, InitializationReport, PaykitSdk, SystemClock};
 #[doc(inline)]

--- a/paykit-sdk/src/linked_peers.rs
+++ b/paykit-sdk/src/linked_peers.rs
@@ -50,6 +50,10 @@ pub struct LinkedPeerHandshakeReport {
     pub handshake_role: Option<EncryptedLinkHandshakeRole>,
 }
 
+pub(crate) struct RecoveryRequiredMark {
+    pub new_episode: bool,
+}
+
 /// Load the durable Linked Peer record for a counterparty.
 pub async fn load_linked_peer<S>(
     storage: &S,
@@ -70,6 +74,10 @@ fn default_linked_peer(counterparty: PubkyPublicKey) -> LinkedPeerRecord {
         last_sync_at: None,
         last_private_receive_at: None,
         failure_count: 0,
+        local_recovery_attempt_id: None,
+        local_recovery_marker_created_at: None,
+        remote_recovery_attempt_id: None,
+        remote_recovery_marker_observed_at: None,
     }
 }
 
@@ -182,7 +190,7 @@ pub(crate) async fn mark_recovery_required_with_lease<S>(
     counterparty: PubkyPublicKey,
     lease: PeerLinkOperationLease,
     now: DateTime<Utc>,
-) -> Result<LinkedPeerRecord>
+) -> Result<RecoveryRequiredMark>
 where
     S: StorageAdapter,
 {
@@ -194,7 +202,7 @@ async fn mark_recovery_required_inner<S>(
     counterparty: PubkyPublicKey,
     lease: Option<PeerLinkOperationLease>,
     now: DateTime<Utc>,
-) -> Result<LinkedPeerRecord>
+) -> Result<RecoveryRequiredMark>
 where
     S: StorageAdapter,
 {
@@ -207,8 +215,11 @@ where
                 .linked_peer(&counterparty)
                 .unwrap_or_else(|| default_linked_peer(counterparty.clone()));
             ensure_not_blocked(&record)?;
+            let new_episode = record.state != LinkedPeerState::RecoveryRequired;
             record.state = LinkedPeerState::RecoveryRequired;
-            record.last_sync_at = Some(now);
+            if new_episode || record.last_sync_at.is_none() {
+                record.last_sync_at = Some(now);
+            }
             record.failure_count = record.failure_count.saturating_add(1);
             tx.save_linked_peer(record.clone());
             if let Some(link_state) = tx.encrypted_link_state(&counterparty) {
@@ -221,7 +232,7 @@ where
                     checkpointed_at: now,
                 });
             }
-            Ok(record)
+            Ok(RecoveryRequiredMark { new_episode })
         })
         .await
 }
@@ -653,10 +664,15 @@ mod tests {
             .await
             .unwrap();
 
-        let peer = mark_recovery_required_inner(&storage, counterparty.clone(), None, timestamp())
+        let mark = mark_recovery_required_inner(&storage, counterparty.clone(), None, timestamp())
             .await
             .unwrap();
 
+        assert!(mark.new_episode);
+        let peer = load_linked_peer(&storage, &counterparty)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(peer.state, LinkedPeerState::RecoveryRequired);
         let link_state = load_encrypted_link_state(&storage, &counterparty)
             .await
@@ -682,10 +698,15 @@ mod tests {
         .await
         .unwrap();
 
-        let peer = mark_recovery_required_inner(&storage, counterparty.clone(), None, timestamp())
+        let mark = mark_recovery_required_inner(&storage, counterparty.clone(), None, timestamp())
             .await
             .unwrap();
 
+        assert!(mark.new_episode);
+        let peer = load_linked_peer(&storage, &counterparty)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(peer.state, LinkedPeerState::RecoveryRequired);
         let link_state = load_encrypted_link_state(&storage, &counterparty)
             .await

--- a/paykit-sdk/src/outbound_private.rs
+++ b/paykit-sdk/src/outbound_private.rs
@@ -25,6 +25,8 @@ pub enum OutboundPrivateMessageStatus {
     Failed,
     /// The stored payload is invalid and must not be retried automatically.
     Invalid,
+    /// Newer latest-state data made this message unnecessary to send.
+    Superseded,
 }
 
 /// Failed outbound private send attempt.

--- a/paykit-sdk/src/payment_requests.rs
+++ b/paykit-sdk/src/payment_requests.rs
@@ -709,7 +709,10 @@ fn derive_payment_request_records(
     }
 
     for message in outbound {
-        if message.status == OutboundPrivateMessageStatus::Invalid {
+        if matches!(
+            message.status,
+            OutboundPrivateMessageStatus::Invalid | OutboundPrivateMessageStatus::Superseded
+        ) {
             continue;
         }
         let Some(parsed) = parse_payment_request_event_message(&PrivateApplicationMessage {

--- a/paykit-sdk/src/recovery.rs
+++ b/paykit-sdk/src/recovery.rs
@@ -1,0 +1,60 @@
+//! Encrypted Link recovery marker state.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    linked_peers::LinkedPeerState,
+    storage::{LinkedPeerRecord, StorageAdapter},
+    PubkyPublicKey, Result,
+};
+
+/// Public recovery marker state tracked for one Linked Peer.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EncryptedLinkRecoveryMarkerReport {
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Current Linked Peer state.
+    pub state: LinkedPeerState,
+    /// Locally published recovery attempt id.
+    pub local_attempt_id: Option<String>,
+    /// Creation time for the local marker payload.
+    pub local_marker_created_at: Option<DateTime<Utc>>,
+    /// Latest observed counterparty recovery attempt id.
+    pub remote_attempt_id: Option<String>,
+    /// Time the counterparty marker was observed.
+    pub remote_marker_observed_at: Option<DateTime<Utc>>,
+    /// Whether this operation observed a new counterparty marker.
+    pub remote_marker_changed: bool,
+}
+
+impl EncryptedLinkRecoveryMarkerReport {
+    pub(crate) fn from_peer(peer: &LinkedPeerRecord, remote_marker_changed: bool) -> Self {
+        Self {
+            counterparty: peer.counterparty.clone(),
+            state: peer.state.clone(),
+            local_attempt_id: peer.local_recovery_attempt_id.clone(),
+            local_marker_created_at: peer.local_recovery_marker_created_at,
+            remote_attempt_id: peer.remote_recovery_attempt_id.clone(),
+            remote_marker_observed_at: peer.remote_recovery_marker_observed_at,
+            remote_marker_changed,
+        }
+    }
+}
+
+pub(crate) async fn recovery_marker_report<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Option<EncryptedLinkRecoveryMarkerReport>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| {
+            Ok(tx
+                .linked_peer(counterparty)
+                .as_ref()
+                .map(|peer| EncryptedLinkRecoveryMarkerReport::from_peer(peer, false)))
+        })
+        .await
+}

--- a/paykit-sdk/src/runtime.rs
+++ b/paykit-sdk/src/runtime.rs
@@ -1,11 +1,12 @@
 use std::{cmp::Reverse, collections::HashSet};
 
-use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, SecondsFormat, Utc};
 use paykit_lib::{
-    BillingPeriod, EventId, PaymentEndpointIdentifier, PaymentProof, PaymentRequest,
-    PaymentRequestAcceptance, PaymentRequestCancellation, PaymentRequestEvent, PaymentRequestId,
-    PaymentRequestRejection, PaymentRequestTerms,
+    BillingPeriod, EncryptedLinkRecoveryMarker, EventId, PaymentEndpointIdentifier, PaymentProof,
+    PaymentRequest, PaymentRequestAcceptance, PaymentRequestCancellation, PaymentRequestEvent,
+    PaymentRequestId, PaymentRequestRejection, PaymentRequestTerms,
 };
+use pubky::{errors::RequestError, Error as PubkyError, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value as JsonValue};
 
@@ -15,10 +16,13 @@ use crate::{
         restore_backup_state as restore_sdk_backup_state, RestoreReport, SdkBackupState,
     },
     config::{
-        EndpointManagementScope, PaykitSdkConfig, PrivateSharingPolicy, PublicFallbackPolicy,
+        EncryptedLinkRecoveryMarkerPolicy, EndpointManagementScope, PaykitSdkConfig,
+        PrivateSharingPolicy, PublicContactSharingPolicy, PublicFallbackPolicy,
     },
     contacts::{
+        parse_profile_json, profile_json, public_contact_json, public_contact_path,
         ContactPaymentResolution, ContactPaymentResolutionRequest, ContactPaymentResolutionStatus,
+        ContactRecord, ContactUpdate, PaykitProfile, PaykitProfileRecord, PAYKIT_PROFILE_PATH,
     },
     endpoint_reservations::{
         payment_endpoint_reservations, queue_private_payment_list_with_reservations,
@@ -63,9 +67,10 @@ use crate::{
         decrypt_receipt_record_from_access, fetch_encrypted_receipt_json,
         receipt_record_matches_access, ReceiptAccessRecord, ReceiptRecord, ReceiptRetrievalStatus,
     },
+    recovery::{recovery_marker_report, EncryptedLinkRecoveryMarkerReport},
     storage::{
-        EncryptedLinkStateRecord, OutboundPrivateMessageRecord, PeerLinkOperationLease,
-        StorageAdapter,
+        EncryptedLinkStateRecord, LinkedPeerRecord, OutboundPrivateMessageRecord,
+        PeerLinkOperationLease, StorageAdapter,
     },
     PaykitSdkError, PaymentAdapter, PaymentEndpointCandidate, PaymentEndpointEvaluation,
     PaymentEndpointReservation, PaymentEndpointReservationRelease,
@@ -205,6 +210,44 @@ where
         Ok((session, state))
     }
 
+    async fn require_initialized_identity(&self, context: &str) -> Result<PubkyPublicKey> {
+        self.storage
+            .transaction(|tx| {
+                tx.load_identity_state()
+                    .and_then(|state| state.public_key)
+                    .ok_or_else(|| PaykitSdkError::Identity {
+                        context: format!("cannot {context} without an initialized Pubky identity"),
+                        source: None,
+                    })
+            })
+            .await
+    }
+
+    async fn load_session_access_for_initialized_identity(
+        &self,
+        context: &str,
+    ) -> Result<PubkySessionAccess> {
+        let expected_public_key = self.require_initialized_identity(context).await?;
+        let session_access =
+            self.pubky
+                .load_session_access()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: format!("cannot {context} without an active Pubky session"),
+                    source: None,
+                })?;
+        let actual_public_key = session_access.public_key()?;
+        if actual_public_key != expected_public_key {
+            return Err(PaykitSdkError::Identity {
+                context: format!(
+                    "cannot {context} because active Pubky session does not match initialized identity"
+                ),
+                source: None,
+            });
+        }
+        Ok(session_access)
+    }
+
     /// Return the last persisted identity status, if initialized.
     pub async fn identity_status(&self) -> Result<Option<IdentityStatus>> {
         Ok(self
@@ -218,6 +261,272 @@ where
     /// Access SDK configuration.
     pub fn config(&self) -> &PaykitSdkConfig {
         &self.config
+    }
+
+    /// Save or update a local contact record.
+    pub async fn save_contact(&self, update: ContactUpdate) -> Result<ContactRecord> {
+        update.validate()?;
+        self.require_initialized_identity("save contact").await?;
+        let now = self.clock.now();
+        self.storage
+            .transaction(move |tx| {
+                let existing = tx.contact_record(&update.public_key);
+                let record = ContactRecord::from_update(update, existing, now);
+                tx.save_contact_record(record.clone());
+                Ok(record)
+            })
+            .await
+    }
+
+    /// Load one local contact record.
+    pub async fn contact_record(
+        &self,
+        public_key: &PubkyPublicKey,
+    ) -> Result<Option<ContactRecord>> {
+        self.require_initialized_identity("load contact").await?;
+        self.storage
+            .transaction(|tx| Ok(tx.contact_record(public_key)))
+            .await
+    }
+
+    /// List local contact records.
+    pub async fn contact_records(&self) -> Result<Vec<ContactRecord>> {
+        self.require_initialized_identity("list contacts").await?;
+        self.storage
+            .transaction(|tx| Ok(tx.contact_records()))
+            .await
+    }
+
+    /// Remove one local contact record.
+    pub async fn remove_contact(
+        &self,
+        public_key: &PubkyPublicKey,
+    ) -> Result<Option<ContactRecord>> {
+        self.require_initialized_identity("remove contact").await?;
+        self.storage
+            .transaction(|tx| {
+                let Some(existing) = tx.contact_record(public_key) else {
+                    return Ok(None);
+                };
+                if !existing.can_remove_locally() {
+                    return Err(PaykitSdkError::Policy(format!(
+                        "remove public contact marker before deleting contact {public_key}"
+                    )));
+                }
+                Ok(tx.remove_contact_record(public_key))
+            })
+            .await
+    }
+
+    /// Publish the local public Paykit profile.
+    ///
+    /// This writes only `/pub/paykit/profile.json`. Profile image blob upload
+    /// and deletion are caller-managed.
+    pub async fn publish_profile(&self, profile: PaykitProfile) -> Result<PaykitProfileRecord> {
+        let json = profile_json(&profile)?;
+        let (session_access, _) = self.load_session_access_and_refresh_identity().await?;
+        let session_access = session_access.ok_or_else(|| PaykitSdkError::Identity {
+            context: "no Pubky session available for profile publication".into(),
+            source: None,
+        })?;
+        session_access
+            .session
+            .storage()
+            .put(PAYKIT_PROFILE_PATH, json)
+            .await
+            .map_err(|err| map_pubky_transport_error("publish Paykit profile", err))?;
+        Ok(PaykitProfileRecord {
+            public_key: session_access.public_key()?,
+            profile,
+            path: PAYKIT_PROFILE_PATH.into(),
+            updated_at: self.clock.now(),
+        })
+    }
+
+    /// Fetch a public Paykit profile.
+    pub async fn fetch_profile(
+        &self,
+        public_key: PubkyPublicKey,
+    ) -> Result<Option<PaykitProfileRecord>> {
+        let public_storage =
+            self.pubky
+                .load_public_storage()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: "no Pubky public storage available for profile lookup".into(),
+                    source: None,
+                })?;
+        let Some(raw_json) = fetch_public_text(
+            &public_storage,
+            &public_key,
+            PAYKIT_PROFILE_PATH,
+            "fetch profile",
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(PaykitProfileRecord {
+            public_key,
+            profile: parse_profile_json(&raw_json)?,
+            path: PAYKIT_PROFILE_PATH.into(),
+            updated_at: self.clock.now(),
+        }))
+    }
+
+    /// Fetch a contact's public profile and cache it in the local contact record.
+    pub async fn refresh_contact_profile(
+        &self,
+        public_key: PubkyPublicKey,
+    ) -> Result<Option<ContactRecord>> {
+        self.require_initialized_identity("refresh contact profile")
+            .await?;
+        let fetched = self.fetch_profile(public_key.clone()).await?;
+        let now = self.clock.now();
+        self.storage
+            .transaction(move |tx| {
+                let Some(existing) = tx.contact_record(&public_key) else {
+                    return Ok(None);
+                };
+                let record = existing.with_profile(fetched.map(|record| record.profile), now);
+                tx.save_contact_record(record.clone());
+                Ok(Some(record))
+            })
+            .await
+    }
+
+    /// Publish a public contact marker for a saved local contact.
+    ///
+    /// This can reveal part of the local contact graph. It only runs when
+    /// `public_contact_sharing` is `PublicPaykitNamespace`.
+    pub async fn publish_public_contact(
+        &self,
+        public_key: PubkyPublicKey,
+    ) -> Result<ContactRecord> {
+        if self.config.public_contact_sharing != PublicContactSharingPolicy::PublicPaykitNamespace {
+            return Err(PaykitSdkError::Policy(
+                "public contact sharing is disabled".into(),
+            ));
+        }
+        let session_access = self
+            .load_session_access_for_initialized_identity("publish public contact")
+            .await?;
+        let pending_at = self.clock.now();
+        self.storage
+            .transaction(|tx| {
+                let Some(existing) = tx.contact_record(&public_key) else {
+                    return Err(PaykitSdkError::Protocol(format!(
+                        "cannot publish unsaved contact {public_key}"
+                    )));
+                };
+                tx.save_contact_record(
+                    existing.mark_public_contact_publication_pending(pending_at),
+                );
+                Ok(())
+            })
+            .await?;
+        let path = public_contact_path(&public_key);
+        let write_result = session_access
+            .session
+            .storage()
+            .put(path, public_contact_json(&public_key)?)
+            .await
+            .map_err(|err| map_pubky_transport_error("publish public contact", err));
+        if let Err(err) = write_result {
+            self.mark_public_contact_failed(&public_key, err.to_string())
+                .await?;
+            return Err(err);
+        }
+        let now = self.clock.now();
+        self.storage
+            .transaction(move |tx| {
+                let Some(existing) = tx.contact_record(&public_key) else {
+                    return Err(PaykitSdkError::Protocol(format!(
+                        "contact {public_key} disappeared before public publication was recorded"
+                    )));
+                };
+                let record = existing.mark_public_contact_published(now);
+                tx.save_contact_record(record.clone());
+                Ok(record)
+            })
+            .await
+    }
+
+    /// Remove a public contact marker for a saved local contact.
+    ///
+    /// Cleanup is allowed even when public contact sharing is disabled, so an
+    /// app can stop publishing markers and still remove previously published
+    /// markers.
+    pub async fn remove_public_contact(
+        &self,
+        public_key: PubkyPublicKey,
+    ) -> Result<Option<ContactRecord>> {
+        let existing_record = self
+            .storage
+            .transaction(|tx| Ok(tx.contact_record(&public_key)))
+            .await?;
+        let session_access = self
+            .load_session_access_for_initialized_identity("remove public contact")
+            .await?;
+        let had_local_record = existing_record.is_some();
+        if existing_record
+            .as_ref()
+            .is_some_and(ContactRecord::may_have_public_marker)
+        {
+            let pending_at = self.clock.now();
+            self.storage
+                .transaction(|tx| {
+                    let Some(existing) = tx.contact_record(&public_key) else {
+                        return Ok(());
+                    };
+                    tx.save_contact_record(
+                        existing.mark_public_contact_removal_pending(pending_at),
+                    );
+                    Ok(())
+                })
+                .await?;
+        }
+        let path = public_contact_path(&public_key);
+        let delete_result = session_access.session.storage().delete(path).await;
+        if let Err(err) = delete_result {
+            if !is_pubky_not_found(&err) {
+                let err = map_pubky_transport_error("remove public contact", err);
+                self.mark_public_contact_failed(&public_key, err.to_string())
+                    .await?;
+                return Err(err);
+            }
+        }
+        if !had_local_record {
+            return Ok(None);
+        }
+        let now = self.clock.now();
+        self.storage
+            .transaction(move |tx| {
+                let Some(existing) = tx.contact_record(&public_key) else {
+                    return Ok(None);
+                };
+                let record = existing.mark_public_contact_removed(now);
+                tx.save_contact_record(record.clone());
+                Ok(Some(record))
+            })
+            .await
+    }
+
+    async fn mark_public_contact_failed(
+        &self,
+        public_key: &PubkyPublicKey,
+        error: String,
+    ) -> Result<()> {
+        let failed_at = self.clock.now();
+        self.storage
+            .transaction(|tx| {
+                let Some(existing) = tx.contact_record(public_key) else {
+                    return Ok(());
+                };
+                tx.save_contact_record(existing.mark_public_contact_failed(error, failed_at));
+                Ok(())
+            })
+            .await
     }
 
     /// Access the payment adapter.
@@ -268,15 +577,111 @@ where
         restore_sdk_backup_state(&self.storage, backup).await
     }
 
+    /// Return tracked Encrypted Link recovery marker state for a counterparty.
+    pub async fn encrypted_link_recovery_marker_status(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Option<EncryptedLinkRecoveryMarkerReport>> {
+        recovery_marker_report(&self.storage, counterparty).await
+    }
+
+    /// Publish a minimal local recovery marker for a counterparty.
+    pub async fn publish_encrypted_link_recovery_marker(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        let (session_access, _) = self.load_session_access_and_refresh_identity().await?;
+        let session_access = session_access.ok_or_else(|| PaykitSdkError::Identity {
+            context: "no Pubky session available".into(),
+            source: None,
+        })?;
+        let new_episode = self
+            .mark_recovery_required_without_lease(&counterparty)
+            .await?;
+        self.publish_local_recovery_marker_with_session(&counterparty, &session_access, new_episode)
+            .await
+    }
+
+    /// Observe a counterparty's public recovery marker.
+    pub async fn observe_encrypted_link_recovery_marker(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        let (session_access, _) = self.load_session_access_and_refresh_identity().await?;
+        let session_access = session_access.ok_or_else(|| PaykitSdkError::Identity {
+            context: "no Pubky session available".into(),
+            source: None,
+        })?;
+        self.observe_remote_recovery_marker_with_session(&counterparty, &session_access)
+            .await
+    }
+
+    /// Remove the local public recovery marker for a counterparty.
+    pub async fn remove_encrypted_link_recovery_marker(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        if self.config.encrypted_link_recovery_markers
+            == EncryptedLinkRecoveryMarkerPolicy::Disabled
+        {
+            return self
+                .recovery_marker_report_or_default(&counterparty, false)
+                .await;
+        }
+
+        let (session_access, _) = self.load_session_access_and_refresh_identity().await?;
+        let session_access = session_access.ok_or_else(|| PaykitSdkError::Identity {
+            context: "no Pubky session available".into(),
+            source: None,
+        })?;
+        let secret_key = session_access
+            .local_secret_key
+            .as_ref()
+            .ok_or_else(|| PaykitSdkError::Identity {
+                context:
+                    "local Pubky secret key is unavailable for Encrypted Link recovery markers"
+                        .into(),
+                source: None,
+            })?
+            .as_bytes();
+        let remote_public_key = counterparty.to_public_key()?;
+        paykit_lib::remove_encrypted_link_recovery_marker(
+            &session_access.session,
+            secret_key,
+            &remote_public_key,
+        )
+        .await?;
+
+        self.storage
+            .transaction(|tx| {
+                if let Some(mut peer) = tx.linked_peer(&counterparty) {
+                    peer.local_recovery_attempt_id = None;
+                    peer.local_recovery_marker_created_at = None;
+                    tx.save_linked_peer(peer);
+                }
+                Ok(())
+            })
+            .await?;
+        self.recovery_marker_report_or_default(&counterparty, false)
+            .await
+    }
+
     /// Return the latest valid Private Payment List view for a counterparty.
     pub async fn current_private_payment_list(
         &self,
         counterparty: &PubkyPublicKey,
     ) -> Result<Option<crate::PrivatePaymentListView>> {
-        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        let (session_access, identity) = self.load_session_access_and_refresh_identity().await?;
         if identity.capability != PubkyIdentityCapability::PrivateLinkCapable {
             return Ok(None);
         }
+        self.ensure_peer_allows_private_automation(counterparty)
+            .await?;
+        self.observe_remote_recovery_marker_for_cached_private_state(
+            counterparty,
+            session_access.as_ref(),
+        )
+        .await?;
         self.ensure_peer_allows_private_automation(counterparty)
             .await?;
         load_current_private_payment_list(&self.storage, counterparty).await
@@ -343,49 +748,49 @@ where
             )));
         }
         let now = self.clock.now();
-        let latest_access = &access_records[0];
-
-        let encrypted_json = match fetch_encrypted_receipt_json(
-            &public_storage,
-            &counterparty,
-            &latest_access.location,
-        )
-        .await
-        {
-            Ok(Some(encrypted_json)) => encrypted_json,
-            Ok(None) => {
-                let error = format!(
-                    "encrypted receipt {} was not found at {}",
-                    latest_access.receipt_id, latest_access.location
-                );
-                self.save_receipt_retrieval_error(
-                    latest_access,
-                    ReceiptRetrievalStatus::NotFound,
-                    now,
-                    error.clone(),
-                )
-                .await?;
-                return Err(PaykitSdkError::Transport {
-                    context: error,
-                    source: None,
-                });
-            }
-            Err(err) => {
-                let error = err.to_string();
-                self.save_receipt_retrieval_error(
-                    latest_access,
-                    ReceiptRetrievalStatus::Failed,
-                    now,
-                    error,
-                )
-                .await?;
-                return Err(err);
-            }
-        };
-
         let all_access_records = access_records.clone();
         let mut last_error = None;
         for access in access_records {
+            let encrypted_json = match fetch_encrypted_receipt_json(
+                &public_storage,
+                &counterparty,
+                &access.location,
+            )
+            .await
+            {
+                Ok(Some(encrypted_json)) => encrypted_json,
+                Ok(None) => {
+                    let error = format!(
+                        "encrypted receipt {} was not found at {}",
+                        access.receipt_id, access.location
+                    );
+                    self.save_receipt_retrieval_error(
+                        &access,
+                        ReceiptRetrievalStatus::NotFound,
+                        now,
+                        error.clone(),
+                    )
+                    .await?;
+                    last_error = Some(PaykitSdkError::Transport {
+                        context: error,
+                        source: None,
+                    });
+                    continue;
+                }
+                Err(err) => {
+                    let error = err.to_string();
+                    self.save_receipt_retrieval_error(
+                        &access,
+                        ReceiptRetrievalStatus::Failed,
+                        now,
+                        error,
+                    )
+                    .await?;
+                    last_error = Some(err);
+                    continue;
+                }
+            };
+
             match decrypt_receipt_record_from_access(
                 &access,
                 &encrypted_json,
@@ -1018,25 +1423,29 @@ where
         }
 
         let Some(handshake_role) = stored_link_state.handshake_role else {
-            mark_recovery_required_with_lease(
+            let mark = mark_recovery_required_with_lease(
                 &self.storage,
                 counterparty.clone(),
                 lease.clone(),
                 self.clock.now(),
             )
             .await?;
+            self.publish_local_recovery_marker_if_possible(&counterparty, mark.new_episode)
+                .await;
             return Err(PaykitSdkError::RecoveryRequired(format!(
                 "missing Encrypted Link Handshake role for counterparty {counterparty}"
             )));
         };
         let Some(snapshot_bytes) = stored_link_state.handshake_snapshot.as_ref() else {
-            mark_recovery_required_with_lease(
+            let mark = mark_recovery_required_with_lease(
                 &self.storage,
                 counterparty.clone(),
                 lease.clone(),
                 self.clock.now(),
             )
             .await?;
+            self.publish_local_recovery_marker_if_possible(&counterparty, mark.new_episode)
+                .await;
             return Err(PaykitSdkError::RecoveryRequired(format!(
                 "no in-progress Encrypted Link Handshake snapshot for counterparty {counterparty}"
             )));
@@ -1055,8 +1464,15 @@ where
             .as_ref()
             .is_err_and(should_mark_link_recovery_required)
         {
-            mark_recovery_required_with_lease(&self.storage, counterparty, lease, self.clock.now())
-                .await?;
+            let mark = mark_recovery_required_with_lease(
+                &self.storage,
+                counterparty.clone(),
+                lease,
+                self.clock.now(),
+            )
+            .await?;
+            self.publish_local_recovery_marker_if_possible(&counterparty, mark.new_episode)
+                .await;
         }
         result
     }
@@ -1066,9 +1482,9 @@ where
         &self,
         request: ContactPaymentResolutionRequest,
     ) -> Result<ContactPaymentResolution> {
-        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        let (session_access, identity) = self.load_session_access_and_refresh_identity().await?;
         let mut evaluations = Vec::new();
-        let private_allowed = match self
+        let mut private_allowed = match self
             .ensure_peer_allows_private_automation(&request.counterparty)
             .await
         {
@@ -1076,6 +1492,30 @@ where
             Err(PaykitSdkError::RecoveryRequired(_)) => false,
             Err(err) => return Err(err),
         };
+        if private_allowed && identity.capability == PubkyIdentityCapability::PrivateLinkCapable {
+            if let Err(err) = self
+                .observe_remote_recovery_marker_for_cached_private_state(
+                    &request.counterparty,
+                    session_access.as_ref(),
+                )
+                .await
+            {
+                if self.config.public_fallback == PublicFallbackPolicy::Disabled {
+                    return Err(err);
+                }
+                private_allowed = false;
+            }
+        }
+        if private_allowed && identity.capability == PubkyIdentityCapability::PrivateLinkCapable {
+            private_allowed = match self
+                .ensure_peer_allows_private_automation(&request.counterparty)
+                .await
+            {
+                Ok(()) => true,
+                Err(PaykitSdkError::RecoveryRequired(_)) => false,
+                Err(err) => return Err(err),
+            };
+        }
         let private_view = if private_allowed
             && identity.capability == PubkyIdentityCapability::PrivateLinkCapable
         {
@@ -1240,6 +1680,16 @@ where
         }
 
         if has_active_link {
+            if let Err(err) = self
+                .observe_remote_recovery_marker_for_cached_private_state(counterparty, None)
+                .await
+            {
+                if self.config.public_fallback == PublicFallbackPolicy::Disabled {
+                    return Err(err);
+                }
+                return Ok(PrivateRecoveryOutcome::NotNeeded);
+            }
+
             match self.receive_private_messages(counterparty.clone()).await {
                 Ok(_) => {
                     let private_view =
@@ -1256,8 +1706,13 @@ where
                 Err(PaykitSdkError::RecoveryRequired(_))
                 | Err(PaykitSdkError::Transport { .. })
                 | Err(PaykitSdkError::Protocol(_)) => {
-                    self.mark_private_recovery_pending(counterparty, link_generation)
+                    let recovery_update = self
+                        .mark_private_recovery_pending(counterparty, link_generation)
                         .await?;
+                    if let RecoveryRequiredUpdate::Marked { new_episode } = recovery_update {
+                        self.publish_local_recovery_marker_if_possible(counterparty, new_episode)
+                            .await;
+                    }
                     return Ok(PrivateRecoveryOutcome::Pending);
                 }
                 Err(err) => return Err(err),
@@ -1271,7 +1726,7 @@ where
         &self,
         counterparty: &PubkyPublicKey,
         expected_link_generation: Option<u64>,
-    ) -> Result<()> {
+    ) -> Result<RecoveryRequiredUpdate> {
         let now = self.clock.now();
         self.storage
             .transaction(|tx| {
@@ -1279,21 +1734,16 @@ where
                     .encrypted_link_state(counterparty)
                     .map(|state| state.generation);
                 if current_generation != expected_link_generation {
-                    return Ok(());
+                    return Ok(RecoveryRequiredUpdate::Skipped);
                 }
-                let previous = tx.linked_peer(counterparty);
-                tx.save_linked_peer(crate::LinkedPeerRecord {
-                    counterparty: counterparty.clone(),
-                    state: LinkedPeerState::RecoveryRequired,
-                    last_sync_at: Some(now),
-                    last_private_receive_at: previous
-                        .as_ref()
-                        .and_then(|peer| peer.last_private_receive_at),
-                    failure_count: previous
-                        .as_ref()
-                        .map(|peer| peer.failure_count.saturating_add(1))
-                        .unwrap_or(1),
-                });
+                let mut peer = recovery_peer_or_default(tx.linked_peer(counterparty), counterparty);
+                let new_episode = peer.state != LinkedPeerState::RecoveryRequired;
+                peer.state = LinkedPeerState::RecoveryRequired;
+                if new_episode || peer.last_sync_at.is_none() {
+                    peer.last_sync_at = Some(now);
+                }
+                peer.failure_count = peer.failure_count.saturating_add(1);
+                tx.save_linked_peer(peer);
                 if let Some(link_state) = tx.encrypted_link_state(counterparty) {
                     tx.save_encrypted_link_state(EncryptedLinkStateRecord {
                         counterparty: counterparty.clone(),
@@ -1304,9 +1754,290 @@ where
                         checkpointed_at: now,
                     });
                 }
-                Ok(())
+                Ok(RecoveryRequiredUpdate::Marked { new_episode })
             })
             .await
+    }
+
+    async fn mark_recovery_required_without_lease(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<bool> {
+        let now = self.clock.now();
+        self.storage
+            .transaction(|tx| {
+                let existing_peer = tx.linked_peer(counterparty);
+                let has_link_state = tx.encrypted_link_state(counterparty).is_some();
+                if !can_publish_recovery_marker(existing_peer.as_ref(), has_link_state) {
+                    return Err(PaykitSdkError::Policy(format!(
+                        "cannot publish Encrypted Link recovery marker without existing private link state for counterparty {counterparty}"
+                    )));
+                }
+                let mut peer = recovery_peer_or_default(existing_peer, counterparty);
+                if peer.state == LinkedPeerState::Blocked {
+                    return Err(PaykitSdkError::Policy(format!(
+                        "counterparty {counterparty} is blocked"
+                    )));
+                }
+                let new_episode = peer.state != LinkedPeerState::RecoveryRequired;
+                if peer.state != LinkedPeerState::RecoveryRequired {
+                    peer.failure_count = peer.failure_count.saturating_add(1);
+                }
+                peer.state = LinkedPeerState::RecoveryRequired;
+                if new_episode || peer.last_sync_at.is_none() {
+                    peer.last_sync_at = Some(now);
+                }
+                tx.save_linked_peer(peer);
+                if let Some(link_state) = tx.encrypted_link_state(counterparty) {
+                    tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                        counterparty: counterparty.clone(),
+                        link_snapshot: None,
+                        handshake_snapshot: None,
+                        handshake_role: None,
+                        generation: link_state.generation.saturating_add(1),
+                        checkpointed_at: now,
+                    });
+                }
+                Ok(new_episode)
+            })
+            .await
+    }
+
+    async fn publish_local_recovery_marker_if_possible(
+        &self,
+        counterparty: &PubkyPublicKey,
+        force_new_attempt: bool,
+    ) {
+        let Ok(Some(session_access)) = self.pubky.load_session_access().await else {
+            return;
+        };
+        let _ = self
+            .publish_local_recovery_marker_with_session(
+                counterparty,
+                &session_access,
+                force_new_attempt,
+            )
+            .await;
+    }
+
+    async fn publish_local_recovery_marker_with_session(
+        &self,
+        counterparty: &PubkyPublicKey,
+        session_access: &PubkySessionAccess,
+        force_new_attempt: bool,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        if self.config.encrypted_link_recovery_markers
+            == EncryptedLinkRecoveryMarkerPolicy::Disabled
+        {
+            return self
+                .recovery_marker_report_or_default(counterparty, false)
+                .await;
+        }
+
+        let secret_key = session_access
+            .local_secret_key
+            .as_ref()
+            .ok_or_else(|| PaykitSdkError::Identity {
+                context:
+                    "local Pubky secret key is unavailable for Encrypted Link recovery markers"
+                        .into(),
+                source: None,
+            })?
+            .as_bytes();
+        let remote_public_key = counterparty.to_public_key()?;
+        let now = self.clock.now();
+        let marker = self
+            .storage
+            .transaction(|tx| {
+                let mut peer = recovery_peer_or_default(tx.linked_peer(counterparty), counterparty);
+                let has_link_state = tx.encrypted_link_state(counterparty).is_some();
+                if !can_publish_recovery_marker(Some(&peer), has_link_state) {
+                    return Err(PaykitSdkError::Policy(format!(
+                        "cannot publish Encrypted Link recovery marker without existing private link state for counterparty {counterparty}"
+                    )));
+                }
+                let reusable_marker = if !force_new_attempt
+                    && peer.state == LinkedPeerState::RecoveryRequired
+                    && local_recovery_marker_belongs_to_current_episode(&peer)
+                {
+                    peer.local_recovery_attempt_id
+                        .as_ref()
+                        .zip(peer.local_recovery_marker_created_at)
+                        .map(|(attempt_id, created_at)| {
+                            let created_at_text =
+                                created_at.to_rfc3339_opts(SecondsFormat::Secs, true);
+                            EncryptedLinkRecoveryMarker::new(attempt_id.clone(), created_at_text)
+                                .map(|marker| (marker, created_at))
+                        })
+                        .transpose()?
+                } else {
+                    None
+                };
+                let (marker, marker_created_at) = reusable_marker
+                    .map(Ok)
+                    .unwrap_or_else(|| {
+                        EncryptedLinkRecoveryMarker::new_v4(
+                            now.to_rfc3339_opts(SecondsFormat::Secs, true),
+                        )
+                        .map(|marker| (marker, now))
+                    })?;
+                peer.local_recovery_attempt_id = Some(marker.attempt_id().to_owned());
+                peer.local_recovery_marker_created_at = Some(marker_created_at);
+                tx.save_linked_peer(peer);
+                Ok(marker)
+            })
+            .await?;
+        paykit_lib::publish_encrypted_link_recovery_marker(
+            &session_access.session,
+            secret_key,
+            &remote_public_key,
+            &marker,
+        )
+        .await?;
+
+        self.recovery_marker_report_or_default(counterparty, false)
+            .await
+    }
+
+    async fn observe_remote_recovery_marker_for_cached_private_state(
+        &self,
+        counterparty: &PubkyPublicKey,
+        session_access: Option<&PubkySessionAccess>,
+    ) -> Result<()> {
+        if self.config.encrypted_link_recovery_markers
+            == EncryptedLinkRecoveryMarkerPolicy::Disabled
+        {
+            return Ok(());
+        }
+
+        let session_access = match session_access {
+            Some(session_access) => session_access,
+            None => {
+                let loaded = self.pubky.load_session_access().await?;
+                let Some(session_access) = loaded else {
+                    return Err(PaykitSdkError::Identity {
+                        context:
+                            "no Pubky session available for Encrypted Link recovery marker lookup"
+                                .into(),
+                        source: None,
+                    });
+                };
+                return self
+                    .observe_remote_recovery_marker_with_session(counterparty, &session_access)
+                    .await
+                    .map(|_| ());
+            }
+        };
+
+        self.observe_remote_recovery_marker_with_session(counterparty, session_access)
+            .await
+            .map(|_| ())
+    }
+
+    async fn observe_remote_recovery_marker_with_session(
+        &self,
+        counterparty: &PubkyPublicKey,
+        session_access: &PubkySessionAccess,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        if self.config.encrypted_link_recovery_markers
+            == EncryptedLinkRecoveryMarkerPolicy::Disabled
+        {
+            return self
+                .recovery_marker_report_or_default(counterparty, false)
+                .await;
+        }
+
+        let public_storage =
+            self.pubky
+                .load_public_storage()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: "no Pubky public storage available for recovery marker lookup".into(),
+                    source: None,
+                })?;
+        let secret_key = session_access
+            .local_secret_key
+            .as_ref()
+            .ok_or_else(|| PaykitSdkError::Identity {
+                context:
+                    "local Pubky secret key is unavailable for Encrypted Link recovery markers"
+                        .into(),
+                source: None,
+            })?
+            .as_bytes();
+        let remote_public_key = counterparty.to_public_key()?;
+        let Some(marker) = paykit_lib::fetch_encrypted_link_recovery_marker(
+            &public_storage,
+            secret_key,
+            &remote_public_key,
+        )
+        .await?
+        else {
+            return self
+                .recovery_marker_report_or_default(counterparty, false)
+                .await;
+        };
+
+        let now = self.clock.now();
+        let changed = self
+            .storage
+            .transaction(|tx| {
+                let existing_peer = tx.linked_peer(counterparty);
+                let has_link_state = tx.encrypted_link_state(counterparty).is_some();
+                if !can_publish_recovery_marker(existing_peer.as_ref(), has_link_state) {
+                    return Ok(false);
+                }
+                let mut peer = recovery_peer_or_default(existing_peer, counterparty);
+                if peer.remote_recovery_attempt_id.as_deref() == Some(marker.attempt_id()) {
+                    tx.save_linked_peer(peer);
+                    return Ok(false);
+                }
+                if peer.state == LinkedPeerState::Blocked {
+                    return Err(PaykitSdkError::Policy(format!(
+                        "counterparty {counterparty} is blocked"
+                    )));
+                }
+                peer.remote_recovery_attempt_id = Some(marker.attempt_id().to_owned());
+                peer.remote_recovery_marker_observed_at = Some(now);
+                peer.state = LinkedPeerState::RecoveryRequired;
+                peer.last_sync_at = Some(now);
+                peer.failure_count = peer.failure_count.saturating_add(1);
+                tx.save_linked_peer(peer);
+                if let Some(link_state) = tx.encrypted_link_state(counterparty) {
+                    tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                        counterparty: counterparty.clone(),
+                        link_snapshot: None,
+                        handshake_snapshot: None,
+                        handshake_role: None,
+                        generation: link_state.generation.saturating_add(1),
+                        checkpointed_at: now,
+                    });
+                }
+                Ok(true)
+            })
+            .await?;
+        self.recovery_marker_report_or_default(counterparty, changed)
+            .await
+    }
+
+    async fn recovery_marker_report_or_default(
+        &self,
+        counterparty: &PubkyPublicKey,
+        remote_marker_changed: bool,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        let peer = self
+            .storage
+            .transaction(|tx| {
+                Ok(recovery_peer_or_default(
+                    tx.linked_peer(counterparty),
+                    counterparty,
+                ))
+            })
+            .await?;
+        Ok(EncryptedLinkRecoveryMarkerReport::from_peer(
+            &peer,
+            remote_marker_changed,
+        ))
     }
 
     fn private_recovery_window_open(&self, started_at: DateTime<Utc>) -> Result<bool> {
@@ -1568,13 +2299,20 @@ where
             })?;
         let Some(snapshot_bytes) = stored_link_state.link_snapshot.as_ref() else {
             let now = self.clock.now();
-            mark_recovery_required_with_lease(
+            let mark = mark_recovery_required_with_lease(
                 &self.storage,
                 counterparty.clone(),
                 lease.clone(),
                 now,
             )
             .await?;
+            let _ = self
+                .publish_local_recovery_marker_with_session(
+                    &counterparty,
+                    &session_access,
+                    mark.new_episode,
+                )
+                .await;
             return Err(PaykitSdkError::RecoveryRequired(format!(
                 "no active Encrypted Link snapshot for counterparty {counterparty}"
             )));
@@ -1583,13 +2321,20 @@ where
             Ok(snapshot) => snapshot,
             Err(err) => {
                 let now = self.clock.now();
-                mark_recovery_required_with_lease(
+                let mark = mark_recovery_required_with_lease(
                     &self.storage,
                     counterparty.clone(),
                     lease.clone(),
                     now,
                 )
                 .await?;
+                let _ = self
+                    .publish_local_recovery_marker_with_session(
+                        &counterparty,
+                        &session_access,
+                        mark.new_episode,
+                    )
+                    .await;
                 return Err(err.into());
             }
         };
@@ -1690,13 +2435,20 @@ where
             })?;
         let Some(snapshot_bytes) = stored_link_state.link_snapshot.as_ref() else {
             let now = self.clock.now();
-            mark_recovery_required_with_lease(
+            let mark = mark_recovery_required_with_lease(
                 &self.storage,
                 counterparty.clone(),
                 lease.clone(),
                 now,
             )
             .await?;
+            let _ = self
+                .publish_local_recovery_marker_with_session(
+                    &counterparty,
+                    &session_access,
+                    mark.new_episode,
+                )
+                .await;
             return Err(PaykitSdkError::RecoveryRequired(format!(
                 "no active Encrypted Link snapshot for counterparty {counterparty}"
             )));
@@ -1705,13 +2457,20 @@ where
             Ok(snapshot) => snapshot,
             Err(err) => {
                 let now = self.clock.now();
-                mark_recovery_required_with_lease(
+                let mark = mark_recovery_required_with_lease(
                     &self.storage,
                     counterparty.clone(),
                     lease.clone(),
                     now,
                 )
                 .await?;
+                let _ = self
+                    .publish_local_recovery_marker_with_session(
+                        &counterparty,
+                        &session_access,
+                        mark.new_episode,
+                    )
+                    .await;
                 return Err(err.into());
             }
         };
@@ -1873,56 +2632,71 @@ where
         role: EncryptedLinkHandshakeRole,
         lease: PeerLinkOperationLease,
     ) -> Result<LinkedPeerHandshakeReport> {
-        self.ensure_peer_allows_private_automation(&counterparty)
-            .await?;
-        if let Some(existing) = self
+        let peer_state = self
             .storage
-            .transaction(|tx| Ok(tx.encrypted_link_state(&counterparty)))
-            .await?
-        {
-            if existing.link_snapshot.is_some() {
-                save_linked_peer_state_with_lease(
-                    &self.storage,
-                    counterparty.clone(),
-                    LinkedPeerState::Linked,
-                    lease.clone(),
-                    self.clock.now(),
-                )
-                .await?;
-                return Ok(LinkedPeerHandshakeReport {
-                    counterparty,
-                    state: LinkedPeerState::Linked,
-                    generation: existing.generation,
-                    handshake_role: None,
-                });
-            }
-            if existing.handshake_snapshot.is_some() {
-                if existing.handshake_role.is_none() {
-                    mark_recovery_required_with_lease(
+            .transaction(|tx| Ok(tx.linked_peer(&counterparty).map(|peer| peer.state)))
+            .await?;
+        if matches!(peer_state, Some(LinkedPeerState::Blocked)) {
+            return Err(PaykitSdkError::Policy(format!(
+                "counterparty {counterparty} is blocked"
+            )));
+        }
+
+        if !matches!(peer_state, Some(LinkedPeerState::RecoveryRequired)) {
+            if let Some(existing) = self
+                .storage
+                .transaction(|tx| Ok(tx.encrypted_link_state(&counterparty)))
+                .await?
+            {
+                if existing.link_snapshot.is_some() {
+                    save_linked_peer_state_with_lease(
                         &self.storage,
                         counterparty.clone(),
+                        LinkedPeerState::Linked,
                         lease.clone(),
                         self.clock.now(),
                     )
                     .await?;
-                    return Err(PaykitSdkError::RecoveryRequired(format!(
-                        "missing Encrypted Link Handshake role for counterparty {counterparty}"
-                    )));
+                    return Ok(LinkedPeerHandshakeReport {
+                        counterparty,
+                        state: LinkedPeerState::Linked,
+                        generation: existing.generation,
+                        handshake_role: None,
+                    });
                 }
-                save_linked_peer_state_with_lease(
-                    &self.storage,
-                    counterparty.clone(),
-                    LinkedPeerState::Linking,
-                    lease.clone(),
-                    self.clock.now(),
-                )
-                .await?;
-                return Ok(LinkedPeerHandshakeReport {
-                    counterparty,
-                    state: LinkedPeerState::Linking,
-                    generation: existing.generation,
-                    handshake_role: existing.handshake_role,
-                });
+                if existing.handshake_snapshot.is_some() {
+                    if existing.handshake_role.is_none() {
+                        let mark = mark_recovery_required_with_lease(
+                            &self.storage,
+                            counterparty.clone(),
+                            lease.clone(),
+                            self.clock.now(),
+                        )
+                        .await?;
+                        self.publish_local_recovery_marker_if_possible(
+                            &counterparty,
+                            mark.new_episode,
+                        )
+                        .await;
+                        return Err(PaykitSdkError::RecoveryRequired(format!(
+                            "missing Encrypted Link Handshake role for counterparty {counterparty}"
+                        )));
+                    }
+                    save_linked_peer_state_with_lease(
+                        &self.storage,
+                        counterparty.clone(),
+                        LinkedPeerState::Linking,
+                        lease.clone(),
+                        self.clock.now(),
+                    )
+                    .await?;
+                    return Ok(LinkedPeerHandshakeReport {
+                        counterparty,
+                        state: LinkedPeerState::Linking,
+                        generation: existing.generation,
+                        handshake_role: existing.handshake_role,
+                    });
+                }
             }
         }
 
@@ -2030,17 +2804,76 @@ where
                 .await
             }
             paykit_lib::HandshakeProgress::Complete(link) => {
-                save_linked_peer_link_state_if_generation_with_lease(
+                let report = save_linked_peer_link_state_if_generation_with_lease(
                     &self.storage,
-                    counterparty,
+                    counterparty.clone(),
                     link.serialize(),
                     expected_generation,
                     lease,
                     self.clock.now(),
                 )
-                .await
+                .await?;
+                self.remove_local_recovery_marker_if_recorded(&counterparty)
+                    .await;
+                Ok(report)
             }
         }
+    }
+
+    async fn remove_local_recovery_marker_if_recorded(&self, counterparty: &PubkyPublicKey) {
+        if self.config.encrypted_link_recovery_markers
+            == EncryptedLinkRecoveryMarkerPolicy::Disabled
+        {
+            return;
+        }
+        let has_local_marker = self
+            .storage
+            .transaction(|tx| {
+                Ok(tx
+                    .linked_peer(counterparty)
+                    .and_then(|peer| peer.local_recovery_attempt_id)
+                    .is_some())
+            })
+            .await
+            .unwrap_or(false);
+        if !has_local_marker {
+            return;
+        }
+
+        let Ok(Some(session_access)) = self.pubky.load_session_access().await else {
+            return;
+        };
+        let Some(secret_key) = session_access
+            .local_secret_key
+            .as_ref()
+            .map(|key| key.as_bytes())
+        else {
+            return;
+        };
+        let Ok(remote_public_key) = counterparty.to_public_key() else {
+            return;
+        };
+        if paykit_lib::remove_encrypted_link_recovery_marker(
+            &session_access.session,
+            secret_key,
+            &remote_public_key,
+        )
+        .await
+        .is_err()
+        {
+            return;
+        }
+        let _ = self
+            .storage
+            .transaction(|tx| {
+                if let Some(mut peer) = tx.linked_peer(counterparty) {
+                    peer.local_recovery_attempt_id = None;
+                    peer.local_recovery_marker_created_at = None;
+                    tx.save_linked_peer(peer);
+                }
+                Ok(())
+            })
+            .await;
     }
 
     async fn private_link_session_access(&self) -> Result<(PubkySessionAccess, [u8; 32])> {
@@ -2091,11 +2924,54 @@ fn should_mark_link_recovery_required(err: &PaykitSdkError) -> bool {
     )
 }
 
+fn recovery_peer_or_default(
+    peer: Option<LinkedPeerRecord>,
+    counterparty: &PubkyPublicKey,
+) -> LinkedPeerRecord {
+    peer.unwrap_or_else(|| LinkedPeerRecord {
+        counterparty: counterparty.clone(),
+        state: LinkedPeerState::Unknown,
+        last_sync_at: None,
+        last_private_receive_at: None,
+        failure_count: 0,
+        local_recovery_attempt_id: None,
+        local_recovery_marker_created_at: None,
+        remote_recovery_attempt_id: None,
+        remote_recovery_marker_observed_at: None,
+    })
+}
+
+fn can_publish_recovery_marker(peer: Option<&LinkedPeerRecord>, has_link_state: bool) -> bool {
+    has_link_state
+        || peer.is_some_and(|peer| {
+            matches!(
+                peer.state,
+                LinkedPeerState::Linking
+                    | LinkedPeerState::Linked
+                    | LinkedPeerState::RecoveryRequired
+            )
+        })
+}
+
+fn local_recovery_marker_belongs_to_current_episode(peer: &LinkedPeerRecord) -> bool {
+    let Some(created_at) = peer.local_recovery_marker_created_at else {
+        return false;
+    };
+    peer.last_sync_at
+        .map(|recovery_started_at| created_at >= recovery_started_at)
+        .unwrap_or(true)
+}
+
 enum PrivateRecoveryOutcome {
     NotNeeded,
     Pending,
     PublicOnly,
     Refreshed(Vec<PaymentEndpointCandidate>),
+}
+
+enum RecoveryRequiredUpdate {
+    Skipped,
+    Marked { new_episode: bool },
 }
 
 fn payable_resolution(
@@ -2195,6 +3071,49 @@ fn reservation_release(
     }
 }
 
+async fn fetch_public_text(
+    storage: &pubky::PublicStorage,
+    public_key: &PubkyPublicKey,
+    path: &str,
+    context: &'static str,
+) -> Result<Option<String>> {
+    let addr = format!("{public_key}{path}");
+    match storage.get(addr).await {
+        Ok(resp) => {
+            let bytes = resp
+                .bytes()
+                .await
+                .map_err(|err| PaykitSdkError::Transport {
+                    context: context.into(),
+                    source: Some(err.into()),
+                })?;
+            if bytes.is_empty() {
+                return Ok(None);
+            }
+            String::from_utf8(bytes.to_vec())
+                .map(Some)
+                .map_err(|err| PaykitSdkError::Protocol(format!("{context}: invalid UTF-8: {err}")))
+        }
+        Err(err) if is_pubky_not_found(&err) => Ok(None),
+        Err(err) => Err(map_pubky_transport_error(context, err)),
+    }
+}
+
+fn map_pubky_transport_error(context: &'static str, err: PubkyError) -> PaykitSdkError {
+    PaykitSdkError::Transport {
+        context: context.into(),
+        source: Some(err.into()),
+    }
+}
+
+fn is_pubky_not_found(err: &PubkyError) -> bool {
+    matches!(
+        err,
+        PubkyError::Request(RequestError::Server { status, .. })
+            if *status == StatusCode::NOT_FOUND || *status == StatusCode::GONE
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
@@ -2235,6 +3154,13 @@ mod tests {
     impl PubkySessionProvider for TestPubkySessionProvider {
         async fn load_session_access(&self) -> Result<Option<PubkySessionAccess>> {
             Ok(self.session.clone())
+        }
+
+        async fn load_public_storage(&self) -> Result<Option<pubky::PublicStorage>> {
+            Ok(self
+                .session
+                .as_ref()
+                .map(|session_access| session_access.outbox_client.public_storage()))
         }
 
         async fn clear_session_access(&self) -> Result<()> {
@@ -2547,6 +3473,10 @@ mod tests {
                         last_sync_at: Some(FixedClock.now()),
                         last_private_receive_at: None,
                         failure_count: 0,
+                        local_recovery_attempt_id: None,
+                        local_recovery_marker_created_at: None,
+                        remote_recovery_attempt_id: None,
+                        remote_recovery_marker_observed_at: None,
                     });
                     tx.save_public_endpoint_record(crate::PublicEndpointRecord {
                         identifier: "btc-lightning-bolt11".into(),
@@ -2554,6 +3484,19 @@ mod tests {
                         status: EndpointPublicationStatus::Published,
                         updated_at: FixedClock.now(),
                         last_error: None,
+                    });
+                    tx.save_contact_record(ContactRecord {
+                        public_key: counterparty.clone(),
+                        label: Some("Alice".into()),
+                        profile: None,
+                        profile_fetched_at: None,
+                        created_at: FixedClock.now(),
+                        updated_at: FixedClock.now(),
+                        public_contact_marker_status:
+                            crate::PublicContactMarkerStatus::NotPublished,
+                        public_contact_published_at: None,
+                        public_contact_removed_at: None,
+                        public_contact_last_error: None,
                     });
                     tx.insert_outbound_private_message(
                         crate::storage::NewOutboundPrivateMessage::new(
@@ -2582,8 +3525,333 @@ mod tests {
         let identity = snapshot.identity_state.unwrap();
         assert_eq!(identity.sign_out_generation, 4);
         assert!(snapshot.linked_peers.is_empty());
+        assert!(snapshot.contact_records.is_empty());
         assert!(snapshot.public_endpoint_records.is_empty());
         assert!(snapshot.outbound_private_messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_contact_records_save_list_and_remove_locally() {
+        let storage = InMemoryStorage::new();
+        let local_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let contact_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        storage
+            .save_identity_state(IdentityState {
+                public_key: Some(local_public_key),
+                capability: PubkyIdentityCapability::PublicOnly,
+                local_secret_available: false,
+                initialized_at: FixedClock.now(),
+                sign_out_generation: 0,
+            })
+            .await
+            .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let saved = sdk
+            .save_contact(ContactUpdate {
+                public_key: contact_public_key.clone(),
+                label: Some("Alice".into()),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(saved.label.as_deref(), Some("Alice"));
+        assert_eq!(sdk.contact_records().await.unwrap(), vec![saved.clone()]);
+        assert_eq!(
+            sdk.contact_record(&contact_public_key).await.unwrap(),
+            Some(saved.clone())
+        );
+        assert_eq!(
+            sdk.remove_contact(&contact_public_key).await.unwrap(),
+            Some(saved)
+        );
+        assert!(sdk
+            .contact_record(&contact_public_key)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_save_contact_empty_label_clears_existing_label() {
+        let storage = InMemoryStorage::new();
+        let local_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let contact_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        storage
+            .save_identity_state(IdentityState {
+                public_key: Some(local_public_key),
+                capability: PubkyIdentityCapability::PublicOnly,
+                local_secret_available: false,
+                initialized_at: FixedClock.now(),
+                sign_out_generation: 0,
+            })
+            .await
+            .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage,
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        sdk.save_contact(ContactUpdate {
+            public_key: contact_public_key.clone(),
+            label: Some("Alice".into()),
+        })
+        .await
+        .unwrap();
+        let updated = sdk
+            .save_contact(ContactUpdate {
+                public_key: contact_public_key,
+                label: Some(String::new()),
+            })
+            .await
+            .unwrap();
+
+        assert!(updated.label.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_remove_contact_blocks_when_public_marker_may_exist() {
+        let storage = InMemoryStorage::new();
+        let local_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let contact_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        storage
+            .save_identity_state(IdentityState {
+                public_key: Some(local_public_key),
+                capability: PubkyIdentityCapability::PublicOnly,
+                local_secret_available: false,
+                initialized_at: FixedClock.now(),
+                sign_out_generation: 0,
+            })
+            .await
+            .unwrap();
+        storage
+            .transaction({
+                let contact_public_key = contact_public_key.clone();
+                move |tx| {
+                    tx.save_contact_record(ContactRecord {
+                        public_key: contact_public_key,
+                        label: None,
+                        profile: None,
+                        profile_fetched_at: None,
+                        created_at: FixedClock.now(),
+                        updated_at: FixedClock.now(),
+                        public_contact_marker_status: crate::PublicContactMarkerStatus::Published,
+                        public_contact_published_at: Some(FixedClock.now()),
+                        public_contact_removed_at: None,
+                        public_contact_last_error: None,
+                    });
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage,
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let result = sdk.remove_contact(&contact_public_key).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    }
+
+    #[tokio::test]
+    async fn test_publish_public_contact_does_not_mark_pending_without_session() {
+        let storage = InMemoryStorage::new();
+        let local_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let contact_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        storage
+            .save_identity_state(IdentityState {
+                public_key: Some(local_public_key),
+                capability: PubkyIdentityCapability::PublicOnly,
+                local_secret_available: false,
+                initialized_at: FixedClock.now(),
+                sign_out_generation: 0,
+            })
+            .await
+            .unwrap();
+        storage
+            .transaction({
+                let contact_public_key = contact_public_key.clone();
+                move |tx| {
+                    tx.save_contact_record(ContactRecord {
+                        public_key: contact_public_key,
+                        label: None,
+                        profile: None,
+                        profile_fetched_at: None,
+                        created_at: FixedClock.now(),
+                        updated_at: FixedClock.now(),
+                        public_contact_marker_status:
+                            crate::PublicContactMarkerStatus::NotPublished,
+                        public_contact_published_at: None,
+                        public_contact_removed_at: None,
+                        public_contact_last_error: None,
+                    });
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig {
+                public_contact_sharing: PublicContactSharingPolicy::PublicPaykitNamespace,
+                ..PaykitSdkConfig::default()
+            },
+            FixedClock,
+        );
+
+        let result = sdk.publish_public_contact(contact_public_key.clone()).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+        let record = storage
+            .snapshot()
+            .unwrap()
+            .contact_records
+            .get(&contact_public_key)
+            .unwrap()
+            .clone();
+        assert_eq!(
+            record.public_contact_marker_status,
+            crate::PublicContactMarkerStatus::NotPublished
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_public_contact_cleanup_is_allowed_when_sharing_disabled() {
+        let storage = InMemoryStorage::new();
+        let local_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let contact_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        storage
+            .save_identity_state(IdentityState {
+                public_key: Some(local_public_key),
+                capability: PubkyIdentityCapability::PublicOnly,
+                local_secret_available: false,
+                initialized_at: FixedClock.now(),
+                sign_out_generation: 0,
+            })
+            .await
+            .unwrap();
+        storage
+            .transaction({
+                let contact_public_key = contact_public_key.clone();
+                move |tx| {
+                    tx.save_contact_record(ContactRecord {
+                        public_key: contact_public_key,
+                        label: None,
+                        profile: None,
+                        profile_fetched_at: None,
+                        created_at: FixedClock.now(),
+                        updated_at: FixedClock.now(),
+                        public_contact_marker_status: crate::PublicContactMarkerStatus::Published,
+                        public_contact_published_at: Some(FixedClock.now()),
+                        public_contact_removed_at: None,
+                        public_contact_last_error: None,
+                    });
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let result = sdk.remove_public_contact(contact_public_key.clone()).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+        let record = storage
+            .snapshot()
+            .unwrap()
+            .contact_records
+            .get(&contact_public_key)
+            .unwrap()
+            .clone();
+        assert_eq!(
+            record.public_contact_marker_status,
+            crate::PublicContactMarkerStatus::Published
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_public_contact_without_local_record_still_requires_session() {
+        let storage = InMemoryStorage::new();
+        let local_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let contact_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        storage
+            .save_identity_state(IdentityState {
+                public_key: Some(local_public_key),
+                capability: PubkyIdentityCapability::PublicOnly,
+                local_secret_available: false,
+                initialized_at: FixedClock.now(),
+                sign_out_generation: 0,
+            })
+            .await
+            .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage,
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let result = sdk.remove_public_contact(contact_public_key).await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_save_contact_requires_initialized_identity() {
+        let storage = InMemoryStorage::new();
+        let sdk = PaykitSdk::with_clock(
+            storage,
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+        let contact_public_key =
+            PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+
+        let result = sdk
+            .save_contact(ContactUpdate {
+                public_key: contact_public_key,
+                label: None,
+            })
+            .await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
     }
 
     #[tokio::test]
@@ -3044,7 +4312,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_accept_payment_request_checks_lifecycle_before_send_readiness() {
+    async fn test_accept_payment_request_does_not_queue_without_private_send_readiness() {
         let storage = InMemoryStorage::new();
         let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
         let request_id = PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap();
@@ -3147,44 +4415,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_initiate_link_with_peer_requires_identity_before_block_policy() {
+    async fn test_recovery_required_peer_allows_relink_attempt() {
         let storage = InMemoryStorage::new();
         let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
         crate::linked_peers::save_linked_peer_state(
             &storage,
             counterparty.clone(),
-            LinkedPeerState::Blocked,
+            LinkedPeerState::RecoveryRequired,
             FixedClock.now(),
         )
         .await
         .unwrap();
-        let sdk = PaykitSdk::with_clock(
-            storage,
-            TestPubkySessionProvider { session: None },
-            TestPaymentAdapter,
-            PaykitSdkConfig::default(),
-            FixedClock,
-        );
-
-        let result = sdk.initiate_link_with_peer(counterparty).await;
-
-        assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
-    }
-
-    #[tokio::test]
-    async fn test_initiate_link_with_peer_requires_identity_before_peer_lease() {
-        let storage = InMemoryStorage::new();
-        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
-        storage
+        let lease = storage
             .transaction({
                 let counterparty = counterparty.clone();
                 move |tx| {
-                    tx.claim_peer_link_operation(
-                        &counterparty,
-                        FixedClock.now(),
-                        FixedClock.now() + chrono::Duration::seconds(60),
-                    );
-                    Ok(())
+                    Ok(tx
+                        .claim_peer_link_operation(
+                            &counterparty,
+                            FixedClock.now(),
+                            FixedClock.now() + chrono::Duration::seconds(60),
+                        )
+                        .unwrap())
                 }
             })
             .await
@@ -3197,13 +4449,19 @@ mod tests {
             FixedClock,
         );
 
-        let result = sdk.initiate_link_with_peer(counterparty).await;
+        let result = sdk
+            .start_link_handshake_with_claim(
+                counterparty,
+                EncryptedLinkHandshakeRole::Initiator,
+                lease,
+            )
+            .await;
 
         assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
     }
 
     #[tokio::test]
-    async fn test_advance_link_handshake_clears_untrusted_missing_snapshot_state() {
+    async fn test_advance_link_handshake_clears_unusable_link_state() {
         let storage = InMemoryStorage::new();
         let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
         storage
@@ -3241,7 +4499,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_advance_link_handshake_clears_untrusted_state_without_session() {
+    async fn test_advance_link_handshake_clears_unusable_handshake_snapshot() {
         let storage = InMemoryStorage::new();
         let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
         storage
@@ -3279,7 +4537,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_advance_link_handshake_clears_untrusted_missing_role_state() {
+    async fn test_advance_link_handshake_clears_unusable_handshake_metadata() {
         let storage = InMemoryStorage::new();
         let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
         storage
@@ -3406,6 +4664,7 @@ mod tests {
                 sign_out_generation: 0,
             }),
             linked_peers: Vec::new(),
+            contact_records: Vec::new(),
             public_endpoint_records: Vec::new(),
             payment_endpoint_reservations: Vec::new(),
             encrypted_link_states: Vec::new(),
@@ -3494,6 +4753,10 @@ mod tests {
                         last_sync_at: Some(FixedClock.now()),
                         last_private_receive_at: None,
                         failure_count: 0,
+                        local_recovery_attempt_id: None,
+                        local_recovery_marker_created_at: None,
+                        remote_recovery_attempt_id: None,
+                        remote_recovery_marker_observed_at: None,
                     });
                     Ok(())
                 }
@@ -3530,6 +4793,10 @@ mod tests {
                         last_sync_at: Some(FixedClock.now()),
                         last_private_receive_at: None,
                         failure_count: 0,
+                        local_recovery_attempt_id: None,
+                        local_recovery_marker_created_at: None,
+                        remote_recovery_attempt_id: None,
+                        remote_recovery_marker_observed_at: None,
                     });
                     tx.save_encrypted_link_state(EncryptedLinkStateRecord {
                         counterparty,
@@ -3552,9 +4819,11 @@ mod tests {
             FixedClock,
         );
 
-        sdk.mark_private_recovery_pending(&counterparty, Some(1))
+        let recovery_update = sdk
+            .mark_private_recovery_pending(&counterparty, Some(1))
             .await
             .unwrap();
+        assert!(matches!(recovery_update, RecoveryRequiredUpdate::Skipped));
 
         let peer = crate::load_linked_peer(&storage, &counterparty)
             .await
@@ -3562,9 +4831,14 @@ mod tests {
             .unwrap();
         assert_eq!(peer.state, LinkedPeerState::Linked);
 
-        sdk.mark_private_recovery_pending(&counterparty, Some(2))
+        let recovery_update = sdk
+            .mark_private_recovery_pending(&counterparty, Some(2))
             .await
             .unwrap();
+        assert!(matches!(
+            recovery_update,
+            RecoveryRequiredUpdate::Marked { new_episode: true }
+        ));
 
         let peer = crate::load_linked_peer(&storage, &counterparty)
             .await
@@ -3577,5 +4851,213 @@ mod tests {
             .unwrap();
         assert!(link_state.link_snapshot.is_none());
         assert_eq!(link_state.generation, 3);
+    }
+
+    #[tokio::test]
+    async fn test_encrypted_link_recovery_marker_status_reports_peer_fields() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| {
+                    tx.save_linked_peer(crate::LinkedPeerRecord {
+                        counterparty,
+                        state: LinkedPeerState::RecoveryRequired,
+                        last_sync_at: Some(FixedClock.now()),
+                        last_private_receive_at: None,
+                        failure_count: 1,
+                        local_recovery_attempt_id: Some(
+                            "650e8400-e29b-41d4-a716-446655440000".into(),
+                        ),
+                        local_recovery_marker_created_at: Some(FixedClock.now()),
+                        remote_recovery_attempt_id: Some(
+                            "550e8400-e29b-41d4-a716-446655440000".into(),
+                        ),
+                        remote_recovery_marker_observed_at: Some(FixedClock.now()),
+                    });
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage,
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let status = sdk
+            .encrypted_link_recovery_marker_status(&counterparty)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(status.state, LinkedPeerState::RecoveryRequired);
+        assert_eq!(
+            status.local_attempt_id.as_deref(),
+            Some("650e8400-e29b-41d4-a716-446655440000")
+        );
+        assert_eq!(
+            status.remote_attempt_id.as_deref(),
+            Some("550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert!(!status.remote_marker_changed);
+    }
+
+    #[tokio::test]
+    async fn test_mark_private_recovery_pending_preserves_marker_until_publish() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| {
+                    tx.save_linked_peer(crate::LinkedPeerRecord {
+                        counterparty: counterparty.clone(),
+                        state: LinkedPeerState::Linked,
+                        last_sync_at: Some(FixedClock.now()),
+                        last_private_receive_at: None,
+                        failure_count: 0,
+                        local_recovery_attempt_id: Some(
+                            "650e8400-e29b-41d4-a716-446655440000".into(),
+                        ),
+                        local_recovery_marker_created_at: Some(FixedClock.now()),
+                        remote_recovery_attempt_id: Some(
+                            "550e8400-e29b-41d4-a716-446655440000".into(),
+                        ),
+                        remote_recovery_marker_observed_at: Some(FixedClock.now()),
+                    });
+                    tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                        counterparty,
+                        link_snapshot: Some(vec![4, 5, 6]),
+                        handshake_snapshot: None,
+                        handshake_role: None,
+                        generation: 2,
+                        checkpointed_at: FixedClock.now(),
+                    });
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let recovery_update = sdk
+            .mark_private_recovery_pending(&counterparty, Some(2))
+            .await
+            .unwrap();
+        assert!(matches!(
+            recovery_update,
+            RecoveryRequiredUpdate::Marked { new_episode: true }
+        ));
+
+        let peer = crate::load_linked_peer(&storage, &counterparty)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(peer.state, LinkedPeerState::RecoveryRequired);
+        assert_eq!(
+            peer.local_recovery_attempt_id.as_deref(),
+            Some("650e8400-e29b-41d4-a716-446655440000")
+        );
+        assert_eq!(
+            peer.remote_recovery_attempt_id.as_deref(),
+            Some("550e8400-e29b-41d4-a716-446655440000")
+        );
+    }
+
+    #[test]
+    fn test_local_recovery_marker_must_belong_to_current_episode() {
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        let recovery_started_at = Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap();
+        let previous_episode_marker_at = Utc.with_ymd_and_hms(2026, 6, 3, 11, 59, 0).unwrap();
+        let current_episode_marker_at = Utc.with_ymd_and_hms(2026, 6, 3, 12, 1, 0).unwrap();
+        let mut peer = crate::LinkedPeerRecord {
+            counterparty,
+            state: LinkedPeerState::RecoveryRequired,
+            last_sync_at: Some(recovery_started_at),
+            last_private_receive_at: None,
+            failure_count: 1,
+            local_recovery_attempt_id: Some("650e8400-e29b-41d4-a716-446655440000".into()),
+            local_recovery_marker_created_at: Some(previous_episode_marker_at),
+            remote_recovery_attempt_id: None,
+            remote_recovery_marker_observed_at: None,
+        };
+
+        assert!(!local_recovery_marker_belongs_to_current_episode(&peer));
+
+        peer.local_recovery_marker_created_at = Some(current_episode_marker_at);
+
+        assert!(local_recovery_marker_belongs_to_current_episode(&peer));
+    }
+
+    #[tokio::test]
+    async fn test_mark_private_recovery_pending_preserves_ongoing_local_marker() {
+        let storage = InMemoryStorage::new();
+        let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+        storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| {
+                    tx.save_linked_peer(crate::LinkedPeerRecord {
+                        counterparty: counterparty.clone(),
+                        state: LinkedPeerState::RecoveryRequired,
+                        last_sync_at: Some(FixedClock.now()),
+                        last_private_receive_at: None,
+                        failure_count: 1,
+                        local_recovery_attempt_id: Some(
+                            "650e8400-e29b-41d4-a716-446655440000".into(),
+                        ),
+                        local_recovery_marker_created_at: Some(FixedClock.now()),
+                        remote_recovery_attempt_id: None,
+                        remote_recovery_marker_observed_at: None,
+                    });
+                    tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                        counterparty,
+                        link_snapshot: Some(vec![4, 5, 6]),
+                        handshake_snapshot: None,
+                        handshake_role: None,
+                        generation: 2,
+                        checkpointed_at: FixedClock.now(),
+                    });
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+        let sdk = PaykitSdk::with_clock(
+            storage.clone(),
+            TestPubkySessionProvider { session: None },
+            TestPaymentAdapter,
+            PaykitSdkConfig::default(),
+            FixedClock,
+        );
+
+        let recovery_update = sdk
+            .mark_private_recovery_pending(&counterparty, Some(2))
+            .await
+            .unwrap();
+        assert!(matches!(
+            recovery_update,
+            RecoveryRequiredUpdate::Marked { new_episode: false }
+        ));
+
+        let peer = crate::load_linked_peer(&storage, &counterparty)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            peer.local_recovery_attempt_id.as_deref(),
+            Some("650e8400-e29b-41d4-a716-446655440000")
+        );
     }
 }

--- a/paykit-sdk/src/storage.rs
+++ b/paykit-sdk/src/storage.rs
@@ -6,10 +6,12 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use paykit_lib::PrivateMessageKind;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     backup::ValidatedStorageState,
+    contacts::ContactRecord,
     endpoints::EndpointPublicationStatus,
     identity::{IdentityState, PubkyPublicKey},
     linked_peers::LinkedPeerState,
@@ -68,6 +70,18 @@ pub trait StorageTransaction {
 
     /// Save one Linked Peer record.
     fn save_linked_peer(&mut self, record: LinkedPeerRecord);
+
+    /// List local contact records.
+    fn contact_records(&self) -> Vec<ContactRecord>;
+
+    /// Load one local contact record.
+    fn contact_record(&self, public_key: &PubkyPublicKey) -> Option<ContactRecord>;
+
+    /// Save one local contact record.
+    fn save_contact_record(&mut self, record: ContactRecord);
+
+    /// Remove one local contact record.
+    fn remove_contact_record(&mut self, public_key: &PubkyPublicKey) -> Option<ContactRecord>;
 
     /// List SDK-managed public Payment Endpoint records.
     fn public_endpoint_records(&self) -> Vec<PublicEndpointRecord>;
@@ -135,7 +149,11 @@ pub trait StorageTransaction {
         counterparty: &PubkyPublicKey,
     ) -> Vec<OutboundPrivateMessageRecord>;
 
-    /// Claim the next outbound private message for sending, preserving FIFO.
+    /// Claim the next outbound private message for sending.
+    ///
+    /// Event Messages are claimed FIFO. Private Payment Lists are Latest-State
+    /// Messages, so older claimable unsent lists should be marked
+    /// [`OutboundPrivateMessageStatus::Superseded`] before claiming.
     fn claim_next_outbound_private_message(
         &mut self,
         counterparty: &PubkyPublicKey,
@@ -198,6 +216,14 @@ pub struct LinkedPeerRecord {
     pub last_private_receive_at: Option<DateTime<Utc>>,
     /// Consecutive failure count for recovery/retry policy.
     pub failure_count: u32,
+    /// Locally published Encrypted Link recovery attempt id.
+    pub local_recovery_attempt_id: Option<String>,
+    /// Creation time for the local recovery marker payload.
+    pub local_recovery_marker_created_at: Option<DateTime<Utc>>,
+    /// Latest counterparty recovery attempt id already observed.
+    pub remote_recovery_attempt_id: Option<String>,
+    /// Time the counterparty recovery marker was observed.
+    pub remote_recovery_marker_observed_at: Option<DateTime<Utc>>,
 }
 
 /// Durable SDK-managed public Payment Endpoint publication record.
@@ -626,12 +652,14 @@ pub struct EventDedupRecord {
 }
 
 /// Logical SDK storage state used by snapshots, tests, and backup/restore.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct StorageState {
     /// Current identity state.
     pub identity_state: Option<IdentityState>,
     /// Linked Peer records by counterparty.
     pub linked_peers: HashMap<PubkyPublicKey, LinkedPeerRecord>,
+    /// Local contact records by public key.
+    pub contact_records: HashMap<PubkyPublicKey, ContactRecord>,
     /// SDK-managed public endpoint records by identifier.
     pub public_endpoint_records: HashMap<String, PublicEndpointRecord>,
     /// SDK-managed Payment Endpoint Reservation records by counterparty and reservation id.
@@ -659,6 +687,74 @@ pub struct StorageState {
     pub receipt_access_records: HashMap<(PubkyPublicKey, String), ReceiptAccessRecord>,
     /// Decrypted Receipt records by issuer and Receipt ID.
     pub receipt_records: HashMap<(PubkyPublicKey, String), ReceiptRecord>,
+}
+
+impl fmt::Debug for StorageState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StorageState")
+            .field(
+                "identity_state",
+                &self.identity_state.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "linked_peers",
+                &format_args!("{} records", self.linked_peers.len()),
+            )
+            .field(
+                "contact_records",
+                &format_args!("{} records", self.contact_records.len()),
+            )
+            .field(
+                "public_endpoint_records",
+                &format_args!("{} records", self.public_endpoint_records.len()),
+            )
+            .field(
+                "payment_endpoint_reservations",
+                &format_args!("{} records", self.payment_endpoint_reservations.len()),
+            )
+            .field(
+                "encrypted_link_states",
+                &format_args!("{} records", self.encrypted_link_states.len()),
+            )
+            .field(
+                "peer_link_operation_leases",
+                &format_args!("{} records", self.peer_link_operation_leases.len()),
+            )
+            .field(
+                "next_peer_link_operation_lease_id",
+                &self.next_peer_link_operation_lease_id,
+            )
+            .field(
+                "outbound_private_messages",
+                &format_args!("{} records", self.outbound_private_messages.len()),
+            )
+            .field(
+                "next_outbound_private_message_id",
+                &self.next_outbound_private_message_id,
+            )
+            .field(
+                "private_stream_items",
+                &format_args!("{} records", self.private_stream_items.len()),
+            )
+            .field("next_receive_batch_id", &self.next_receive_batch_id)
+            .field(
+                "next_private_stream_item_id",
+                &self.next_private_stream_item_id,
+            )
+            .field(
+                "event_dedup_records",
+                &format_args!("{} records", self.event_dedup_records.len()),
+            )
+            .field(
+                "receipt_access_records",
+                &format_args!("{} records", self.receipt_access_records.len()),
+            )
+            .field(
+                "receipt_records",
+                &format_args!("{} records", self.receipt_records.len()),
+            )
+            .finish()
+    }
 }
 
 /// In-memory SDK storage implementation for tests and examples.
@@ -732,6 +828,7 @@ impl StorageTransaction for InMemoryStorageTransaction {
 
     fn clear_identity_scoped_state(&mut self) {
         self.clear_private_identity_scoped_state();
+        self.state.contact_records.clear();
         self.state.public_endpoint_records.clear();
     }
 
@@ -755,6 +852,31 @@ impl StorageTransaction for InMemoryStorageTransaction {
         self.state
             .linked_peers
             .insert(record.counterparty.clone(), record);
+    }
+
+    fn contact_records(&self) -> Vec<ContactRecord> {
+        let mut records = self
+            .state
+            .contact_records
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by(|left, right| left.public_key.as_str().cmp(right.public_key.as_str()));
+        records
+    }
+
+    fn contact_record(&self, public_key: &PubkyPublicKey) -> Option<ContactRecord> {
+        self.state.contact_records.get(public_key).cloned()
+    }
+
+    fn save_contact_record(&mut self, record: ContactRecord) {
+        self.state
+            .contact_records
+            .insert(record.public_key.clone(), record);
+    }
+
+    fn remove_contact_record(&mut self, public_key: &PubkyPublicKey) -> Option<ContactRecord> {
+        self.state.contact_records.remove(public_key)
     }
 
     fn public_endpoint_records(&self) -> Vec<PublicEndpointRecord> {
@@ -918,6 +1040,8 @@ impl StorageTransaction for InMemoryStorageTransaction {
         now: DateTime<Utc>,
         stale_before: DateTime<Utc>,
     ) -> Option<OutboundPrivateMessageRecord> {
+        supersede_outdated_private_payment_lists(&mut self.state, counterparty, now, stale_before);
+
         let mut indexes = self
             .state
             .outbound_private_messages
@@ -927,7 +1051,9 @@ impl StorageTransaction for InMemoryStorageTransaction {
                 &message.counterparty == counterparty
                     && !matches!(
                         message.status,
-                        OutboundPrivateMessageStatus::Sent | OutboundPrivateMessageStatus::Invalid
+                        OutboundPrivateMessageStatus::Sent
+                            | OutboundPrivateMessageStatus::Invalid
+                            | OutboundPrivateMessageStatus::Superseded
                     )
             })
             .map(|(index, message)| (index, message.outbound_message_id))
@@ -1059,7 +1185,46 @@ fn is_claimable_outbound_private_message(
             Some(last_attempt_at) => last_attempt_at <= stale_before,
             None => true,
         },
-        OutboundPrivateMessageStatus::Sent | OutboundPrivateMessageStatus::Invalid => false,
+        OutboundPrivateMessageStatus::Sent
+        | OutboundPrivateMessageStatus::Invalid
+        | OutboundPrivateMessageStatus::Superseded => false,
+    }
+}
+
+fn supersede_outdated_private_payment_lists(
+    state: &mut StorageState,
+    counterparty: &PubkyPublicKey,
+    now: DateTime<Utc>,
+    stale_before: DateTime<Utc>,
+) {
+    let latest_private_list_id = state
+        .outbound_private_messages
+        .iter()
+        .filter(|message| {
+            &message.counterparty == counterparty
+                && message.kind == PrivateMessageKind::PrivatePaymentList.as_str()
+                && !matches!(
+                    message.status,
+                    OutboundPrivateMessageStatus::Invalid
+                        | OutboundPrivateMessageStatus::Superseded
+                )
+        })
+        .map(|message| message.outbound_message_id)
+        .max();
+    let Some(latest_private_list_id) = latest_private_list_id else {
+        return;
+    };
+
+    for message in state.outbound_private_messages.iter_mut() {
+        if &message.counterparty == counterparty
+            && message.kind == PrivateMessageKind::PrivatePaymentList.as_str()
+            && message.outbound_message_id < latest_private_list_id
+            && is_claimable_outbound_private_message(message, stale_before)
+        {
+            message.status = OutboundPrivateMessageStatus::Superseded;
+            message.updated_at = now;
+            message.last_error = None;
+        }
     }
 }
 
@@ -1096,6 +1261,15 @@ mod tests {
             counterparty,
             "paykit.private_payment_list".into(),
             r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#.into(),
+            timestamp(),
+        )
+    }
+
+    fn outbound_payment_request_message(counterparty: PubkyPublicKey) -> NewOutboundPrivateMessage {
+        NewOutboundPrivateMessage::new(
+            counterparty,
+            "paykit.payment_request".into(),
+            r#"{"version":1,"kind":"paykit.payment_request","event_id":"650e8400-e29b-41d4-a716-446655440000","payment_request_id":"550e8400-e29b-41d4-a716-446655440000","request":{"payment_request_id":"550e8400-e29b-41d4-a716-446655440000","terms":{"amount":{"value":"1","asset":"btc"},"payment_reference":"invoice-2026-0001","proposal_expires_at":null,"recurrence":null,"accepted_payment_endpoint_identifiers":["btc-lightning-bolt11"],"metadata":{}}}}"#.into(),
             timestamp(),
         )
     }
@@ -1157,9 +1331,9 @@ mod tests {
 
     #[test]
     fn test_sensitive_storage_debug_is_redacted() {
-        let counterparty = counterparty();
+        let stream_counterparty = counterparty();
         let link_state = EncryptedLinkStateRecord {
-            counterparty: counterparty.clone(),
+            counterparty: stream_counterparty.clone(),
             link_snapshot: Some(vec![1, 2, 3]),
             handshake_snapshot: Some(vec![4, 5, 6]),
             handshake_role: None,
@@ -1168,12 +1342,12 @@ mod tests {
         };
         let outbound = OutboundPrivateMessageRecord::from_new(
             0,
-            outbound_private_message(counterparty.clone()),
+            outbound_private_message(stream_counterparty.clone()),
         );
         let stream = PrivateStreamItemRecord::from_new(
             0,
             NewPrivateStreamItem::new(NewPrivateStreamItemDetails {
-                counterparty,
+                counterparty: stream_counterparty,
                 receive_batch_id: 0,
                 raw_json: r#"{"key":"secret"}"#.into(),
                 parsed_version: Some(1),
@@ -1187,14 +1361,35 @@ mod tests {
         let receipt_access = receipt_access_record(stream.counterparty.clone());
         let receipt = receipt_record(receipt_access.counterparty.clone());
         let reservation = payment_endpoint_reservation_record(receipt_access.counterparty.clone());
+        let contact_public_key = counterparty();
+        let contact = ContactRecord {
+            public_key: contact_public_key.clone(),
+            label: Some("contact-secret".into()),
+            profile: Some(crate::PaykitProfile {
+                display_name: Some("profile-secret".into()),
+                image_uri: None,
+            }),
+            profile_fetched_at: Some(timestamp()),
+            created_at: timestamp(),
+            updated_at: timestamp(),
+            public_contact_marker_status: crate::PublicContactMarkerStatus::Published,
+            public_contact_published_at: Some(timestamp()),
+            public_contact_removed_at: None,
+            public_contact_last_error: Some("marker-secret".into()),
+        };
+        let storage_state = StorageState {
+            contact_records: HashMap::from([(contact_public_key.clone(), contact.clone())]),
+            ..StorageState::default()
+        };
 
         let debug = format!(
-            "{link_state:?} {outbound:?} {stream:?} {receipt_access:?} {receipt:?} {reservation:?}"
+            "{link_state:?} {outbound:?} {stream:?} {receipt_access:?} {receipt:?} {reservation:?} {contact:?} {storage_state:?}"
         );
         assert!(debug.contains("<redacted:"));
         assert!(!debug.contains("secret"));
         assert!(!debug.contains("receipt-secret"));
         assert!(!debug.contains("alice"));
+        assert!(!debug.contains(contact_public_key.as_str()));
         assert!(!debug.contains("[1, 2, 3]"));
     }
 
@@ -1213,6 +1408,10 @@ mod tests {
                         last_sync_at: Some(timestamp()),
                         last_private_receive_at: Some(timestamp()),
                         failure_count: 0,
+                        local_recovery_attempt_id: None,
+                        local_recovery_marker_created_at: None,
+                        remote_recovery_attempt_id: None,
+                        remote_recovery_marker_observed_at: None,
                     });
                     tx.save_public_endpoint_record(public_endpoint_record("btc-lightning-bolt11"));
                     tx.save_payment_endpoint_reservation(payment_endpoint_reservation_record(
@@ -1363,6 +1562,88 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_private_payment_list_queue_sends_only_latest_state() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+
+        let (first, second) = storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| {
+                    let first = tx.insert_outbound_private_message(outbound_private_message(
+                        counterparty.clone(),
+                    ));
+                    let second =
+                        tx.insert_outbound_private_message(outbound_private_message(counterparty));
+                    Ok((first, second))
+                }
+            })
+            .await
+            .unwrap();
+
+        let claimed = claim_next_outbound_private_message(
+            &storage,
+            &counterparty,
+            timestamp(),
+            timestamp() - chrono::Duration::seconds(60),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(claimed.outbound_message_id, second.outbound_message_id);
+        assert_eq!(claimed.status, OutboundPrivateMessageStatus::Sending);
+        let snapshot = storage.snapshot().unwrap();
+        let first = snapshot
+            .outbound_private_messages
+            .iter()
+            .find(|message| message.outbound_message_id == first.outbound_message_id)
+            .unwrap();
+        assert_eq!(first.status, OutboundPrivateMessageStatus::Superseded);
+    }
+
+    #[tokio::test]
+    async fn test_event_message_queue_preserves_fifo() {
+        let storage = InMemoryStorage::new();
+        let counterparty = counterparty();
+
+        let (first, second) = storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| {
+                    let first = tx.insert_outbound_private_message(
+                        outbound_payment_request_message(counterparty.clone()),
+                    );
+                    let second = tx.insert_outbound_private_message(
+                        outbound_payment_request_message(counterparty),
+                    );
+                    Ok((first, second))
+                }
+            })
+            .await
+            .unwrap();
+
+        let claimed = claim_next_outbound_private_message(
+            &storage,
+            &counterparty,
+            timestamp(),
+            timestamp() - chrono::Duration::seconds(60),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(claimed.outbound_message_id, first.outbound_message_id);
+        assert_eq!(claimed.status, OutboundPrivateMessageStatus::Sending);
+        let queued = queued_outbound_private_messages(&storage, &counterparty)
+            .await
+            .unwrap();
+        assert!(queued
+            .iter()
+            .any(|message| message.outbound_message_id == second.outbound_message_id));
+    }
+
+    #[tokio::test]
     async fn test_peer_link_operation_lease_blocks_until_released() {
         let storage = InMemoryStorage::new();
         let counterparty = counterparty();
@@ -1447,6 +1728,10 @@ mod tests {
                         last_sync_at: Some(timestamp()),
                         last_private_receive_at: None,
                         failure_count: 0,
+                        local_recovery_attempt_id: None,
+                        local_recovery_marker_created_at: None,
+                        remote_recovery_attempt_id: None,
+                        remote_recovery_marker_observed_at: None,
                     });
                     tx.save_public_endpoint_record(public_endpoint_record("btc-lightning-bolt11"));
                     tx.save_payment_endpoint_reservation(payment_endpoint_reservation_record(
@@ -1514,6 +1799,10 @@ mod tests {
                         last_sync_at: Some(timestamp()),
                         last_private_receive_at: None,
                         failure_count: 0,
+                        local_recovery_attempt_id: None,
+                        local_recovery_marker_created_at: None,
+                        remote_recovery_attempt_id: None,
+                        remote_recovery_marker_observed_at: None,
                     });
                     tx.save_public_endpoint_record(public_endpoint_record("btc-lightning-bolt11"));
                     tx.save_payment_endpoint_reservation(payment_endpoint_reservation_record(
@@ -1764,6 +2053,10 @@ mod tests {
                         last_sync_at: Some(timestamp()),
                         last_private_receive_at: None,
                         failure_count: 0,
+                        local_recovery_attempt_id: None,
+                        local_recovery_marker_created_at: None,
+                        remote_recovery_attempt_id: None,
+                        remote_recovery_marker_observed_at: None,
                     });
 
                     Err(PaykitSdkError::Storage {

--- a/specs/paykit-sdk.md
+++ b/specs/paykit-sdk.md
@@ -1,11 +1,8 @@
-# Paykit SDK Plan
-
-Status: implementation plan with initial Rust SDK foundation
-Date: 2026-06-04
+# Paykit SDK Architecture
 
 ## Goal
 
-Define the Paykit SDK layer that sits above Paykit Library.
+Describe the Paykit SDK layer that sits above Paykit Library.
 
 Paykit Library remains the stateless Rust implementation of Paykit Protocol
 wire formats, Pubky storage helpers, Encrypted Link transport helpers, and
@@ -64,7 +61,7 @@ only for low-level protocol operations.
 
 ## Crate Layout
 
-The initial implementation adds a new Rust crate:
+The SDK crate uses this layout:
 
 ```text
 paykit-sdk/
@@ -82,11 +79,13 @@ paykit-sdk/
     linked_peers.rs
     private_stream.rs
     private_lists.rs
+    payment_requests.rs
+    receipts.rs
     endpoint_reservations.rs
     backup.rs
 ```
 
-Suggested module responsibilities:
+Module responsibilities:
 
 - `runtime`: owns `PaykitSdk`, coordinates adapters, storage, and workflow
   modules.
@@ -94,31 +93,30 @@ Suggested module responsibilities:
   limits, stale cache rules, and future message retention limits.
 - `adapters`: payment-method adapter plus narrow platform hook for live Pubky
   session access.
-- `storage`: durable records, transaction interface, migrations, and in-memory
-  test storage.
+- `storage`: durable records, transaction interface, and in-memory test
+  storage.
 - `identity`: SDK-owned Pubky session capability state and identity
   refresh/import/export workflows.
 - `endpoints`: public Payment Endpoint publication, cleanup, and remote public
   Payment List reads.
-- `contacts`: contact payment resolution types. SDK-owned Paykit-facing
-  contact/profile records, shared namespace handling, and optional custom
-  path/schema hooks are future scope.
+- `contacts`: SDK-owned Paykit-facing profile records, local contact records,
+  optional public contact markers, and contact payment resolution types.
 - `linked_peers`: Encrypted Link establishment, restore, recovery, and
   per-counterparty runtime state.
 - `private_stream`: ordered Private Application Message intake, persistence,
   parsing, dedupe, and current derived view rebuilds.
 - `private_lists`: local and remote Private Payment List publication, caching,
   latest-state derivation, and size policy.
-- `endpoint_reservations`: optional receiving-detail reservation records for
-  Private Payment List sharing.
+- `payment_requests`: Payment Request event state derivation, outbound event
+  queueing, and proof correlation.
 - `receipts`: Receipt Access event indexing, Encrypted Receipt retrieval,
   decryption, and retrieval state.
+- `endpoint_reservations`: optional receiving-detail reservation records for
+  Private Payment List sharing.
 - `backup`: versioned export/import of SDK-managed state.
 
-Future modules should be added only when they have concrete implementation:
+Additional modules should be added only when they have concrete implementation:
 
-- `payment_requests`: Payment Request event state machine, outbound event
-  queueing, proof correlation, and scheduling hooks.
 - `scheduler`: optional recurring Payment Request scheduling integration.
 - `telemetry`: structured logs and redaction helpers.
 
@@ -181,10 +179,11 @@ pub trait StorageAdapter {
 }
 ```
 
-The current Rust SDK foundation supports records for:
+The Rust SDK storage model supports records for:
 
 - identity state
 - linked peer state
+- local Contact Records and cached Paykit Profiles
 - Encrypted Link snapshots and handshake snapshots
 - endpoint publication records
 - endpoint reservation records
@@ -236,48 +235,35 @@ not a separate Pubky SDK that integrators must use.
 
 ### Paykit Profile And Contact Namespace
 
-The SDK should provide default Pubky-backed Paykit-facing profile and contact
-metadata so different Paykit apps can interoperate. This belongs in the SDK, not
-in `paykit-lib` core protocol validation.
+The SDK provides default Pubky-backed Paykit-facing profile metadata so
+different Paykit apps can interoperate. This belongs in the SDK, not in
+`paykit-lib` core protocol validation.
 
-The default namespace must not pollute the public Payment Endpoint root. Public
-Payment Endpoints currently live directly under `/pub/paykit/v0/`, so SDK
-profile/contact records should use a reserved Paykit path such as:
+The default public profile namespace is unversioned:
 
-- a reserved subdirectory under `/pub/paykit/v0/`, or
-- an unversioned Paykit-level path under `/pub/paykit/`.
+- profile record: `/pub/paykit/profile.json`
+- profile blobs: `/pub/paykit/blobs/...`
 
-The versioned option keeps SDK metadata beside the current protocol version.
-The unversioned option may be better if profile/contact records should remain
-stable across Paykit protocol versions. Either way, the chosen path must be
-reserved so it cannot collide with Payment Endpoint Identifier files.
+Public Payment Endpoints remain under `/pub/paykit/v0/`, so SDK profile paths
+do not collide with Payment Endpoint Identifier files.
 
-The exact path policy should be configurable:
+`image_uri` may point at `/pub/paykit/blobs/...` or another public image
+location. The SDK profile API publishes `profile.json`; blob upload/delete
+helpers are caller-managed.
 
-- default shared Paykit SDK profile/contact paths for apps that want
-  cross-Paykit interoperability
-- custom app paths for products that already have profile/contact storage
-- adapter-only mode for apps that want Paykit SDK to consume profile/contact
-  data without writing any Pubky profile/contact records
-
-Custom profile/contact hooks are optional escape hatches. The default path for
-most integrators should be: configure Paykit SDK, provide secure storage and a
-payment adapter, and let the SDK handle Pubky-backed Paykit profile/contact
-reads and writes.
-
-Default profile records can be public because they are display metadata. Contact
-records need more care because they can reveal a social/payment graph. The SDK
-should support shared Paykit contacts, but should also allow apps to keep saved
-contacts local, encrypted, or app-specific when privacy policy requires it.
+Default profile records can be public because they are display metadata.
+Contacts need more care because they can reveal a social/payment graph. The SDK
+keeps saved contacts in local/private SDK storage by default. Public contact
+markers under `/pub/paykit/contacts/` are opt-in through SDK policy and explicit
+runtime calls.
 
 Schemas should be small, versioned, and Paykit-facing:
 
 - profile display name and image pointer
 - normalized Pubky public key
-- optional app/profile source metadata
 - contact public key
 - optional local display snapshot
-- optional Paykit capability summary
+- optional public contact marker
 
 The SDK should not standardize product profile pages, social graph semantics,
 contact grouping, or UI behavior.
@@ -328,14 +314,14 @@ The adapter owns payment-method-specific endpoint details:
 - method-specific payload parsing beyond basic Paykit compatibility
 
 Payment execution and settlement detection stay with the integrating
-application or payment provider. Future SDK APIs may accept execution results
-from those systems.
+application or payment provider. SDK APIs can accept execution results from
+those systems when Paykit needs to record them.
 
 ### Payment Endpoint Reservations
 
-Some payment methods need contact-scoped receiving details. The current SDK lets
-payment adapters reserve receiving details for Private Payment List sharing. The
-SDK queues the Private Payment List and stores linked reservation records in one
+Some payment methods need contact-scoped receiving details. The SDK lets payment
+adapters reserve receiving details for Private Payment List sharing. The SDK
+queues the Private Payment List and stores linked reservation records in one
 storage transaction. Reservation records keep lifecycle metadata and a payload
 hash; they do not store the raw reserved endpoint payload.
 
@@ -355,8 +341,8 @@ record to the latest outbound message id. Idempotent repeats preserve the
 original reservation attribution, expiry, and creation time; adapters that want
 new metadata should use a new reservation id.
 
-Single-use Payment Request reservations are not part of the current SDK shape.
-They need more request-specific context before they should be exposed.
+Single-use Payment Request reservations are outside the SDK shape until the
+request-specific context is defined.
 
 ### Future Scheduling
 
@@ -468,8 +454,8 @@ Tracks SDK-managed public Payment Endpoint publication:
 - last status update time
 - last error, when available
 
-Future versions may add payload hashes, separate attempt/confirmation times,
-and retry counters if the SDK needs change detection or richer retry policy.
+Additional endpoint fields should be added only when the SDK needs change
+detection or richer retry policy.
 
 ### EndpointReservationRecord
 
@@ -559,10 +545,12 @@ Durable outbound Private Application Message queue:
 - last error
 
 The SDK should use one generic outbound Private Application Message record type
-for all Private Application Message kinds, but process it as a FIFO queue per
-counterparty/Encrypted Link. Send workers must claim the next message through
-storage before sending it, and in-progress claims must expire so a crashed
-worker can be retried without letting two workers advance the same link at once.
+for all Private Application Message kinds. Event Messages are processed as FIFO
+per counterparty/Encrypted Link. Private Payment Lists use latest-state
+semantics, so older unsent lists may be superseded by a newer complete list.
+Send workers must claim the next sendable message through storage before
+sending it, and in-progress claims must expire so a crashed worker can be
+retried without letting two workers advance the same link at once.
 
 Event Message retries must reuse the same Event ID and exact payload.
 
@@ -667,6 +655,37 @@ configured to manage the whole Paykit public namespace.
 7. If restore or handshake advancement fails, mark the peer recovery-required
    and stop private automation for that peer.
 
+### Encrypted Link Recovery Markers
+
+When one side can no longer trust its local Encrypted Link state, the SDK should
+fail closed locally and may publish an Encrypted Link Recovery Marker through
+Pubky public storage. The marker is not sent over the broken link. It is a
+minimal public signal that the counterparty should relink.
+
+Marker privacy rules:
+
+- derive marker paths per peer pair from local secret material and the
+  counterparty public key
+- keep marker payloads minimal: version, kind, recovery attempt ID, and creation
+  time
+- do not include Payment Endpoints, Payment References, message counts, peer
+  display metadata, payment state, or detailed recovery stages
+- make marker usage policy-controlled so apps can disable public markers and
+  require manual or out-of-band relink when needed
+
+SDK behavior:
+
+1. Publish a local marker when a link is marked recovery-required and the local
+   identity is private-link-capable.
+2. Observe the counterparty marker before trusting cached private payment state.
+3. If a new counterparty attempt ID is observed, mark the peer
+   recovery-required, clear active link/handshake snapshots, and pause private
+   automation.
+4. Record observed attempt IDs so a stale marker does not repeatedly break a
+   newly established link.
+5. Remove local markers after successful relink when possible; stale remote
+   markers remain safe because attempt IDs are deduped locally.
+
 ### Publish Private Payment List
 
 1. Ensure the identity is private-link-capable.
@@ -697,8 +716,8 @@ Payment Requests, Payment Proofs, and Receipts.
    from stored stream items.
 8. Return a receive report.
 
-Future receive routing should extend the same raw stream log to Payment
-Requests, Payment Proofs, and any other Event Message kinds.
+Receive routing should extend the same raw stream log to Payment Requests,
+Payment Proofs, and any other Event Message kinds.
 
 ### Resolve Contact Payment
 
@@ -798,6 +817,8 @@ Backup should include SDK-managed state:
 - Private Payment List cache
 - endpoint publication records
 - endpoint reservations
+- local Contact Records, including local labels, cached Paykit Profiles, public
+  contact marker status/timestamps, and marker errors
 - raw private stream log or checkpointed subset
 - outbound queue
 - recovery markers
@@ -805,7 +826,7 @@ Backup should include SDK-managed state:
 Backup should not include:
 
 - app cloud transport details
-- product-specific profile/contact schema beyond adapter-owned records
+- product-specific profile/contact data outside SDK Contact Records
 - payment-provider secrets unless explicitly provided by the payment adapter
 - seed material unless Paykit standardizes that policy
 
@@ -822,13 +843,14 @@ Restore flow:
 
 The current Rust SDK exposes initialization, identity status, public endpoint
 sync, linked peer handshakes, private stream receive, Private Payment List
-derivation/publication, contact payment resolution, outbound Private
+derivation/publication, Paykit Profile publication/fetching, local Contact
+Record CRUD/profile refresh, contact payment resolution, outbound Private
 Application Message processing, Receipt Access indexing/retrieval, Payment
 Request lifecycle derivation plus checked outbound lifecycle queueing, optional
-Payment Endpoint Reservation records, and backup/export/restore for
-SDK-managed state. Use `paykit-sdk` rustdoc for the exact current signatures.
+Payment Endpoint Reservation records, and backup/export/restore for SDK-managed
+state. Use `paykit-sdk` rustdoc for exact signatures.
 
-Future SDK versions should extend the current surface with operations like:
+Additional SDK operations can extend this surface with methods like:
 
 ```rust
 impl PaykitSdk {
@@ -907,10 +929,12 @@ Current `PaykitSdkConfig` includes:
 - private sharing enabled/disabled
 - public fallback policy
 - private recovery wait duration
+- Encrypted Link Recovery Marker policy
+- public contact sharing policy, defaulting to local-only Contact Records
 - peer link operation lease timeout
 - outbound private send lease timeout
 
-Future policy configuration may add:
+Additional policy configuration can add:
 
 - stale private cache policy
 - outbound retry policy beyond lease expiry
@@ -931,6 +955,7 @@ These are good candidates to move into Paykit SDK:
 - Encrypted Link snapshot and handshake runtime
 - stale link recovery markers and bounded recovery policy
 - ordered private stream receive/persist/route
+- Paykit profile publishing/fetching and local contact records
 - contact payment resolution and payable endpoint checks
 - endpoint reservation records and attribution helpers
 - SDK-managed backup records
@@ -948,26 +973,6 @@ These should stay outside Paykit SDK:
 - app backup transport and cloud sync
 - seed/secret derivation policy unless standardized
 
-## Current Foundation And Next Work
-
-The current Rust SDK foundation includes the crate skeleton, error/config
-types, adapter traits, in-memory test storage, identity state, public endpoint
-sync, Encrypted Link runtime records, private stream intake, Private Payment
-List latest-state derivation, contact payment resolution, outbound Private
-Application Message delivery, Receipt Access indexing, receipt retrieval,
-Payment Request lifecycle derivation, and checked outbound Payment Request
-lifecycle queueing, optional Payment Endpoint Reservation storage for reserved
-private receiving details, and backup/export/restore for SDK-managed state.
-
-Next work:
-
-1. Add SDK FFI and platform wrappers.
-2. Migrate one existing app integration behind the SDK and use that to refine
-   adapters.
-
-Each step should include unit tests for storage invariants and at least one
-integration-style test using an in-memory adapter setup.
-
 ## Test Plan
 
 Core tests:
@@ -984,6 +989,7 @@ Core tests:
 - outbound retries reuse exact Event ID and payload
 - Payment Request role/lifecycle checks
 - Receipt Access dedupe and receipt retrieval
+- profile serialization and local contact storage
 - backup/restore validates snapshot recipient and pauses unsafe automation
 
 Platform tests:
@@ -994,20 +1000,19 @@ Platform tests:
 - serialization parity for records and errors
 - no nullable/optional protocol ambiguity in wrappers
 
-## Open Questions
+## Later Design Areas
 
-1. Should the first storage implementation be caller-provided only, or should
-   Paykit ship a SQLite-backed storage adapter?
-2. Should the default Paykit SDK profile/contact namespace use a reserved
-   subdirectory under `/pub/paykit/v0/`, or an unversioned Paykit-level path
-   under `/pub/paykit/`?
-3. Should the current default public fallback and private recovery timeouts
-   differ for saved contacts versus one-off counterparties?
-4. Which reservation lifecycle hooks should be standardized beyond private-list
-   queueing?
-5. How much recurring Payment Request scheduling should the SDK own versus
-   delegating to app/runtime schedulers?
-6. What unknown Private Application Message retention defaults are appropriate
-   for mobile storage budgets once retention enforcement is implemented?
-7. Should SDK bindings become the primary mobile API while `paykit-ffi` remains
-   low-level protocol API?
+- Durable storage adapters, including whether Paykit should ship a
+  SQLite-backed implementation.
+- Custom profile/contact path hooks for apps that already have product-specific
+  Pubky namespaces.
+- Public contact marker discovery and richer contact-sharing policy.
+- Public fallback and private recovery timeout policies for saved contacts
+  versus one-off counterparties.
+- Reservation lifecycle hooks beyond Private Payment List queueing.
+- Recurring Payment Request scheduling ownership between the SDK and
+  app/runtime schedulers.
+- Unknown Private Application Message retention defaults for mobile storage
+  budgets.
+- SDK platform bindings as the primary mobile API, with `paykit-ffi` kept for
+  low-level protocol integrations.

--- a/specs/payment-endpoint-identifier.md
+++ b/specs/payment-endpoint-identifier.md
@@ -24,7 +24,8 @@ each other without side-channel coordination.
 This is a *recommended* convention, not a mandatory one. Paykit's routing
 layer does not enforce identifier shape beyond the structural checks performed
 by [`PaymentEndpointIdentifier`](../paykit-lib/src/payment_endpoint.rs) (ASCII alphanumeric, `-`, `_`, `.`;
-max 64 characters; no path traversal; the value `private` is reserved).
+max 64 characters; no path traversal; reserved Paykit storage values are
+rejected).
 
 Identifiers that follow this specification are interoperable with Paykit
 clients that follow the same conventions. Identifiers that do not follow it
@@ -245,10 +246,10 @@ Payment Endpoint Payloads are stored as [`PaymentEndpointPayload`](../paykit-lib
 UTF-8 strings. The reference implementation does not parse or validate payloads
 as JSON at the Paykit layer.
 
-The reserved identifier `private` is used internally by Paykit for private
-Paykit storage paths; it is rejected at `PaymentEndpointIdentifier`
-construction and therefore cannot appear as a conforming identifier under this
-specification either.
+The reserved identifiers `private` and `encrypted-link-recovery` are used
+internally by Paykit storage paths; they are rejected at
+`PaymentEndpointIdentifier` construction and therefore cannot appear as
+conforming identifiers under this specification either.
 
 ## 10. Security considerations
 


### PR DESCRIPTION
## Summary

Stack PR 5/6 for the Paykit SDK split.

Adds Encrypted Link Recovery Markers plus Paykit profile/contact support: recovery marker storage helpers, policy-gated marker workflows, Paykit Profile publishing/fetching, local Contact Records, optional public contact markers, and related SDK docs/spec updates.

## Review Notes

- Base: `codex/sdk-stack-backup-reservations`
- Head: `codex/sdk-stack-profiles-recovery`
- This builds on the backup/reservations PR.
- The final stack branch was verified to have the same tree as #55's head.

## Verification

The final stacked branch matches #55's final tree exactly.
