### PR TITLE
Add SDK domain and storage foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 
@@ -3145,6 +3146,23 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "paykit-sdk"
+version = "0.1.0-rc12"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "paykit-lib",
+ "pubky",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["paykit-lib", "paykit-ffi"]
+members = ["paykit-lib", "paykit-ffi", "paykit-sdk"]

--- a/paykit-lib/src/encrypted_link/link.rs
+++ b/paykit-lib/src/encrypted_link/link.rs
@@ -106,7 +106,7 @@ impl EncryptedLink {
         &self.recipient
     }
 
-    async fn send_private_application_message(
+    async fn send_private_application_message_with_context(
         &mut self,
         plaintext: &[u8],
         context: &'static str,
@@ -124,17 +124,17 @@ impl EncryptedLink {
         &mut self,
         plaintext: &[u8],
     ) -> Result<()> {
-        self.send_private_application_message(plaintext, "Private Payment List")
+        self.send_private_application_message_with_context(plaintext, "Private Payment List")
             .await
     }
 
     pub(crate) async fn send_receipt_access_message(&mut self, plaintext: &[u8]) -> Result<()> {
-        self.send_private_application_message(plaintext, "Receipt Access")
+        self.send_private_application_message_with_context(plaintext, "Receipt Access")
             .await
     }
 
     pub(crate) async fn send_payment_request_message(&mut self, plaintext: &[u8]) -> Result<()> {
-        self.send_private_application_message(plaintext, "Payment Request")
+        self.send_private_application_message_with_context(plaintext, "Payment Request")
             .await
     }
 
@@ -142,7 +142,7 @@ impl EncryptedLink {
         &mut self,
         plaintext: &[u8],
     ) -> Result<()> {
-        self.send_private_application_message(plaintext, "Payment Request Acceptance")
+        self.send_private_application_message_with_context(plaintext, "Payment Request Acceptance")
             .await
     }
 
@@ -150,7 +150,7 @@ impl EncryptedLink {
         &mut self,
         plaintext: &[u8],
     ) -> Result<()> {
-        self.send_private_application_message(plaintext, "Payment Request Rejection")
+        self.send_private_application_message_with_context(plaintext, "Payment Request Rejection")
             .await
     }
 
@@ -158,13 +158,36 @@ impl EncryptedLink {
         &mut self,
         plaintext: &[u8],
     ) -> Result<()> {
-        self.send_private_application_message(plaintext, "Payment Request Cancellation")
-            .await
+        self.send_private_application_message_with_context(
+            plaintext,
+            "Payment Request Cancellation",
+        )
+        .await
     }
 
     pub(crate) async fn send_payment_proof_message(&mut self, plaintext: &[u8]) -> Result<()> {
-        self.send_private_application_message(plaintext, "Payment Proof")
+        self.send_private_application_message_with_context(plaintext, "Payment Proof")
             .await
+    }
+
+    /// Send one raw JSON Private Application Message.
+    ///
+    /// This is the low-level send counterpart to
+    /// [`receive_private_application_messages`](Self::receive_private_application_messages).
+    /// It validates only the generic `version` and `kind` envelope fields; it
+    /// does not require a known Paykit kind or validate known Paykit message
+    /// bodies. Use the typed serializers or SDK queue for protocol-managed
+    /// Paykit messages.
+    ///
+    /// Higher-level callers should persist the exact JSON before sending when
+    /// retrying the same message matters.
+    pub async fn send_private_application_message_json(&mut self, raw_json: &str) -> Result<()> {
+        validate_private_application_message_json(raw_json)?;
+        self.send_private_application_message_with_context(
+            raw_json.as_bytes(),
+            "Private Application Message",
+        )
+        .await
     }
 
     #[cfg(test)]
@@ -172,11 +195,14 @@ impl EncryptedLink {
         &mut self,
         plaintext: &[u8],
     ) -> Result<()> {
-        self.send_private_application_message(plaintext, "raw test Private Application Message")
-            .await
+        self.send_private_application_message_with_context(
+            plaintext,
+            "raw test Private Application Message",
+        )
+        .await
     }
 
-    /// Receive currently available Private Application Messages in stream order.
+    /// Receive available Private Application Messages in stream order.
     ///
     /// The Noise read checkpoint advances past the returned messages. Callers
     /// that need crash-safe Event Message handling should persist returned
@@ -187,6 +213,26 @@ impl EncryptedLink {
     ) -> Result<Vec<PrivateApplicationMessage>> {
         private_application_message::receive_private_application_messages(&mut self.encryptor).await
     }
+}
+
+fn validate_private_application_message_json(raw_json: &str) -> Result<()> {
+    let value: serde_json::Value =
+        serde_json::from_str(raw_json).map_err(|err| PaykitError::Validation(err.to_string()))?;
+    if value
+        .get("version")
+        .and_then(serde_json::Value::as_u64)
+        .is_none_or(|version| u8::try_from(version).is_err())
+    {
+        return Err(PaykitError::Validation(
+            "Private Application Message version must be a u8 integer".into(),
+        ));
+    }
+    if !value.get("kind").is_some_and(serde_json::Value::is_string) {
+        return Err(PaykitError::Validation(
+            "Private Application Message kind must be a string".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Default maximum number of automatic Private Application Message
@@ -300,4 +346,19 @@ async fn restore_encrypted_link_inner(
         remote_pubkey.clone(),
         config,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_private_application_message_json_requires_header() {
+        assert!(validate_private_application_message_json(
+            r#"{"version":1,"kind":"paykit.private_payment_list"}"#
+        )
+        .is_ok());
+        assert!(validate_private_application_message_json(r#"{"version":1}"#).is_err());
+        assert!(validate_private_application_message_json(r#"{"kind":"paykit.test"}"#).is_err());
+    }
 }

--- a/paykit-lib/src/encrypted_link/private_application_message.rs
+++ b/paykit-lib/src/encrypted_link/private_application_message.rs
@@ -1,6 +1,12 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use tracing::{debug, warn};
 
-use crate::{PaykitError, Result};
+use crate::{
+    error::{NonRetryablePrivateReceiveError, NonRetryablePrivateSendError},
+    PaykitError, Result,
+};
+
+const INVALID_UTF8_PRIVATE_MESSAGE_PREFIX: &str = "paykit.invalid_utf8_private_message:";
 
 /// Private Message Kind values understood by Paykit.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -70,7 +76,9 @@ impl std::fmt::Display for PrivateMessageKind {
 /// One Private Application Message received from an Encrypted Link.
 ///
 /// This is the low-level receive item for the Private Application Message stream.
-/// It keeps the raw JSON so callers can route and persist messages themselves.
+/// It keeps the raw plaintext payload so callers can route and persist messages
+/// themselves. If decrypted bytes are not UTF-8, `raw_json` contains an
+/// invalid-JSON marker with the bytes encoded as base64url.
 #[derive(Clone, PartialEq, Eq)]
 pub struct PrivateApplicationMessage {
     /// Private Application Message version from the JSON `version` field, when
@@ -79,7 +87,7 @@ pub struct PrivateApplicationMessage {
     /// Message kind string from the JSON `kind` field, when the field is a
     /// string.
     pub kind: Option<String>,
-    /// Raw JSON plaintext received over the Encrypted Link.
+    /// Raw plaintext received over the Encrypted Link.
     pub raw_json: String,
 }
 
@@ -97,29 +105,27 @@ impl std::fmt::Debug for PrivateApplicationMessage {
 }
 
 impl PrivateApplicationMessage {
-    pub(super) fn from_plaintext(plaintext: String) -> Result<Self> {
-        let value: serde_json::Value =
-            serde_json::from_str(&plaintext).map_err(|err| PaykitError::InvalidData {
-                context: format!("failed to parse Private Application Message JSON: {err}"),
-                source: Some(err.into()),
-            })?;
+    pub(super) fn from_plaintext(plaintext: String) -> Self {
+        let value = serde_json::from_str::<serde_json::Value>(&plaintext).ok();
         let version = value
-            .get("version")
+            .as_ref()
+            .and_then(|value| value.get("version"))
             .and_then(serde_json::Value::as_u64)
             .and_then(|version| u8::try_from(version).ok());
         let kind = value
-            .get("kind")
+            .as_ref()
+            .and_then(|value| value.get("kind"))
             .and_then(serde_json::Value::as_str)
             .map(str::to_owned);
-        Ok(Self {
+        Self {
             version,
             kind,
             raw_json: plaintext,
-        })
+        }
     }
 
-    /// Return the known Paykit kind from the raw JSON payload, if this library
-    /// version recognizes it.
+    /// Return the known Paykit kind from the raw payload, if this library can
+    /// parse and recognize it.
     pub fn known_kind(&self) -> Option<PrivateMessageKind> {
         serde_json::from_str::<serde_json::Value>(&self.raw_json)
             .ok()
@@ -130,6 +136,13 @@ impl PrivateApplicationMessage {
                     .and_then(PrivateMessageKind::parse)
             })
     }
+
+    /// Return a parse error when this item represents non-UTF-8 plaintext bytes.
+    pub fn invalid_utf8_error(&self) -> Option<&'static str> {
+        self.raw_json
+            .starts_with(INVALID_UTF8_PRIVATE_MESSAGE_PREFIX)
+            .then_some("Private Application Message plaintext is not valid UTF-8")
+    }
 }
 
 fn decode_private_application_message(
@@ -139,56 +152,42 @@ fn decode_private_application_message(
     // Paykit application messages are JSON, so trailing NUL bytes are not valid
     // payload content.
     let end = raw.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
-    let plaintext = std::str::from_utf8(&raw[..end]).map_err(|err| PaykitError::InvalidData {
-        context: format!("Private Application Message plaintext is not valid UTF-8: {err}"),
-        source: Some(err.into()),
-    })?;
+    let plaintext = match std::str::from_utf8(&raw[..end]) {
+        Ok(plaintext) => plaintext.to_owned(),
+        Err(_) => format!(
+            "{INVALID_UTF8_PRIVATE_MESSAGE_PREFIX}{}",
+            URL_SAFE_NO_PAD.encode(&raw[..end])
+        ),
+    };
 
-    PrivateApplicationMessage::from_plaintext(plaintext.to_owned())
+    Ok(PrivateApplicationMessage::from_plaintext(plaintext))
 }
 
 pub(super) async fn receive_private_application_messages(
     encryptor: &mut pubky_noise::PubkyNoiseEncryptor,
 ) -> Result<Vec<PrivateApplicationMessage>> {
-    let mut received = 0usize;
-    let mut malformed = 0usize;
     let mut messages = Vec::new();
 
     loop {
-        let batch = encryptor
-            .receive_message()
-            .await
-            .map_err(|err| PaykitError::Transport {
-                context: format!("failed to receive Private Application Messages: {err:?}"),
-                source: anyhow::anyhow!("pubky-noise receive_message failed: {err:?}"),
-            })?;
+        let batch = encryptor.receive_message().await.map_err(|err| {
+            let context = format!("failed to receive Private Application Messages: {err:?}");
+            let source = if is_retryable_private_receive_error(&err) {
+                anyhow::anyhow!("pubky-noise receive_message failed: {err:?}")
+            } else {
+                anyhow::Error::new(NonRetryablePrivateReceiveError(err))
+            };
+            PaykitError::Transport { context, source }
+        })?;
 
         if batch.is_empty() {
             break;
         }
 
-        received += batch.len();
         for raw in batch {
-            match decode_private_application_message(&raw) {
-                Ok(message) => messages.push(message),
-                Err(err) => {
-                    malformed += 1;
-                    warn!(
-                        error = ?err,
-                        "dropping malformed Private Application Message"
-                    );
-                }
-            }
+            messages.push(decode_private_application_message(&raw)?);
         }
     }
 
-    if malformed > 0 {
-        warn!(
-            received,
-            malformed,
-            "ignored malformed Private Application Messages while preserving later messages"
-        );
-    }
     Ok(messages)
 }
 
@@ -198,6 +197,10 @@ fn send_attempts_from_retries(max_send_retries: u32) -> u32 {
 
 fn is_retryable_private_send_error(err: &pubky_noise::PubkyNoiseError) -> bool {
     matches!(err, pubky_noise::PubkyNoiseError::HomeserverWriteError)
+}
+
+fn is_retryable_private_receive_error(err: &pubky_noise::PubkyNoiseError) -> bool {
+    matches!(err, pubky_noise::PubkyNoiseError::HomeserverResponseError)
 }
 
 fn validate_private_application_message_size(
@@ -244,11 +247,10 @@ pub(super) async fn send_private_application_message(
                 }
             }
             Err(err) => {
+                let context = format!("failed to send {context}: {err:?}");
                 return Err(PaykitError::Transport {
-                    context: format!("failed to send {context}: {err:?}"),
-                    source: anyhow::anyhow!(
-                        "pubky-noise send_message failed with non-retryable error: {err:?}"
-                    ),
+                    context,
+                    source: anyhow::Error::new(NonRetryablePrivateSendError(err)),
                 });
             }
         }
@@ -295,6 +297,50 @@ mod tests {
     }
 
     #[test]
+    fn test_non_retryable_private_send_error_is_classified() {
+        let err = PaykitError::Transport {
+            context: "failed to send Private Application Message".into(),
+            source: anyhow::Error::new(NonRetryablePrivateSendError(
+                pubky_noise::PubkyNoiseError::EncryptionError,
+            )),
+        };
+
+        assert!(err.is_non_retryable_private_send_error());
+    }
+
+    #[test]
+    fn test_private_receive_retry_classification() {
+        assert!(is_retryable_private_receive_error(
+            &pubky_noise::PubkyNoiseError::HomeserverResponseError,
+        ));
+
+        for err in [
+            pubky_noise::PubkyNoiseError::BadLengthCiphertext,
+            pubky_noise::PubkyNoiseError::IsHandshake,
+            pubky_noise::PubkyNoiseError::DecryptionError,
+            pubky_noise::PubkyNoiseError::CounterOverflow,
+            pubky_noise::PubkyNoiseError::NonceOverflow,
+        ] {
+            assert!(
+                !is_retryable_private_receive_error(&err),
+                "{err:?} should not be retried"
+            );
+        }
+    }
+
+    #[test]
+    fn test_non_retryable_private_receive_error_is_classified() {
+        let err = PaykitError::Transport {
+            context: "failed to receive Private Application Messages".into(),
+            source: anyhow::Error::new(NonRetryablePrivateReceiveError(
+                pubky_noise::PubkyNoiseError::DecryptionError,
+            )),
+        };
+
+        assert!(err.is_non_retryable_private_receive_error());
+    }
+
+    #[test]
     fn test_private_application_message_size_validation_rejects_oversized_payload() {
         let payload = vec![b'x'; pubky_noise::snow_crypto::PUBKY_NOISE_MSG_LEN + 1];
         let err =
@@ -308,7 +354,7 @@ mod tests {
     #[test]
     fn test_private_application_message_keeps_malformed_header() {
         let raw = r#"{"version":"bad","kind":"paykit.payment_request","event_id":"not-a-uuid"}"#;
-        let message = PrivateApplicationMessage::from_plaintext(raw.to_string()).unwrap();
+        let message = PrivateApplicationMessage::from_plaintext(raw.to_string());
 
         assert_eq!(message.version, None);
         assert_eq!(
@@ -321,7 +367,7 @@ mod tests {
     #[test]
     fn test_private_application_message_keeps_json_without_kind() {
         let raw = r#"{"version":1,"payload":"unknown"}"#;
-        let message = PrivateApplicationMessage::from_plaintext(raw.to_string()).unwrap();
+        let message = PrivateApplicationMessage::from_plaintext(raw.to_string());
 
         assert_eq!(message.version, Some(1));
         assert_eq!(message.kind, None);
@@ -347,10 +393,40 @@ mod tests {
     #[test]
     fn test_private_application_message_debug_redacts_raw_json() {
         let raw = r#"{"version":1,"kind":"paykit.receipt_access","key":"secret"}"#;
-        let message = PrivateApplicationMessage::from_plaintext(raw.to_string()).unwrap();
+        let message = PrivateApplicationMessage::from_plaintext(raw.to_string());
         let debug = format!("{message:?}");
 
         assert!(!debug.contains("secret"));
         assert!(debug.contains("<redacted:"));
+    }
+
+    #[test]
+    fn test_private_application_message_keeps_invalid_json() {
+        let raw = "not json";
+        let message = PrivateApplicationMessage::from_plaintext(raw.to_string());
+
+        assert_eq!(message.version, None);
+        assert_eq!(message.kind, None);
+        assert_eq!(message.known_kind(), None);
+        assert_eq!(message.raw_json, raw);
+    }
+
+    #[test]
+    fn test_decode_private_application_message_retains_invalid_utf8_marker() {
+        let mut raw = [0u8; pubky_noise::snow_crypto::PUBKY_NOISE_MSG_LEN];
+        raw[0] = 0xff;
+
+        let message = decode_private_application_message(&raw).unwrap();
+
+        assert_eq!(message.version, None);
+        assert_eq!(message.kind, None);
+        assert_eq!(message.known_kind(), None);
+        assert_eq!(
+            message.invalid_utf8_error(),
+            Some("Private Application Message plaintext is not valid UTF-8")
+        );
+        assert!(message
+            .raw_json
+            .starts_with(INVALID_UTF8_PRIVATE_MESSAGE_PREFIX));
     }
 }

--- a/paykit-lib/src/encrypted_link_recovery.rs
+++ b/paykit-lib/src/encrypted_link_recovery.rs
@@ -1,0 +1,255 @@
+//! Stateless Encrypted Link recovery marker helpers.
+
+use pubky::{
+    errors::RequestError, Error as PubkyError, PubkySession, PublicKey, PublicStorage, StatusCode,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    validation::{invalid_data, invalid_wire, parse_utc_timestamp, validate_uuid_v4},
+    PaykitError, Result, PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX,
+};
+
+const RECOVERY_MARKER_KIND: &str = "paykit.encrypted_link_recovery";
+const RECOVERY_MARKER_PATH_DOMAIN: &[u8] = b"paykit-link-recovery-v0";
+
+/// Minimal public marker that asks a counterparty to relink an Encrypted Link.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EncryptedLinkRecoveryMarker {
+    attempt_id: String,
+    created_at: String,
+}
+
+impl EncryptedLinkRecoveryMarker {
+    /// Create a marker from a UUID-v4 attempt id and RFC3339 UTC timestamp.
+    pub fn new(attempt_id: impl Into<String>, created_at: impl Into<String>) -> Result<Self> {
+        let attempt_id = validate_uuid_v4(attempt_id.into(), "Encrypted Link recovery attempt ID")?;
+        let created_at = created_at.into();
+        parse_utc_timestamp(&created_at, "Encrypted Link recovery marker created_at")?;
+        Ok(Self {
+            attempt_id,
+            created_at,
+        })
+    }
+
+    /// Generate a marker with a fresh UUID-v4 attempt id.
+    pub fn new_v4(created_at: impl Into<String>) -> Result<Self> {
+        Self::new(uuid::Uuid::new_v4().to_string(), created_at)
+    }
+
+    /// Stable recovery attempt id.
+    pub fn attempt_id(&self) -> &str {
+        &self.attempt_id
+    }
+
+    /// Marker creation time as an RFC3339 UTC timestamp.
+    pub fn created_at(&self) -> &str {
+        &self.created_at
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RecoveryMarkerWire {
+    version: u8,
+    kind: String,
+    attempt_id: String,
+    created_at: String,
+}
+
+impl From<&EncryptedLinkRecoveryMarker> for RecoveryMarkerWire {
+    fn from(marker: &EncryptedLinkRecoveryMarker) -> Self {
+        Self {
+            version: 1,
+            kind: RECOVERY_MARKER_KIND.into(),
+            attempt_id: marker.attempt_id.clone(),
+            created_at: marker.created_at.clone(),
+        }
+    }
+}
+
+impl TryFrom<RecoveryMarkerWire> for EncryptedLinkRecoveryMarker {
+    type Error = PaykitError;
+
+    fn try_from(wire: RecoveryMarkerWire) -> Result<Self> {
+        if wire.version != 1 || wire.kind != RECOVERY_MARKER_KIND {
+            return Err(invalid_data(
+                format!(
+                    "unsupported Encrypted Link recovery marker version/kind: {}/{}",
+                    wire.version, wire.kind
+                ),
+                None,
+            ));
+        }
+        Self::new(wire.attempt_id, wire.created_at)
+            .map_err(|err| invalid_wire(err, "Encrypted Link recovery marker"))
+    }
+}
+
+/// Serialize an Encrypted Link Recovery Marker to canonical JSON.
+pub fn serialize_encrypted_link_recovery_marker(
+    marker: &EncryptedLinkRecoveryMarker,
+) -> Result<String> {
+    serde_json::to_string(&RecoveryMarkerWire::from(marker)).map_err(|err| {
+        PaykitError::Validation(format!(
+            "failed to serialize Encrypted Link recovery marker: {err}"
+        ))
+    })
+}
+
+/// Parse an Encrypted Link Recovery Marker JSON payload.
+pub fn parse_encrypted_link_recovery_marker_json(
+    raw_json: &str,
+) -> Result<EncryptedLinkRecoveryMarker> {
+    let wire = serde_json::from_str::<RecoveryMarkerWire>(raw_json).map_err(|err| {
+        invalid_data(
+            format!("Encrypted Link recovery marker JSON is invalid: {err}"),
+            Some(err.into()),
+        )
+    })?;
+    wire.try_into()
+}
+
+/// Compute local write and remote read paths for recovery markers.
+pub fn encrypted_link_recovery_marker_paths(
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+) -> (String, String) {
+    pubky_noise::path_derivation::derive_asymmetric_paths(
+        local_secret_key,
+        remote_pubkey,
+        RECOVERY_MARKER_PATH_DOMAIN,
+        PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX,
+    )
+}
+
+/// Publish a local recovery marker and return the path written.
+pub async fn publish_encrypted_link_recovery_marker(
+    session: &PubkySession,
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+    marker: &EncryptedLinkRecoveryMarker,
+) -> Result<String> {
+    let (write_path, _) = encrypted_link_recovery_marker_paths(local_secret_key, remote_pubkey);
+    let payload = serialize_encrypted_link_recovery_marker(marker)?;
+    session
+        .storage()
+        .put(write_path.clone(), payload)
+        .await
+        .map_err(|err| PaykitError::Transport {
+            context: "publish Encrypted Link recovery marker".into(),
+            source: err.into(),
+        })?;
+    Ok(write_path)
+}
+
+/// Remove the local recovery marker for a counterparty.
+pub async fn remove_encrypted_link_recovery_marker(
+    session: &PubkySession,
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+) -> Result<String> {
+    let (write_path, _) = encrypted_link_recovery_marker_paths(local_secret_key, remote_pubkey);
+    match session.storage().delete(write_path.clone()).await {
+        Ok(_) => Ok(write_path),
+        Err(err) if is_not_found(&err) => Ok(write_path),
+        Err(err) => Err(PaykitError::Transport {
+            context: "remove Encrypted Link recovery marker".into(),
+            source: err.into(),
+        }),
+    }
+}
+
+/// Fetch a counterparty's recovery marker, if one is present.
+pub async fn fetch_encrypted_link_recovery_marker(
+    storage: &PublicStorage,
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+) -> Result<Option<EncryptedLinkRecoveryMarker>> {
+    let (_, read_path) = encrypted_link_recovery_marker_paths(local_secret_key, remote_pubkey);
+    let addr = format!("{remote_pubkey}{read_path}");
+    match storage.get(&addr).await {
+        Ok(resp) => {
+            let bytes = resp.bytes().await.map_err(|err| PaykitError::Transport {
+                context: "fetch Encrypted Link recovery marker".into(),
+                source: err.into(),
+            })?;
+            if bytes.is_empty() {
+                return Ok(None);
+            }
+            let raw_json = String::from_utf8(bytes.to_vec()).map_err(|err| {
+                let pos = err.utf8_error().valid_up_to();
+                invalid_data(
+                    format!("Encrypted Link recovery marker is invalid UTF-8 at byte {pos}"),
+                    Some(err.into()),
+                )
+            })?;
+            parse_encrypted_link_recovery_marker_json(&raw_json).map(Some)
+        }
+        Err(err) if is_not_found(&err) => Ok(None),
+        Err(err) => Err(PaykitError::Transport {
+            context: "fetch Encrypted Link recovery marker".into(),
+            source: err.into(),
+        }),
+    }
+}
+
+fn is_not_found(err: &PubkyError) -> bool {
+    matches!(
+        err,
+        PubkyError::Request(RequestError::Server { status, .. })
+            if *status == StatusCode::NOT_FOUND || *status == StatusCode::GONE
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use pubky::Keypair;
+
+    use super::*;
+
+    fn secret_pair() -> ([u8; 32], PublicKey) {
+        let keypair = Keypair::random();
+        (keypair.secret_key(), keypair.public_key())
+    }
+
+    #[test]
+    fn test_recovery_marker_json_round_trips() {
+        let marker = EncryptedLinkRecoveryMarker::new(
+            "650e8400-e29b-41d4-a716-446655440000",
+            "2026-06-03T12:00:00Z",
+        )
+        .unwrap();
+
+        let raw = serialize_encrypted_link_recovery_marker(&marker).unwrap();
+        let parsed = parse_encrypted_link_recovery_marker_json(&raw).unwrap();
+
+        assert_eq!(parsed, marker);
+        assert!(raw.contains("\"kind\":\"paykit.encrypted_link_recovery\""));
+    }
+
+    #[test]
+    fn test_recovery_marker_rejects_extra_fields() {
+        let raw = r#"{"version":1,"kind":"paykit.encrypted_link_recovery","attempt_id":"650e8400-e29b-41d4-a716-446655440000","created_at":"2026-06-03T12:00:00Z","peer":"extra"}"#;
+
+        let result = parse_encrypted_link_recovery_marker_json(raw);
+
+        assert!(matches!(result, Err(PaykitError::InvalidData { .. })));
+    }
+
+    #[test]
+    fn test_recovery_marker_paths_are_pairwise_symmetric() {
+        let (alice_secret, alice_public) = secret_pair();
+        let (bob_secret, bob_public) = secret_pair();
+
+        let (alice_write, alice_read) =
+            encrypted_link_recovery_marker_paths(&alice_secret, &bob_public);
+        let (bob_write, bob_read) =
+            encrypted_link_recovery_marker_paths(&bob_secret, &alice_public);
+
+        assert_eq!(alice_write, bob_read);
+        assert_eq!(alice_read, bob_write);
+        assert!(alice_write.starts_with(PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX));
+        assert_ne!(alice_write, alice_read);
+    }
+}

--- a/paykit-lib/src/error.rs
+++ b/paykit-lib/src/error.rs
@@ -53,6 +53,42 @@ pub enum PaykitError {
     Validation(String),
 }
 
+#[derive(Debug, Error)]
+#[error("pubky-noise send_message failed with non-retryable error: {0:?}")]
+pub(crate) struct NonRetryablePrivateSendError(pub(crate) pubky_noise::PubkyNoiseError);
+
+#[derive(Debug, Error)]
+#[error("pubky-noise receive_message failed with non-retryable error: {0:?}")]
+pub(crate) struct NonRetryablePrivateReceiveError(pub(crate) pubky_noise::PubkyNoiseError);
+
+impl PaykitError {
+    /// Returns true when this error came from a deterministic Encrypted Link
+    /// private-message send failure that should trigger link recovery instead
+    /// of ordinary transport retry.
+    pub fn is_non_retryable_private_send_error(&self) -> bool {
+        matches!(
+            self,
+            Self::Transport { source, .. }
+                if source
+                    .downcast_ref::<NonRetryablePrivateSendError>()
+                    .is_some()
+        )
+    }
+
+    /// Returns true when this error came from a deterministic Encrypted Link
+    /// private-message receive failure that should trigger link recovery
+    /// instead of ordinary transport retry.
+    pub fn is_non_retryable_private_receive_error(&self) -> bool {
+        matches!(
+            self,
+            Self::Transport { source, .. }
+                if source
+                    .downcast_ref::<NonRetryablePrivateReceiveError>()
+                    .is_some()
+        )
+    }
+}
+
 pub(crate) fn map_error(label: &'static str, err: PaykitError) -> PaykitError {
     match err {
         PaykitError::Transport { context, source } => PaykitError::Transport {

--- a/paykit-lib/src/lib.rs
+++ b/paykit-lib/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 mod encrypted_link;
+mod encrypted_link_recovery;
 mod error;
 mod event;
 mod payment_amount;
@@ -22,6 +23,13 @@ pub use encrypted_link::{
     EncryptedLinkHandshakeSnapshot, EncryptedLinkSnapshot, HandshakeProgress,
     PrivateApplicationMessage, PrivateMessageKind, DEFAULT_MAX_RECOVERY_ATTEMPTS,
     DEFAULT_MAX_SEND_RETRIES,
+};
+#[doc(inline)]
+pub use encrypted_link_recovery::{
+    encrypted_link_recovery_marker_paths, fetch_encrypted_link_recovery_marker,
+    parse_encrypted_link_recovery_marker_json, publish_encrypted_link_recovery_marker,
+    remove_encrypted_link_recovery_marker, serialize_encrypted_link_recovery_marker,
+    EncryptedLinkRecoveryMarker,
 };
 #[doc(inline)]
 pub use error::PaykitError;
@@ -47,18 +55,22 @@ pub use payment_request::{
 };
 #[doc(inline)]
 pub use private_payment_list::{
-    parse_private_payment_list_json, set_private_payment_list, PrivatePaymentList,
+    parse_private_payment_list_json, serialize_private_payment_list_json, set_private_payment_list,
+    PrivatePaymentList,
 };
 #[doc(inline)]
 pub use pubky::PublicKey;
 pub use pubky_noise;
 #[doc(inline)]
-pub use pubky_routing::{PAYKIT_PATH_PREFIX, PAYKIT_PRIVATE_PATH_PREFIX};
+pub use pubky_routing::{
+    PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX, PAYKIT_PATH_PREFIX, PAYKIT_PRIVATE_PATH_PREFIX,
+};
 #[doc(inline)]
 pub use receipt::{
     decrypt_receipt, parse_receipt_access_event_message, parse_receipt_access_json,
-    prepare_receipt, send_receipt_access, store_prepared_receipt, PreparedReceipt, Receipt,
-    ReceiptAccess, ReceiptAccessEventMessage, ReceiptDecryptionKey, ReceiptDraft, ReceiptId,
+    prepare_receipt, prepare_receipt_for_recipient, send_receipt_access,
+    serialize_receipt_access_json, store_prepared_receipt, PreparedReceipt, Receipt, ReceiptAccess,
+    ReceiptAccessEventMessage, ReceiptDecryptionKey, ReceiptDraft, ReceiptId,
 };
 
 /// Common result alias for Paykit operations.

--- a/paykit-lib/src/payment_endpoint.rs
+++ b/paykit-lib/src/payment_endpoint.rs
@@ -18,7 +18,7 @@ use crate::{error::map_error, pubky_routing, PaykitError, PublicKey, Result};
 /// # Limits
 /// - Must not be empty.
 /// - Must not exceed 64 characters.
-/// - Must not be the reserved value `"private"`.
+/// - Must not be a reserved Paykit storage value.
 ///
 /// # Examples
 /// ```
@@ -36,6 +36,8 @@ pub struct PaymentEndpointIdentifier(String);
 const PAYMENT_ENDPOINT_IDENTIFIER_MAX_LEN: usize = 64;
 /// Reserved [`PaymentEndpointIdentifier`] value used by private Paykit storage.
 const PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE: &str = "private";
+/// Reserved [`PaymentEndpointIdentifier`] value used by recovery marker storage.
+const PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_RECOVERY: &str = "encrypted-link-recovery";
 
 impl PaymentEndpointIdentifier {
     /// Create a new `PaymentEndpointIdentifier` after validating the identifier.
@@ -59,9 +61,11 @@ impl PaymentEndpointIdentifier {
             )));
         }
 
-        if id == PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE {
+        if id == PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE
+            || id == PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_RECOVERY
+        {
             return Err(PaykitError::Validation(format!(
-                "PaymentEndpointIdentifier '{PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE}' is reserved for Private Payment Lists"
+                "PaymentEndpointIdentifier '{id}' is reserved for Paykit storage"
             )));
         }
 
@@ -398,9 +402,11 @@ mod validation_tests {
     }
 
     #[test]
-    fn test_payment_endpoint_identifier_reject_reserved_private() {
-        let err = PaymentEndpointIdentifier::new("private").unwrap_err();
-        assert!(matches!(err, PaykitError::Validation(msg) if msg.contains("reserved")));
+    fn test_payment_endpoint_identifier_reject_reserved_values() {
+        for reserved in ["private", "encrypted-link-recovery"] {
+            let err = PaymentEndpointIdentifier::new(reserved).unwrap_err();
+            assert!(matches!(err, PaykitError::Validation(msg) if msg.contains("reserved")));
+        }
     }
 
     // ── PaymentEndpointPayload: basic accessors ───────────────────────────────────

--- a/paykit-lib/src/payment_reference.rs
+++ b/paykit-lib/src/payment_reference.rs
@@ -1,7 +1,7 @@
 use crate::{PaykitError, Result};
 
 /// Payee-visible correlation reference used to connect payments with Paykit artifacts.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PaymentReference(String);
 
 /// Maximum Payment Reference length in Unicode scalar values.
@@ -44,6 +44,12 @@ impl std::fmt::Display for PaymentReference {
     }
 }
 
+impl std::fmt::Debug for PaymentReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("PaymentReference(<redacted>)")
+    }
+}
+
 impl AsRef<str> for PaymentReference {
     fn as_ref(&self) -> &str {
         &self.0
@@ -60,6 +66,7 @@ mod tests {
         let reference = PaymentReference::new("invoice 2026/0001").unwrap();
         assert_eq!(reference.as_str(), "invoice 2026/0001");
         assert_eq!(format!("{reference}"), "invoice 2026/0001");
+        assert_eq!(format!("{reference:?}"), "PaymentReference(<redacted>)");
     }
 
     #[test]

--- a/paykit-lib/src/payment_request/types.rs
+++ b/paykit-lib/src/payment_request/types.rs
@@ -122,7 +122,7 @@ impl fmt::Debug for PaymentRequestTerms {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PaymentRequestTerms")
             .field("amount", &"<redacted>")
-            .field("payment_reference", &self.payment_reference)
+            .field("payment_reference", &"<redacted>")
             .field("proposal_expires_at", &self.proposal_expires_at)
             .field("recurrence", &self.recurrence)
             .field(
@@ -307,7 +307,7 @@ impl fmt::Debug for PaymentProof {
             .field("kind", &self.kind)
             .field("event_id", &self.event_id)
             .field("payment_request_id", &self.payment_request_id)
-            .field("payment_reference", &self.payment_reference)
+            .field("payment_reference", &"<redacted>")
             .field("billing_period", &self.billing_period)
             .field(
                 "payment_endpoint_identifier",
@@ -659,6 +659,8 @@ mod tests {
             event: Ok(PaymentRequestEvent::Proof(proof.clone())),
         };
 
+        assert!(!format!("{request:?}").contains("invoice-2026-0001"));
+        assert!(!format!("{proof:?}").contains("invoice-2026-0001"));
         assert!(!format!("{request:?}").contains("private request note"));
         assert!(!format!("{proof:?}").contains("private proof secret"));
         let debug = format!("{message:?}");

--- a/paykit-lib/src/private_payment_list.rs
+++ b/paykit-lib/src/private_payment_list.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt};
 
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Serialize};
 use tracing::{debug, instrument};
 
 use crate::{
@@ -76,6 +76,7 @@ impl PrivatePaymentList {
 struct PrivatePaymentListWire {
     version: u8,
     kind: String,
+    #[serde(deserialize_with = "deserialize_payment_endpoints")]
     payment_endpoints: HashMap<String, String>,
 }
 
@@ -84,6 +85,42 @@ struct PrivatePaymentListWireRef<'a> {
     version: u8,
     kind: &'static str,
     payment_endpoints: HashMap<&'a str, &'a str>,
+}
+
+fn deserialize_payment_endpoints<'de, D>(
+    deserializer: D,
+) -> std::result::Result<HashMap<String, String>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    struct PaymentEndpointsVisitor;
+
+    impl<'de> de::Visitor<'de> for PaymentEndpointsVisitor {
+        type Value = HashMap<String, String>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a Payment Endpoint map without duplicate identifiers")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut payment_endpoints = HashMap::new();
+
+            while let Some((key, value)) = map.next_entry::<String, String>()? {
+                if payment_endpoints.insert(key.clone(), value).is_some() {
+                    return Err(de::Error::custom(format!(
+                        "duplicate Payment Endpoint identifier '{key}'"
+                    )));
+                }
+            }
+
+            Ok(payment_endpoints)
+        }
+    }
+
+    deserializer.deserialize_map(PaymentEndpointsVisitor)
 }
 
 /// Parse a versioned Private Payment List JSON message.
@@ -124,8 +161,8 @@ pub fn parse_private_payment_list_json(json: &str) -> Result<PrivatePaymentList>
     Ok(PrivatePaymentList::new(payment_endpoints))
 }
 
-/// Serializes a Private Payment List into its JSON wire representation.
-fn serialize_private_payment_list_json(list: &PrivatePaymentList) -> Result<String> {
+/// Serialize a Private Payment List into its JSON wire representation.
+pub fn serialize_private_payment_list_json(list: &PrivatePaymentList) -> Result<String> {
     let payment_endpoints = list
         .payment_endpoints
         .iter()
@@ -232,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_private_payment_list_json_rejects_removed_reference_field() {
+    fn test_parse_private_payment_list_json_rejects_reference_field() {
         let err = parse_private_payment_list_json(
             r#"{"version":1,"kind":"paykit.private_payment_list","reference":"invoice-2026-0001","payment_endpoints":{}}"#,
         )
@@ -301,6 +338,18 @@ mod tests {
         assert!(
             matches!(err, PaykitError::InvalidData { ref context, .. } if context.contains("failed to parse")),
             "expected InvalidData for non-string values, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_private_payment_list_json_rejects_duplicate_identifiers() {
+        let err = parse_private_payment_list_json(
+            r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{"lightning":"ln-one","lightning":"ln-two"}}"#,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, PaykitError::InvalidData { ref context, .. } if context.contains("duplicate Payment Endpoint identifier")),
+            "expected InvalidData for duplicate identifiers, got: {err}"
         );
     }
 

--- a/paykit-lib/src/pubky_routing.rs
+++ b/paykit-lib/src/pubky_routing.rs
@@ -29,6 +29,15 @@ pub const PAYKIT_PATH_PREFIX: &str = "/pub/paykit/v0/";
 /// individual file slots within the derived folders using a counter-based scheme.
 pub const PAYKIT_PRIVATE_PATH_PREFIX: &str = "/pub/paykit/v0/private";
 
+/// Conventional prefix for Encrypted Link recovery markers.
+///
+/// Marker paths are derived per-counterparty pair before being appended below
+/// this prefix, so the prefix itself does not identify the counterparty pair.
+pub const PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX: &str =
+    "/pub/paykit/v0/encrypted-link-recovery";
+
+const LIST_PAGE_LIMIT: u16 = 100;
+
 /// Writes or updates a payment endpoint document in the authenticated Pubky session.
 #[instrument(skip(session, payload), fields(identifier = %identifier))]
 pub async fn upsert_payment_endpoint(
@@ -61,13 +70,19 @@ pub async fn delete_payment_endpoint(
 ) -> Result<()> {
     let path = payment_endpoint_path(identifier);
     debug!(path = %path, "deleting payment endpoint from Pubky storage");
-    session.storage().delete(path).await.map_err(|err| {
-        error!(error = %err, "failed to delete payment endpoint");
-        PaykitError::Transport {
-            context: "delete endpoint".into(),
-            source: err.into(),
+    match session.storage().delete(path).await {
+        Ok(_) => {}
+        Err(err) if is_not_found(&err) => {
+            debug!("payment endpoint already absent");
         }
-    })?;
+        Err(err) => {
+            error!(error = %err, "failed to delete payment endpoint");
+            return Err(PaykitError::Transport {
+                context: "delete endpoint".into(),
+                source: err.into(),
+            });
+        }
+    }
     debug!("payment endpoint removed successfully");
     Ok(())
 }
@@ -207,38 +222,61 @@ async fn list_resources(
     label: &str,
 ) -> Result<Vec<PubkyResource>> {
     trace!("listing directory resources");
-    let builder = match storage.list(&addr) {
-        Ok(builder) => builder,
-        Err(err) if is_not_found(&err) => {
-            debug!("directory not found, returning empty list");
-            return Ok(Vec::new());
-        }
-        Err(err) => {
-            error!(error = %err, "failed to create list builder");
-            return Err(PaykitError::Transport {
-                context: label.to_string(),
-                source: err.into(),
-            });
-        }
-    };
+    let mut resources = Vec::new();
+    let mut cursor = None::<String>;
 
-    match builder.shallow(true).send().await {
-        Ok(resources) => {
-            debug!(count = resources.len(), "directory resources listed");
-            Ok(resources)
+    loop {
+        let mut builder = match storage.list(&addr) {
+            Ok(builder) => builder.shallow(true).limit(LIST_PAGE_LIMIT),
+            Err(err) if is_not_found(&err) => {
+                debug!("directory not found, returning listed resources");
+                return Ok(resources);
+            }
+            Err(err) => {
+                error!(error = %err, "failed to create list builder");
+                return Err(PaykitError::Transport {
+                    context: label.to_string(),
+                    source: err.into(),
+                });
+            }
+        };
+
+        if let Some(cursor) = cursor.as_deref() {
+            builder = builder.cursor(cursor);
         }
-        Err(err) if is_not_found(&err) => {
-            debug!("directory not found during send, returning empty list");
-            Ok(Vec::new())
+
+        let page = match builder.send().await {
+            Ok(page) => page,
+            Err(err) if is_not_found(&err) => {
+                debug!("directory not found during send, returning listed resources");
+                return Ok(resources);
+            }
+            Err(err) => {
+                error!(error = %err, "list send failed");
+                return Err(PaykitError::Transport {
+                    context: format!("{label} send failed"),
+                    source: err.into(),
+                });
+            }
+        };
+
+        if page.is_empty() {
+            break;
         }
-        Err(err) => {
-            error!(error = %err, "list send failed");
-            Err(PaykitError::Transport {
-                context: format!("{label} send failed"),
-                source: err.into(),
-            })
+
+        let page_len = page.len();
+        cursor = page
+            .last()
+            .map(|resource| format!("{}{}", resource.owner.z32(), resource.path.as_str()));
+        resources.extend(page);
+
+        if page_len < LIST_PAGE_LIMIT as usize {
+            break;
         }
     }
+
+    debug!(count = resources.len(), "directory resources listed");
+    Ok(resources)
 }
 
 fn is_not_found(err: &PubkyError) -> bool {

--- a/paykit-lib/src/receipt.rs
+++ b/paykit-lib/src/receipt.rs
@@ -3,14 +3,18 @@ mod crypto;
 mod types;
 mod wire;
 
-pub use access::{prepare_receipt, send_receipt_access, store_prepared_receipt};
+pub use access::{
+    prepare_receipt, prepare_receipt_for_recipient, send_receipt_access, store_prepared_receipt,
+};
 pub use crypto::decrypt_receipt;
 pub(crate) use types::RECEIPT_ENCRYPTION_ALGORITHM;
 pub use types::{
     PreparedReceipt, Receipt, ReceiptAccess, ReceiptAccessEventMessage, ReceiptDecryptionKey,
     ReceiptDraft, ReceiptId,
 };
-pub use wire::{parse_receipt_access_event_message, parse_receipt_access_json};
+pub use wire::{
+    parse_receipt_access_event_message, parse_receipt_access_json, serialize_receipt_access_json,
+};
 
 #[cfg(test)]
 use wire::{EncryptedReceiptWire, ReceiptWire};

--- a/paykit-lib/src/receipt/access.rs
+++ b/paykit-lib/src/receipt/access.rs
@@ -1,7 +1,7 @@
 use tracing::{debug, instrument};
 
 use crate::{
-    error::map_error, EncryptedLink, PaykitError, PrivateMessageKind, Result,
+    error::map_error, EncryptedLink, PaykitError, PrivateMessageKind, PublicKey, Result,
     PAYKIT_PRIVATE_PATH_PREFIX,
 };
 
@@ -71,6 +71,19 @@ impl ReceiptAccess {
 /// must be handled as sensitive data.
 #[instrument(skip(link, draft))]
 pub fn prepare_receipt(link: &EncryptedLink, draft: ReceiptDraft) -> Result<PreparedReceipt> {
+    prepare_receipt_for_recipient(link.recipient().clone(), draft)
+}
+
+/// Prepare a plaintext Receipt, Encrypted Receipt, and Receipt Access
+/// descriptor for an explicit recipient public key.
+///
+/// This is useful for stateful runtimes that queue Receipt Access delivery
+/// separately from receipt preparation.
+#[instrument(skip(recipient_public_key, draft))]
+pub fn prepare_receipt_for_recipient(
+    recipient_public_key: PublicKey,
+    draft: ReceiptDraft,
+) -> Result<PreparedReceipt> {
     debug!("preparing encrypted receipt");
     draft.validate_request_context()?;
     let receipt_id = draft.receipt_id.unwrap_or_else(ReceiptId::new_v4);
@@ -87,7 +100,7 @@ pub fn prepare_receipt(link: &EncryptedLink, draft: ReceiptDraft) -> Result<Prep
         payment_reference: payment_reference.clone(),
         payment_request_id: payment_request_id.clone(),
         billing_period: billing_period.clone(),
-        recipient_public_key: link.recipient().clone(),
+        recipient_public_key,
         payment_endpoint_identifier: draft.payment_endpoint_identifier,
         amount: draft.amount,
         metadata: draft.metadata,

--- a/paykit-lib/src/receipt/types.rs
+++ b/paykit-lib/src/receipt/types.rs
@@ -71,7 +71,7 @@ impl fmt::Debug for ReceiptDraft {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ReceiptDraft")
             .field("receipt_id", &self.receipt_id)
-            .field("payment_reference", &self.payment_reference)
+            .field("payment_reference", &"<redacted>")
             .field("payment_request_id", &self.payment_request_id)
             .field("billing_period", &self.billing_period)
             .field(
@@ -112,7 +112,7 @@ impl fmt::Debug for Receipt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Receipt")
             .field("receipt_id", &self.receipt_id)
-            .field("payment_reference", &self.payment_reference)
+            .field("payment_reference", &"<redacted>")
             .field("payment_request_id", &self.payment_request_id)
             .field("billing_period", &self.billing_period)
             .field("recipient_public_key", &self.recipient_public_key)
@@ -231,7 +231,7 @@ impl fmt::Debug for PreparedReceipt {
 }
 
 /// Receipt Access descriptor sent over the existing Noise channel.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ReceiptAccess {
     /// Receipt Access message version. Currently always `1`.
     pub version: u8,
@@ -251,6 +251,22 @@ pub struct ReceiptAccess {
     pub location: String,
     /// Symmetric key needed to decrypt the Receipt.
     pub key: ReceiptDecryptionKey,
+}
+
+impl fmt::Debug for ReceiptAccess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiptAccess")
+            .field("version", &self.version)
+            .field("kind", &self.kind)
+            .field("event_id", &self.event_id)
+            .field("receipt_id", &self.receipt_id)
+            .field("payment_reference", &"<redacted>")
+            .field("payment_request_id", &self.payment_request_id)
+            .field("billing_period", &self.billing_period)
+            .field("location", &"<redacted>")
+            .field("key", &"<redacted>")
+            .finish()
+    }
 }
 
 /// A recognized Receipt Access Event Message plus the raw JSON payload received
@@ -367,5 +383,72 @@ impl ReceiptAccess {
             self.billing_period.as_ref(),
             "Receipt Access",
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receipt_debug_redacts_payment_reference() {
+        let payment_reference = PaymentReference::new("invoice-secret-123").unwrap();
+        let draft = ReceiptDraft {
+            receipt_id: Some(ReceiptId::new_v4()),
+            payment_reference: payment_reference.clone(),
+            payment_request_id: Some(PaymentRequestId::new_v4()),
+            billing_period: None,
+            payment_endpoint_identifier: Some(
+                PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap(),
+            ),
+            amount: Some(PaymentAmount {
+                value: "0.001".to_string(),
+                asset: "btc".to_string(),
+            }),
+            metadata: JsonMap::from_iter([(
+                "note".to_string(),
+                JsonValue::String("private receipt note".to_string()),
+            )]),
+        };
+        let receipt = Receipt {
+            receipt_id: draft.receipt_id.clone().unwrap(),
+            payment_reference,
+            payment_request_id: draft.payment_request_id.clone(),
+            billing_period: None,
+            recipient_public_key: pubky::Keypair::random().public_key().clone(),
+            payment_endpoint_identifier: draft.payment_endpoint_identifier.clone(),
+            amount: draft.amount.clone(),
+            metadata: draft.metadata.clone(),
+        };
+
+        let access = ReceiptAccess {
+            version: 1,
+            kind: PrivateMessageKind::ReceiptAccess,
+            event_id: EventId::new_v4(),
+            receipt_id: receipt.receipt_id.clone(),
+            payment_reference: receipt.payment_reference.clone(),
+            payment_request_id: receipt.payment_request_id.clone(),
+            billing_period: None,
+            location: ReceiptAccess::location_for(&receipt.receipt_id),
+            key: ReceiptDecryptionKey::generate(),
+        };
+        let prepared = PreparedReceipt {
+            receipt: receipt.clone(),
+            encrypted_receipt: "encrypted-secret".into(),
+            access: access.clone(),
+        };
+
+        for debug in [
+            format!("{draft:?}"),
+            format!("{receipt:?}"),
+            format!("{access:?}"),
+            format!("{prepared:?}"),
+        ] {
+            assert!(!debug.contains("invoice-secret-123"));
+            assert!(!debug.contains("private receipt note"));
+            assert!(!debug.contains("encrypted-secret"));
+            assert!(!debug.contains(access.key.as_str()));
+            assert!(!debug.contains(&access.location));
+        }
     }
 }

--- a/paykit-lib/src/receipt/wire.rs
+++ b/paykit-lib/src/receipt/wire.rs
@@ -246,7 +246,7 @@ impl TryFrom<ReceiptAccessWire> for ReceiptAccess {
     }
 }
 
-pub(super) fn serialize_receipt_access_json(access: &ReceiptAccess) -> Result<String> {
+pub fn serialize_receipt_access_json(access: &ReceiptAccess) -> Result<String> {
     serde_json::to_string(&ReceiptAccessWire::from(access)).map_err(|err| {
         invalid_data(
             format!("failed to serialize Receipt Access JSON: {err}"),

--- a/paykit-lib/src/tests/payment_endpoint.rs
+++ b/paykit-lib/src/tests/payment_endpoint.rs
@@ -104,13 +104,35 @@ async fn list_reflects_additions_and_removals() {
 }
 
 #[tokio::test]
-async fn removing_missing_endpoint_is_error() {
+async fn list_fetches_multiple_pages() {
+    let setup = TestSetup::new().await;
+    let mut expected = HashMap::new();
+
+    for index in 0..105 {
+        let identifier = PaymentEndpointIdentifier::new(format!("endpoint-{index:03}")).unwrap();
+        let payload = PaymentEndpointPayload::new(format!("payload-{index:03}"));
+        set_payment_endpoint(&setup.session, identifier.clone(), payload.clone())
+            .await
+            .unwrap();
+        expected.insert(identifier, payload);
+    }
+
+    let list = get_payment_list(&setup.public_storage, &setup.public_key)
+        .await
+        .unwrap();
+    assert_eq!(list.payment_endpoints, expected);
+
+    setup.raw_session.signout().await.unwrap();
+}
+
+#[tokio::test]
+async fn removing_missing_endpoint_is_idempotent() {
     let setup = TestSetup::new().await;
     let method = PaymentEndpointIdentifier::new("unused").unwrap();
 
     remove_payment_endpoint(&setup.session, method)
         .await
-        .expect_err("removing non-existent endpoint should fail");
+        .expect("removing non-existent endpoint should be idempotent");
 
     setup.raw_session.signout().await.unwrap();
 }

--- a/paykit-sdk/Cargo.toml
+++ b/paykit-sdk/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "paykit-sdk"
+version = "0.1.0-rc12"
+authors = ["denys@synonym.to"]
+description = "Stateful Paykit SDK runtime"
+license = "MIT"
+edition = "2021"
+rust-version = "1.91.1"
+repository = "https://github.com/pubky/paykit-rs"
+homepage = "https://github.com/pubky/paykit-rs#readme"
+documentation = "https://docs.rs/paykit-sdk"
+readme = "README.md"
+keywords = ["paykit", "payments", "routing", "pubky"]
+categories = ["network-programming", "finance"]
+
+[dependencies]
+anyhow = "1.0.102"
+async-trait = "0.1"
+chrono = { version = "0.4.44", default-features = false, features = ["clock", "serde", "std"] }
+paykit-lib = { path = "../paykit-lib", version = "0.1.0-rc12" }
+pubky = "0.8.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+thiserror = "2.0.18"
+zeroize = "1"
+
+[dev-dependencies]
+tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }

--- a/paykit-sdk/README.md
+++ b/paykit-sdk/README.md
@@ -1,0 +1,170 @@
+# Paykit SDK
+
+Stateful Rust runtime for Paykit integrations.
+
+`paykit-sdk` builds on `paykit-lib` and owns SDK-level local state for Pubky
+identity status, public Payment Endpoint sync, Encrypted Link state, private
+stream intake, Private Payment List derivation, contact payment resolution, and
+outbound Private Application Message delivery. It also derives Payment Request
+state, indexes Receipt Access events, retrieves/decrypts Encrypted Receipts,
+tracks local receipt issuance, tracks optional Payment Endpoint Reservations,
+manages Paykit-facing profile and local contact records, and exports/restores
+SDK-managed backup state.
+
+The SDK currently exposes a Rust API. Platform SDK bindings are the next layer
+and should wrap this SDK surface as the primary mobile/app integration API.
+
+Payment execution, settlement detection, balances, route policy, product UI,
+and app backup transport stay outside the SDK and are provided by application
+or payment-adapter code.
+
+## Current Scope
+
+Implemented in this Rust SDK crate:
+
+- SDK runtime facade and atomic storage adapter contract
+- Pubky identity capability tracking and sign-out handling
+- public Payment Endpoint sync
+- Encrypted Link setup, private stream intake, outbound retries, and recovery
+  marker workflows
+- Private Payment List publication/cache and contact payment resolution
+- Payment Endpoint Reservations for contact-scoped receiving details
+- Payment Request lifecycle state, Receipt Access indexing, receipt issuance,
+  and receipt retrieval
+- Paykit-facing profile/contact helpers and SDK backup/restore
+
+Not implemented in this crate yet:
+
+- platform SDK bindings and first-party durable mobile storage helpers
+- payment execution, settlement confirmation, balances, fees, or route policy
+- product UI/profile screens, localization, and app backup transport
+- multi-device checkpoint synchronization and recurring payment scheduling
+
+## Integration Shape
+
+Apps construct `PaykitSdk` with three pieces:
+
+- a `StorageAdapter` that provides atomic local transactions
+- a `PubkySessionProvider` that returns live Pubky session access and clears it
+  during sign-out
+- a `PaymentAdapter` that supplies receiving details, endpoint selection, and
+  payment-target construction
+
+Typical startup:
+
+```rust,no_run
+use paykit_sdk::{PaykitSdk, PaykitSdkConfig};
+
+# async fn example<S, K, P>(storage: S, pubky: K, payment: P) -> paykit_sdk::Result<()>
+# where
+#     S: paykit_sdk::StorageAdapter,
+#     K: paykit_sdk::PubkySessionProvider,
+#     P: paykit_sdk::PaymentAdapter,
+# {
+let sdk = PaykitSdk::try_new(storage, pubky, payment, PaykitSdkConfig::default())?;
+let report = sdk.initialize().await?;
+
+if report.identity.private_link_capable {
+    // Private Paykit workflows can run for linked peers.
+}
+# Ok(())
+# }
+```
+
+Common workflows:
+
+- call `initialize` on startup to refresh identity capability from the Pubky
+  provider when live session access is available
+- call `sync_public_endpoints` after local receiving details change
+- set `profile_namespace` to a namespace segment such as `bitkit.to` when
+  profile/contact helpers should publish under `/pub/bitkit.to/...`
+- use `publish_paykit_profile` / `fetch_paykit_profile` for configured
+  Paykit Profile metadata, including app-specific public fields in `extra`
+- use `publish_paykit_blob` / `delete_paykit_blob` for files under the
+  configured Paykit blob prefix
+- use `fetch_pubky_file` / `fetch_pubky_text` to load public `pubky://`
+  files referenced by profile metadata
+- use `fetch_pubky_profile` / `fetch_pubky_follows` for read-only Pubky app
+  profile and follows data
+- use `resolve_contact_profile` when contact display should prefer Paykit
+  Profile and fall back to Pubky Profile
+- call `receive_private_messages` before deriving private Payment Lists,
+  Payment Requests, Receipt Access state, or resolving a contact payment when
+  the freshest private endpoints matter
+- call `resolve_contact_payment` to get ordered payable Payment Endpoints, each
+  with an adapter-built `PaymentTarget`; check `status` for the general payment
+  outcome and `private_state` for private-payment-specific recovery or
+  capability state
+- build receipt drafts with `ReceiptDraftBuilder`; call
+  `prepare_receipt_issuance` before receipt network side effects, then
+  `process_receipt_issuance`; use `issue_receipt` only when the draft already
+  has a caller-provided Receipt ID
+- call `linked_peers`, `pending_outbound_private_counterparties`,
+  `receipt_access_from`, `receipts_from`, and `issued_receipts_to` to drive
+  app-visible work queues
+- call `process_outbound_private_messages` for one counterparty, or
+  `process_pending_private_messages` from a broader retry worker
+- call `sync_public_contact_markers` on startup if the app uses public contact
+  markers
+- call `sign_out` when the app wants to clear live Pubky access and
+  SDK-managed identity-scoped state
+- export and persist an SDK backup before `sign_out` if the app wants that
+  sign-out to be reversible for the same user
+
+Outbound private sends are retried from durable records while the local
+Encrypted Link checkpoint is trustworthy. If a worker may have sent the queue
+head but failed before storing `Sent` status and the advanced snapshot, the SDK
+retries the same stale `Sending` message before later messages can advance the
+link. Outbound status is local checkpoint state, not counterparty
+acknowledgement. Non-retryable link-state failures still pause the peer for
+recovery. Superseded reservation cleanup failures are reported separately and do
+not block delivery of current outbound messages.
+
+Storage implementations must commit raw private stream items, derived indexes,
+and the advanced Encrypted Link snapshot atomically. If storage cannot provide
+that transaction boundary, it should fail the receive operation instead of
+persisting a partial checkpoint.
+
+Apps should also serialize identity-scoped operations such as `initialize`,
+`sign_out`, backup restore, and public endpoint sync when multiple runtime
+instances share the same storage. The SDK serializes `initialize`, `sign_out`,
+and public endpoint sync calls on one runtime instance and uses storage-backed
+per-peer leases for Encrypted Link work, but it does not add a process-wide
+identity or public endpoint lock by itself.
+
+`sign_out` clears live Pubky session access before clearing SDK-managed
+identity-scoped storage. If provider clearing fails, the SDK leaves local state
+intact so callers can retry without losing contacts, links, queues, or receipts.
+If provider clearing succeeds but local storage clearing fails, Pubky-backed
+workflows remain blocked because no live session is available; retry `sign_out`
+or clear SDK storage through the adapter.
+
+If the provider returns no live session access during ordinary startup or
+workflow calls, the SDK blocks Pubky-backed work but preserves the last
+identity-scoped state. Call `sign_out` when the app intentionally wants to clear
+that state. If the app wants to restore private Paykit state after sign-out, it
+must keep a separate SDK backup and not delete it as part of sign-out.
+
+Read-only private views such as cached Private Payment Lists can still be
+returned for the initialized identity when live private-link capability is
+missing. These cached views are local state, not proof that the Encrypted Link is
+currently healthy; apps should surface linked-peer recovery status when using
+cached private endpoints for payment resolution.
+
+The `storage` module is the advanced adapter boundary. Its record types include
+raw private payloads, Encrypted Link snapshots, and Receipt Decryption Keys so
+custom adapters can persist exact SDK state. App code should usually prefer the
+`PaykitSdk` runtime methods and app-facing record/view types.
+
+Backup restore preserves terminal invalid and recovery-required outbound
+private records for audit, while pending, sending, failed, sent, and superseded
+outbound records are validated before restore.
+Restored Encrypted Link checkpoints resume when they are valid. Missing or
+unsafe checkpoints mark affected peers recovery-required so private automation
+pauses until relink.
+
+Losing SDK-managed backup or state blob data means losing access to local
+private Paykit runtime state. Public Paykit data can be rediscovered from Pubky,
+but Encrypted Link snapshots, private stream history, Receipt Access keys,
+outbound queues, local Contact Records, and Payment Request/Receipt history
+cannot be safely reconstructed from homeserver data alone.

--- a/paykit-sdk/src/adapters.rs
+++ b/paykit-sdk/src/adapters.rs
@@ -1,0 +1,250 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fmt};
+
+use crate::{identity::PubkyPublicKey, PaykitSdkError, PubkySessionAccess, Result};
+
+/// Provides live Pubky session access to the SDK.
+///
+/// The provider owns platform-specific auth handoff, secure persistence, and
+/// key rotation. The SDK consumes the returned Pubky access for Paykit
+/// workflows.
+#[async_trait]
+pub trait PubkySessionProvider: Send + Sync {
+    /// Load live Pubky access for storage and Encrypted Link workflows.
+    ///
+    /// Returning `None` means no live session access is currently available. It
+    /// does not sign the SDK out or clear identity-scoped storage; call
+    /// [`PaykitSdk::sign_out`](crate::PaykitSdk::sign_out) for explicit sign-out.
+    async fn load_session_access(&self) -> Result<Option<PubkySessionAccess>>;
+
+    /// Load public Pubky storage for unauthenticated counterparty reads.
+    async fn load_public_storage(&self) -> Result<Option<pubky::PublicStorage>>;
+
+    /// Clear local Pubky session access during sign-out.
+    async fn clear_session_access(&self) -> Result<()>;
+}
+
+/// Adapter for payment-method-specific endpoint publication and selection.
+#[async_trait]
+pub trait PaymentAdapter: Send + Sync {
+    /// Return current receiving details for a scope.
+    async fn current_receiving_details(
+        &self,
+        scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>>;
+
+    /// Reserve receiving details for a counterparty's Private Payment List.
+    ///
+    /// Returning `None` means this adapter does not handle reservations and the
+    /// SDK should use regular receiving details.
+    ///
+    /// Returning `Some` means the returned reservations are the complete set of
+    /// private receiving details to share for that counterparty.
+    ///
+    /// Reservation happens in the payment adapter before the SDK can persist
+    /// linked records. Adapters that return reservations should make them
+    /// idempotent, expiring, or otherwise safe to abandon if the process stops
+    /// before the SDK queues a Private Payment List.
+    ///
+    /// The SDK cancels reservations that become invalid before they are sent.
+    /// Once a reservation-backed detail has been shared, payment-specific
+    /// settlement, expiry, and cleanup remain adapter responsibilities.
+    async fn reserve_receiving_details(
+        &self,
+        _counterparty: &PubkyPublicKey,
+    ) -> Result<Option<Vec<PaymentEndpointReservation>>> {
+        Ok(None)
+    }
+
+    /// Cancel a previously reserved receiving detail.
+    ///
+    /// Adapters that return reservations must implement this explicitly so
+    /// cleanup cannot silently succeed while backend reservations remain held.
+    async fn cancel_receiving_detail_reservation(
+        &self,
+        _cancellation: &PaymentEndpointReservationCancellation,
+    ) -> Result<()> {
+        Err(PaykitSdkError::PaymentAdapter {
+            context: "receiving-detail reservation cancellation is not implemented".into(),
+            source: None,
+        })
+    }
+
+    /// Return payable candidates in adapter-preferred order.
+    async fn select_payment_endpoints(
+        &self,
+        request: &PaymentEndpointSelectionRequest,
+    ) -> Result<Vec<PaymentEndpointCandidate>>;
+
+    /// Build a payment target from a payable endpoint.
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget>;
+}
+
+/// Scope used when asking for receiving details.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ReceivingDetailScope {
+    /// Details intended for public Payment Endpoints.
+    Public,
+    /// Details intended for one counterparty's Private Payment List.
+    Private {
+        /// Counterparty that will receive the private details.
+        counterparty: PubkyPublicKey,
+    },
+}
+
+/// Payment-method-specific receiving detail returned by an adapter.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceivingDetail {
+    /// Payment Endpoint Identifier string.
+    pub identifier: String,
+    /// Serialized endpoint payload.
+    pub payload: String,
+}
+
+impl fmt::Debug for ReceivingDetail {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceivingDetail")
+            .field("identifier", &self.identifier)
+            .field("payload", &redacted_payload(&self.payload))
+            .finish()
+    }
+}
+
+/// Receiving detail reserved by the payment adapter.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentEndpointReservation {
+    /// Adapter-stable reservation id; non-empty, at most 128 bytes, no control characters.
+    pub reservation_id: String,
+    /// Reserved receiving detail.
+    pub receiving_detail: ReceivingDetail,
+    /// Optional reservation expiry.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Adapter-provided attribution metadata.
+    pub attribution: HashMap<String, String>,
+}
+
+/// Request passed to cancel a receiving-detail reservation.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentEndpointReservationCancellation {
+    /// Adapter-stable reservation id.
+    pub reservation_id: String,
+    /// Counterparty the reservation was intended for.
+    pub counterparty: PubkyPublicKey,
+    /// Payment Endpoint Identifier.
+    pub identifier: String,
+    /// Hash of the reserved endpoint payload.
+    pub payload_hash: String,
+    /// Adapter-provided attribution metadata from the reservation.
+    pub attribution: HashMap<String, String>,
+}
+
+impl fmt::Debug for PaymentEndpointReservationCancellation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentEndpointReservationCancellation")
+            .field("reservation_id", &self.reservation_id)
+            .field("counterparty", &self.counterparty)
+            .field("identifier", &self.identifier)
+            .field("payload_hash", &self.payload_hash)
+            .field(
+                "attribution",
+                &format_args!("<redacted:{} fields>", self.attribution.len()),
+            )
+            .finish()
+    }
+}
+
+impl fmt::Debug for PaymentEndpointReservation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentEndpointReservation")
+            .field("reservation_id", &self.reservation_id)
+            .field("receiving_detail", &self.receiving_detail)
+            .field("expires_at", &self.expires_at)
+            .field(
+                "attribution",
+                &format_args!("<redacted:{} fields>", self.attribution.len()),
+            )
+            .finish()
+    }
+}
+
+/// Candidate endpoint to check or pay.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentEndpointCandidate {
+    /// Counterparty that published the endpoint.
+    pub counterparty: PubkyPublicKey,
+    /// Where the endpoint was discovered.
+    pub source: PaymentEndpointSource,
+    /// Payment Endpoint Identifier string.
+    pub identifier: String,
+    /// Serialized endpoint payload.
+    pub payload: String,
+}
+
+impl fmt::Debug for PaymentEndpointCandidate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentEndpointCandidate")
+            .field("counterparty", &self.counterparty)
+            .field("source", &self.source)
+            .field("identifier", &self.identifier)
+            .field("payload", &redacted_payload(&self.payload))
+            .finish()
+    }
+}
+
+/// Source of a discovered Payment Endpoint candidate.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PaymentEndpointSource {
+    /// Endpoint came from a counterparty-specific Private Payment List.
+    PrivatePaymentList,
+    /// Endpoint came from a public Payment Endpoint.
+    PublicPaymentEndpoint,
+}
+
+/// Optional amount context for endpoint selection.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentAmountContext {
+    /// Decimal amount text.
+    pub value: String,
+    /// Asset code or unit.
+    pub asset: String,
+}
+
+/// Request passed to the payment adapter for payable endpoint ordering.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentEndpointSelectionRequest {
+    /// Counterparty being paid.
+    pub counterparty: PubkyPublicKey,
+    /// Optional amount context.
+    pub amount: Option<PaymentAmountContext>,
+    /// Candidate endpoints in SDK preference order.
+    pub candidates: Vec<PaymentEndpointCandidate>,
+}
+
+/// Payment-method-specific execution payload produced by an adapter.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentTarget {
+    /// Method-specific target payload.
+    pub payload: String,
+}
+
+impl fmt::Debug for PaymentTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentTarget")
+            .field("payload", &redacted_payload(&self.payload))
+            .finish()
+    }
+}
+
+fn redacted_payload(payload: &str) -> String {
+    format!("<redacted:{} bytes>", payload.len())
+}
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/adapters/tests.rs
+++ b/paykit-sdk/src/adapters/tests.rs
@@ -1,0 +1,25 @@
+use super::*;
+
+fn counterparty() -> PubkyPublicKey {
+    PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+}
+
+#[test]
+fn test_endpoint_debug_redacts_payloads() {
+    let candidate = PaymentEndpointCandidate {
+        counterparty: counterparty(),
+        source: PaymentEndpointSource::PrivatePaymentList,
+        identifier: "btc-lightning-bolt11".into(),
+        payload: "ln-private-secret".into(),
+    };
+    let target = PaymentTarget {
+        payload: "method-specific-target".into(),
+    };
+
+    let debug = format!("{:?} {target:?}", vec![candidate]);
+
+    assert!(!debug.contains("ln-private-secret"));
+    assert!(!debug.contains("method-specific-target"));
+    assert!(debug.contains("<redacted:17 bytes>"));
+    assert!(debug.contains("<redacted:22 bytes>"));
+}

--- a/paykit-sdk/src/backup.rs
+++ b/paykit-sdk/src/backup.rs
@@ -1,0 +1,529 @@
+//! SDK backup and restore state.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    contacts::ContactRecord,
+    endpoint_reservations::{reservation_payload_hash, validate_reservation_id},
+    identity::{IdentityState, PubkyIdentityCapability, PubkyPublicKey},
+    linked_peers::LinkedPeerState,
+    outbound_private::validate_queued_outbound_private_message,
+    private_stream::{
+        classify_private_application_message, payload_hash, PrivateStreamParseStatus,
+    },
+    publication::PublicationStatus,
+    receipts::{
+        receipt_access_key_hash, ReceiptAccessRecord, ReceiptIssuanceRecord, ReceiptIssuanceStatus,
+        ReceiptRecord, ReceiptRetrievalStatus,
+    },
+    records::{AmountRecord, BillingPeriodRecord},
+    storage::{
+        EncryptedLinkStateRecord, EventDedupRecord, LinkedPeerRecord, OutboundPrivateMessageRecord,
+        PaymentEndpointReservationRecord, PrivateStreamItemRecord, PublicEndpointRecord,
+        StorageAdapter, StorageState,
+    },
+    OutboundPrivateMessageStatus, PaykitSdkError, Result,
+};
+use paykit_lib::{
+    parse_private_payment_list_json, PaymentEndpointIdentifier, PrivateApplicationMessage,
+    PrivateMessageKind, ReceiptId,
+};
+
+mod validation;
+
+use validation::*;
+
+/// Current SDK backup schema version.
+pub const SDK_BACKUP_VERSION: u32 = 1;
+
+/// Versioned SDK-managed backup payload.
+///
+/// This payload includes private SDK recovery data such as Encrypted Link
+/// snapshots, raw Private Application Messages, outbound payloads, and Receipt
+/// Decryption Keys. Store and transport it with caller-managed encryption.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SdkBackupState {
+    /// Backup schema version.
+    pub version: u32,
+    /// Current identity state.
+    pub identity_state: Option<IdentityState>,
+    /// Linked Peer records.
+    pub linked_peers: Vec<LinkedPeerRecord>,
+    /// Local contact records.
+    pub contact_records: Vec<ContactRecord>,
+    /// Public Payment Endpoint records.
+    pub public_endpoint_records: Vec<PublicEndpointRecord>,
+    /// Payment Endpoint Reservation records.
+    pub payment_endpoint_reservations: Vec<PaymentEndpointReservationRecord>,
+    /// Encrypted Link state records.
+    pub encrypted_link_states: Vec<EncryptedLinkStateRecord>,
+    /// Outbound Private Application Message records.
+    pub outbound_private_messages: Vec<OutboundPrivateMessageRecord>,
+    /// Private stream item records.
+    pub private_stream_items: Vec<PrivateStreamItemRecord>,
+    /// Event Message dedupe records.
+    pub event_dedup_records: Vec<EventDedupRecord>,
+    /// Receipt Access records.
+    pub receipt_access_records: Vec<ReceiptAccessRecord>,
+    /// Decrypted Receipt records.
+    pub receipt_records: Vec<ReceiptRecord>,
+    /// Local receipt issuance records.
+    pub receipt_issuance_records: Vec<ReceiptIssuanceRecord>,
+    /// Next outbound Private Application Message id.
+    pub next_outbound_private_message_id: u64,
+    /// Next private receive batch id.
+    pub next_receive_batch_id: u64,
+    /// Next private stream item id.
+    pub next_private_stream_item_id: u64,
+}
+
+impl fmt::Debug for SdkBackupState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SdkBackupState")
+            .field("version", &self.version)
+            .field(
+                "identity_state",
+                &self.identity_state.as_ref().map(|_| "<redacted>"),
+            )
+            .field("linked_peers", &self.linked_peers.len())
+            .field("contact_records", &self.contact_records.len())
+            .field(
+                "public_endpoint_records",
+                &self.public_endpoint_records.len(),
+            )
+            .field(
+                "payment_endpoint_reservations",
+                &self.payment_endpoint_reservations.len(),
+            )
+            .field("encrypted_link_states", &self.encrypted_link_states.len())
+            .field(
+                "outbound_private_messages",
+                &self.outbound_private_messages.len(),
+            )
+            .field("private_stream_items", &self.private_stream_items.len())
+            .field("event_dedup_records", &self.event_dedup_records.len())
+            .field("receipt_access_records", &self.receipt_access_records.len())
+            .field("receipt_records", &self.receipt_records.len())
+            .field(
+                "receipt_issuance_records",
+                &self.receipt_issuance_records.len(),
+            )
+            .field(
+                "next_outbound_private_message_id",
+                &self.next_outbound_private_message_id,
+            )
+            .field("next_receive_batch_id", &self.next_receive_batch_id)
+            .field(
+                "next_private_stream_item_id",
+                &self.next_private_stream_item_id,
+            )
+            .finish()
+    }
+}
+
+/// Report returned after restoring SDK-managed backup state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RestoreReport {
+    /// Restored backup schema version.
+    pub version: u32,
+    /// Whether identity state was restored.
+    pub restored_identity: bool,
+    /// Number of restored Linked Peer records.
+    pub linked_peers: usize,
+    /// Number of restored local contact records.
+    pub contact_records: usize,
+    /// Number of restored public Payment Endpoint records.
+    pub public_endpoint_records: usize,
+    /// Number of restored Payment Endpoint Reservation records.
+    pub payment_endpoint_reservations: usize,
+    /// Number of restored Encrypted Link state records.
+    pub encrypted_link_states: usize,
+    /// Number of restored outbound Private Application Message records.
+    pub outbound_private_messages: usize,
+    /// Number of restored private stream item records.
+    pub private_stream_items: usize,
+    /// Number of restored Event Message dedupe records.
+    pub event_dedup_records: usize,
+    /// Number of restored Receipt Access records.
+    pub receipt_access_records: usize,
+    /// Number of restored decrypted Receipt records.
+    pub receipt_records: usize,
+    /// Number of restored local receipt issuance records.
+    pub receipt_issuance_records: usize,
+    /// Counterparties restored as recovery-required.
+    pub recovery_required_peers: Vec<PubkyPublicKey>,
+}
+
+/// Backup-validated storage replacement payload.
+///
+/// This type is intentionally opaque to callers. It prevents arbitrary full
+/// storage replacement through [`StorageTransaction`](crate::StorageTransaction)
+/// while still letting storage adapters apply validated backup state.
+pub struct ValidatedStorageState {
+    state: StorageState,
+}
+
+impl ValidatedStorageState {
+    pub(crate) fn new(state: StorageState) -> Self {
+        Self { state }
+    }
+
+    /// Consume the validated wrapper and return the storage state.
+    pub fn into_storage_state(self) -> StorageState {
+        self.state
+    }
+}
+
+/// Export SDK-managed state from storage.
+pub async fn export_backup_state<S>(storage: &S) -> Result<SdkBackupState>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| {
+            Ok(SdkBackupState::from_storage_state(
+                tx.export_storage_state(),
+            ))
+        })
+        .await
+}
+
+#[cfg(test)]
+pub(crate) async fn restore_backup_state<S>(
+    storage: &S,
+    backup: SdkBackupState,
+) -> Result<RestoreReport>
+where
+    S: StorageAdapter,
+{
+    restore_backup_state_with_identity(storage, backup, None).await
+}
+
+pub(crate) async fn restore_backup_state_with_identity<S>(
+    storage: &S,
+    backup: SdkBackupState,
+    trusted_identity: Option<IdentityState>,
+) -> Result<RestoreReport>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(move |tx| {
+            let stored_identity = tx.load_identity_state();
+            let current_identity = trusted_identity.as_ref().or(stored_identity.as_ref());
+            let current_next_peer_link_operation_lease_id =
+                tx.export_storage_state().next_peer_link_operation_lease_id;
+            let (state, report) = backup
+                .into_storage_state(current_identity, current_next_peer_link_operation_lease_id)?;
+            tx.replace_storage_state(state);
+            Ok(report)
+        })
+        .await
+}
+
+impl SdkBackupState {
+    pub(crate) fn from_storage_state(state: StorageState) -> Self {
+        let mut linked_peers = state.linked_peers.into_values().collect::<Vec<_>>();
+        linked_peers
+            .sort_by(|left, right| left.counterparty.as_str().cmp(right.counterparty.as_str()));
+
+        let mut contact_records = state.contact_records.into_values().collect::<Vec<_>>();
+        contact_records
+            .sort_by(|left, right| left.public_key.as_str().cmp(right.public_key.as_str()));
+
+        let mut public_endpoint_records = state
+            .public_endpoint_records
+            .into_values()
+            .collect::<Vec<_>>();
+        public_endpoint_records.sort_by(|left, right| left.identifier.cmp(&right.identifier));
+
+        let mut payment_endpoint_reservations = state
+            .payment_endpoint_reservations
+            .into_values()
+            .collect::<Vec<_>>();
+        payment_endpoint_reservations.sort_by(|left, right| {
+            left.counterparty
+                .as_str()
+                .cmp(right.counterparty.as_str())
+                .then(left.reservation_id.cmp(&right.reservation_id))
+        });
+
+        let mut encrypted_link_states = state
+            .encrypted_link_states
+            .into_values()
+            .collect::<Vec<_>>();
+        encrypted_link_states
+            .sort_by(|left, right| left.counterparty.as_str().cmp(right.counterparty.as_str()));
+
+        let mut event_dedup_records = state.event_dedup_records.into_values().collect::<Vec<_>>();
+        event_dedup_records.sort_by(|left, right| {
+            left.counterparty
+                .as_str()
+                .cmp(right.counterparty.as_str())
+                .then(left.event_id.cmp(&right.event_id))
+        });
+
+        let mut receipt_access_records = state
+            .receipt_access_records
+            .into_values()
+            .collect::<Vec<_>>();
+        receipt_access_records.sort_by(|left, right| {
+            left.counterparty
+                .as_str()
+                .cmp(right.counterparty.as_str())
+                .then(left.event_id.cmp(&right.event_id))
+        });
+
+        let mut receipt_records = state.receipt_records.into_values().collect::<Vec<_>>();
+        receipt_records.sort_by(|left, right| {
+            left.issuer
+                .as_str()
+                .cmp(right.issuer.as_str())
+                .then(left.receipt_id.cmp(&right.receipt_id))
+        });
+
+        let mut receipt_issuance_records = state
+            .receipt_issuance_records
+            .into_values()
+            .collect::<Vec<_>>();
+        receipt_issuance_records.sort_by(|left, right| {
+            left.counterparty
+                .as_str()
+                .cmp(right.counterparty.as_str())
+                .then(left.receipt_id.cmp(&right.receipt_id))
+        });
+
+        Self {
+            version: SDK_BACKUP_VERSION,
+            identity_state: state.identity_state,
+            linked_peers,
+            contact_records,
+            public_endpoint_records,
+            payment_endpoint_reservations,
+            encrypted_link_states,
+            outbound_private_messages: state.outbound_private_messages,
+            private_stream_items: state.private_stream_items,
+            event_dedup_records,
+            receipt_access_records,
+            receipt_records,
+            receipt_issuance_records,
+            next_outbound_private_message_id: state.next_outbound_private_message_id,
+            next_receive_batch_id: state.next_receive_batch_id,
+            next_private_stream_item_id: state.next_private_stream_item_id,
+        }
+    }
+
+    fn into_storage_state(
+        self,
+        current_identity: Option<&IdentityState>,
+        next_peer_link_operation_lease_id: u64,
+    ) -> Result<(ValidatedStorageState, RestoreReport)> {
+        self.validate(current_identity)?;
+
+        let mut identity_state = self.identity_state;
+        preserve_current_sign_out_generation(&mut identity_state, current_identity);
+        let mut linked_peers = keyed_by_counterparty(self.linked_peers, "Linked Peer")?;
+        validate_linked_peer_records(&linked_peers)?;
+        let contact_records = keyed_by_tuple(
+            self.contact_records,
+            |record| record.public_key.clone(),
+            "local contact",
+        )?;
+        validate_contact_records(&contact_records)?;
+        let public_endpoint_records = keyed_by_string(
+            self.public_endpoint_records,
+            |record| record.identifier.clone(),
+            "public Payment Endpoint",
+        )?;
+        validate_public_endpoint_records(&public_endpoint_records)?;
+        let payment_endpoint_reservations = keyed_by_tuple(
+            self.payment_endpoint_reservations,
+            |record| (record.counterparty.clone(), record.reservation_id.clone()),
+            "Payment Endpoint Reservation",
+        )?;
+        let mut encrypted_link_states =
+            keyed_by_counterparty(self.encrypted_link_states, "Encrypted Link state")?;
+        validate_encrypted_link_snapshots(&encrypted_link_states)?;
+        let mut outbound_private_messages =
+            unique_outbound_messages(self.outbound_private_messages)?;
+        validate_outbound_private_messages(&outbound_private_messages)?;
+        validate_payment_endpoint_reservations(
+            &payment_endpoint_reservations,
+            &outbound_private_messages,
+        )?;
+        let private_stream_items = unique_private_stream_items(self.private_stream_items)?;
+        validate_private_stream_items(&private_stream_items)?;
+        let event_dedup_records = keyed_by_tuple(
+            self.event_dedup_records,
+            |record| (record.counterparty.clone(), record.event_id.clone()),
+            "Event dedupe",
+        )?;
+        validate_event_dedup_records(&event_dedup_records, &private_stream_items)?;
+        let receipt_access_records = keyed_by_tuple(
+            self.receipt_access_records,
+            |record| (record.counterparty.clone(), record.event_id.clone()),
+            "Receipt Access",
+        )?;
+        validate_receipt_access_records(&receipt_access_records, &private_stream_items)?;
+        validate_required_private_stream_indexes(
+            &private_stream_items,
+            &event_dedup_records,
+            &receipt_access_records,
+        )?;
+        let receipt_records = keyed_by_tuple(
+            self.receipt_records,
+            |record| (record.issuer.clone(), record.receipt_id.clone()),
+            "Receipt",
+        )?;
+        let expected_receipt_recipient = identity_state
+            .as_ref()
+            .and_then(|identity| identity.public_key.as_ref());
+        validate_receipt_records(
+            &receipt_records,
+            &receipt_access_records,
+            expected_receipt_recipient,
+        )?;
+        let receipt_issuance_records = keyed_by_tuple(
+            self.receipt_issuance_records,
+            |record| (record.counterparty.clone(), record.receipt_id.clone()),
+            "Receipt issuance",
+        )?;
+        validate_receipt_issuance_records(&receipt_issuance_records, &outbound_private_messages)?;
+
+        let recovery_required_peers = reconcile_restored_linked_peers(
+            &mut linked_peers,
+            &encrypted_link_states,
+            &outbound_private_messages,
+        );
+        clear_recovery_required_link_snapshots(
+            &mut encrypted_link_states,
+            &recovery_required_peers,
+        );
+        mark_restored_sending_outbound_recovery_required(
+            &mut outbound_private_messages,
+            &recovery_required_peers,
+        );
+
+        let next_outbound_private_message_id = self
+            .next_outbound_private_message_id
+            .max(next_outbound_id(&outbound_private_messages));
+        let next_receive_batch_id = self
+            .next_receive_batch_id
+            .max(next_receive_batch_id(&private_stream_items));
+        let next_private_stream_item_id = self
+            .next_private_stream_item_id
+            .max(next_private_stream_item_id(&private_stream_items));
+
+        let report = RestoreReport {
+            version: self.version,
+            restored_identity: identity_state.is_some(),
+            linked_peers: linked_peers.len(),
+            contact_records: contact_records.len(),
+            public_endpoint_records: public_endpoint_records.len(),
+            payment_endpoint_reservations: payment_endpoint_reservations.len(),
+            encrypted_link_states: encrypted_link_states.len(),
+            outbound_private_messages: outbound_private_messages.len(),
+            private_stream_items: private_stream_items.len(),
+            event_dedup_records: event_dedup_records.len(),
+            receipt_access_records: receipt_access_records.len(),
+            receipt_records: receipt_records.len(),
+            receipt_issuance_records: receipt_issuance_records.len(),
+            recovery_required_peers,
+        };
+
+        let state = StorageState {
+            identity_state,
+            linked_peers,
+            contact_records,
+            public_endpoint_records,
+            payment_endpoint_reservations,
+            encrypted_link_states,
+            peer_link_operation_leases: HashMap::new(),
+            next_peer_link_operation_lease_id,
+            outbound_private_messages,
+            next_outbound_private_message_id,
+            private_stream_items,
+            next_receive_batch_id,
+            next_private_stream_item_id,
+            event_dedup_records,
+            receipt_access_records,
+            receipt_records,
+            receipt_issuance_records,
+        };
+
+        Ok((ValidatedStorageState::new(state), report))
+    }
+
+    fn validate(&self, current_identity: Option<&IdentityState>) -> Result<()> {
+        if self.version != SDK_BACKUP_VERSION {
+            return Err(PaykitSdkError::Protocol(format!(
+                "unsupported SDK backup version {}",
+                self.version
+            )));
+        }
+
+        if let Some(current_public_key) =
+            current_identity.and_then(|state| state.public_key.as_ref())
+        {
+            let backup_public_key = self
+                .identity_state
+                .as_ref()
+                .and_then(|state| state.public_key.as_ref());
+            if backup_public_key != Some(current_public_key) {
+                return Err(PaykitSdkError::Identity {
+                    context: "backup identity does not match current local identity".into(),
+                    source: None,
+                });
+            }
+        }
+
+        let backup_public_key = self
+            .identity_state
+            .as_ref()
+            .and_then(|state| state.public_key.as_ref());
+        if backup_public_key.is_none() && self.has_identity_scoped_state() {
+            return Err(PaykitSdkError::Protocol(
+                "backup has SDK state but no local public identity".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn identity_public_key(&self) -> Option<&PubkyPublicKey> {
+        self.identity_state
+            .as_ref()
+            .and_then(|state| state.public_key.as_ref())
+    }
+
+    pub(crate) fn has_identity_scoped_state(&self) -> bool {
+        !self.linked_peers.is_empty()
+            || !self.contact_records.is_empty()
+            || !self.public_endpoint_records.is_empty()
+            || !self.payment_endpoint_reservations.is_empty()
+            || !self.encrypted_link_states.is_empty()
+            || !self.outbound_private_messages.is_empty()
+            || !self.private_stream_items.is_empty()
+            || !self.event_dedup_records.is_empty()
+            || !self.receipt_access_records.is_empty()
+            || !self.receipt_records.is_empty()
+            || !self.receipt_issuance_records.is_empty()
+    }
+
+    pub(crate) fn has_private_identity_scoped_state(&self) -> bool {
+        !self.linked_peers.is_empty()
+            || !self.payment_endpoint_reservations.is_empty()
+            || !self.encrypted_link_states.is_empty()
+            || !self.outbound_private_messages.is_empty()
+            || !self.private_stream_items.is_empty()
+            || !self.event_dedup_records.is_empty()
+            || !self.receipt_access_records.is_empty()
+            || !self.receipt_records.is_empty()
+            || !self.receipt_issuance_records.is_empty()
+    }
+}

--- a/paykit-sdk/src/backup/validation.rs
+++ b/paykit-sdk/src/backup/validation.rs
@@ -1,0 +1,1245 @@
+use super::*;
+use chrono::{DateTime, Utc};
+
+pub(super) fn preserve_current_sign_out_generation(
+    backup_identity: &mut Option<IdentityState>,
+    current_identity: Option<&IdentityState>,
+) {
+    match (backup_identity, current_identity) {
+        (Some(backup_identity), Some(current_identity))
+            if backup_identity.public_key == current_identity.public_key =>
+        {
+            backup_identity.sign_out_generation = backup_identity
+                .sign_out_generation
+                .max(current_identity.sign_out_generation);
+        }
+        (backup_identity @ None, Some(current_identity))
+            if current_identity.capability == PubkyIdentityCapability::SignedOut =>
+        {
+            *backup_identity = Some(current_identity.clone());
+        }
+        _ => {}
+    }
+}
+
+pub(super) fn keyed_by_counterparty<T>(
+    records: Vec<T>,
+    label: &str,
+) -> Result<HashMap<PubkyPublicKey, T>>
+where
+    T: HasCounterparty,
+{
+    keyed_by_tuple(records, |record| record.counterparty().clone(), label)
+}
+
+pub(super) trait HasCounterparty {
+    fn counterparty(&self) -> &PubkyPublicKey;
+}
+
+impl HasCounterparty for LinkedPeerRecord {
+    fn counterparty(&self) -> &PubkyPublicKey {
+        &self.counterparty
+    }
+}
+
+impl HasCounterparty for EncryptedLinkStateRecord {
+    fn counterparty(&self) -> &PubkyPublicKey {
+        &self.counterparty
+    }
+}
+
+pub(super) fn keyed_by_string<T, F>(
+    records: Vec<T>,
+    key: F,
+    label: &str,
+) -> Result<HashMap<String, T>>
+where
+    F: Fn(&T) -> String,
+{
+    keyed_by_tuple(records, key, label)
+}
+
+pub(super) fn keyed_by_tuple<K, T, F>(records: Vec<T>, key: F, label: &str) -> Result<HashMap<K, T>>
+where
+    K: Eq + std::hash::Hash + fmt::Debug,
+    F: Fn(&T) -> K,
+{
+    let mut keyed = HashMap::new();
+    for record in records {
+        let key = key(&record);
+        if keyed.insert(key, record).is_some() {
+            return Err(PaykitSdkError::Protocol(format!(
+                "duplicate {label} backup key"
+            )));
+        }
+    }
+    Ok(keyed)
+}
+
+pub(super) fn unique_outbound_messages(
+    mut records: Vec<OutboundPrivateMessageRecord>,
+) -> Result<Vec<OutboundPrivateMessageRecord>> {
+    let mut ids = HashSet::new();
+    for record in &records {
+        if !ids.insert(record.outbound_message_id) {
+            return Err(PaykitSdkError::Protocol(format!(
+                "duplicate outbound Private Application Message id {}",
+                record.outbound_message_id
+            )));
+        }
+    }
+    records.sort_by_key(|record| record.outbound_message_id);
+    Ok(records)
+}
+
+pub(super) fn unique_private_stream_items(
+    mut records: Vec<PrivateStreamItemRecord>,
+) -> Result<Vec<PrivateStreamItemRecord>> {
+    let mut ids = HashSet::new();
+    for record in &records {
+        if !ids.insert(record.stream_item_id) {
+            return Err(PaykitSdkError::Protocol(format!(
+                "duplicate private stream item id {}",
+                record.stream_item_id
+            )));
+        }
+    }
+    records.sort_by_key(|record| record.stream_item_id);
+    Ok(records)
+}
+
+pub(super) fn next_outbound_id(records: &[OutboundPrivateMessageRecord]) -> u64 {
+    records
+        .iter()
+        .map(|record| record.outbound_message_id.saturating_add(1))
+        .max()
+        .unwrap_or_default()
+}
+
+pub(super) fn next_receive_batch_id(records: &[PrivateStreamItemRecord]) -> u64 {
+    records
+        .iter()
+        .map(|record| record.receive_batch_id.saturating_add(1))
+        .max()
+        .unwrap_or_default()
+}
+
+pub(super) fn next_private_stream_item_id(records: &[PrivateStreamItemRecord]) -> u64 {
+    records
+        .iter()
+        .map(|record| record.stream_item_id.saturating_add(1))
+        .max()
+        .unwrap_or_default()
+}
+
+pub(super) fn reconcile_restored_linked_peers(
+    linked_peers: &mut HashMap<PubkyPublicKey, LinkedPeerRecord>,
+    encrypted_link_states: &HashMap<PubkyPublicKey, EncryptedLinkStateRecord>,
+    outbound_private_messages: &[OutboundPrivateMessageRecord],
+) -> Vec<PubkyPublicKey> {
+    for (counterparty, link_state) in encrypted_link_states {
+        let restored_state = restored_peer_state_from_link_state(link_state);
+        let checkpointed_at = link_state.checkpointed_at;
+        linked_peers
+            .entry(counterparty.clone())
+            .and_modify(|peer| {
+                if matches!(
+                    peer.state,
+                    LinkedPeerState::Blocked | LinkedPeerState::RecoveryRequired
+                ) {
+                    return;
+                }
+                match restored_state {
+                    Some(LinkedPeerState::Linked) => peer.state = LinkedPeerState::Linked,
+                    Some(LinkedPeerState::Linking) if peer.state != LinkedPeerState::Linked => {
+                        peer.state = LinkedPeerState::Linking;
+                    }
+                    None if matches!(
+                        peer.state,
+                        LinkedPeerState::Linked | LinkedPeerState::Linking
+                    ) =>
+                    {
+                        peer.state = LinkedPeerState::RecoveryRequired;
+                    }
+                    _ => {}
+                }
+                if peer.last_sync_at.is_none() {
+                    peer.last_sync_at = Some(checkpointed_at);
+                }
+            })
+            .or_insert_with(|| {
+                restored_peer_record(
+                    counterparty.clone(),
+                    restored_state.unwrap_or(LinkedPeerState::RecoveryRequired),
+                    checkpointed_at,
+                )
+            });
+    }
+
+    for (counterparty, peer) in linked_peers.iter_mut() {
+        if !encrypted_link_states.contains_key(counterparty)
+            && matches!(
+                peer.state,
+                LinkedPeerState::Linked | LinkedPeerState::Linking
+            )
+        {
+            peer.state = LinkedPeerState::RecoveryRequired;
+        }
+    }
+
+    let active_link_counterparties = encrypted_link_states
+        .iter()
+        .filter_map(|(counterparty, state)| state.link_snapshot.is_some().then_some(counterparty))
+        .cloned()
+        .collect::<HashSet<_>>();
+    for message in outbound_private_messages {
+        if outbound_status_requires_link(&message.status)
+            && !active_link_counterparties.contains(&message.counterparty)
+        {
+            linked_peers
+                .entry(message.counterparty.clone())
+                .and_modify(|peer| {
+                    if peer.state != LinkedPeerState::Blocked {
+                        peer.state = LinkedPeerState::RecoveryRequired;
+                    }
+                })
+                .or_insert_with(|| {
+                    restored_peer_record(
+                        message.counterparty.clone(),
+                        LinkedPeerState::RecoveryRequired,
+                        message.updated_at,
+                    )
+                });
+        }
+    }
+
+    let mut peers = Vec::new();
+    for record in linked_peers.values() {
+        if record.state == LinkedPeerState::RecoveryRequired {
+            peers.push(record.counterparty.clone());
+        }
+    }
+    peers.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+    peers
+}
+
+fn restored_peer_state_from_link_state(
+    record: &EncryptedLinkStateRecord,
+) -> Option<LinkedPeerState> {
+    if record.link_snapshot.is_some() {
+        Some(LinkedPeerState::Linked)
+    } else if record.handshake_snapshot.is_some() && record.handshake_role.is_some() {
+        Some(LinkedPeerState::Linking)
+    } else {
+        None
+    }
+}
+
+fn restored_peer_record(
+    counterparty: PubkyPublicKey,
+    state: LinkedPeerState,
+    last_sync_at: DateTime<Utc>,
+) -> LinkedPeerRecord {
+    LinkedPeerRecord {
+        counterparty,
+        state,
+        last_sync_at: Some(last_sync_at),
+        last_private_receive_at: None,
+        failure_count: 0,
+        local_recovery_attempt_id: None,
+        local_recovery_marker_created_at: None,
+        local_recovery_marker_last_error: None,
+        remote_recovery_attempt_id: None,
+        remote_recovery_marker_observed_at: None,
+    }
+}
+
+fn outbound_status_requires_link(status: &OutboundPrivateMessageStatus) -> bool {
+    matches!(
+        status,
+        OutboundPrivateMessageStatus::Pending
+            | OutboundPrivateMessageStatus::Sending
+            | OutboundPrivateMessageStatus::Failed
+    )
+}
+
+pub(super) fn clear_recovery_required_link_snapshots(
+    encrypted_link_states: &mut HashMap<PubkyPublicKey, EncryptedLinkStateRecord>,
+    recovery_required_peers: &[PubkyPublicKey],
+) {
+    for counterparty in recovery_required_peers {
+        let Some(record) = encrypted_link_states.get_mut(counterparty) else {
+            continue;
+        };
+        let had_snapshot = record.link_snapshot.is_some()
+            || record.handshake_snapshot.is_some()
+            || record.handshake_role.is_some();
+        record.link_snapshot = None;
+        record.handshake_snapshot = None;
+        record.handshake_role = None;
+        if had_snapshot {
+            record.generation = record.generation.saturating_add(1);
+        }
+    }
+}
+
+pub(super) fn mark_restored_sending_outbound_recovery_required(
+    records: &mut [OutboundPrivateMessageRecord],
+    recovery_required_peers: &[PubkyPublicKey],
+) {
+    let recovery_required_peers = recovery_required_peers
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    for record in records.iter_mut() {
+        if record.status == OutboundPrivateMessageStatus::Sending
+            && recovery_required_peers.contains(&record.counterparty)
+        {
+            record.status = OutboundPrivateMessageStatus::RecoveryRequired;
+            record.updated_at = record
+                .updated_at
+                .max(record.last_attempt_at.unwrap_or(record.created_at));
+            record.last_error =
+                Some("restored sending message requires Encrypted Link recovery".into());
+        }
+    }
+}
+
+pub(super) fn validate_encrypted_link_snapshots(
+    records: &HashMap<PubkyPublicKey, EncryptedLinkStateRecord>,
+) -> Result<()> {
+    for (counterparty, record) in records {
+        let expected_recipient = counterparty.to_public_key()?;
+        if let Some(snapshot_bytes) = record.link_snapshot.as_ref() {
+            let snapshot = paykit_lib::EncryptedLinkSnapshot::deserialize(snapshot_bytes)
+                .map_err(PaykitSdkError::from)?;
+            if snapshot.recipient() != &expected_recipient {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Encrypted Link snapshot recipient does not match counterparty {counterparty}"
+                )));
+            }
+        }
+        if let Some(snapshot_bytes) = record.handshake_snapshot.as_ref() {
+            let snapshot = paykit_lib::EncryptedLinkHandshakeSnapshot::deserialize(snapshot_bytes)
+                .map_err(PaykitSdkError::from)?;
+            if snapshot.recipient() != &expected_recipient {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Encrypted Link Handshake snapshot recipient does not match counterparty {counterparty}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_linked_peer_records(
+    records: &HashMap<PubkyPublicKey, LinkedPeerRecord>,
+) -> Result<()> {
+    for record in records.values() {
+        validate_recovery_marker_fields(
+            &record.counterparty,
+            "local Encrypted Link recovery marker",
+            record.local_recovery_attempt_id.as_deref(),
+            record.local_recovery_marker_created_at,
+        )?;
+        validate_recovery_marker_fields(
+            &record.counterparty,
+            "remote Encrypted Link recovery marker",
+            record.remote_recovery_attempt_id.as_deref(),
+            record.remote_recovery_marker_observed_at,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_recovery_marker_fields(
+    counterparty: &PubkyPublicKey,
+    label: &str,
+    attempt_id: Option<&str>,
+    timestamp: Option<chrono::DateTime<chrono::Utc>>,
+) -> Result<()> {
+    match (attempt_id, timestamp) {
+        (Some(attempt_id), Some(timestamp)) => {
+            paykit_lib::EncryptedLinkRecoveryMarker::new(
+                attempt_id,
+                timestamp.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            )
+            .map_err(|err| {
+                PaykitSdkError::Protocol(format!(
+                    "{label} for counterparty {counterparty} is invalid: {err}"
+                ))
+            })?;
+        }
+        (None, None) => {}
+        _ => {
+            return Err(PaykitSdkError::Protocol(format!(
+                "{label} for counterparty {counterparty} must store attempt id and timestamp together"
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_public_endpoint_records(
+    records: &HashMap<String, PublicEndpointRecord>,
+) -> Result<()> {
+    for record in records.values() {
+        PaymentEndpointIdentifier::new(&record.identifier)?;
+        match record.status {
+            PublicationStatus::NotPublished => {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "public endpoint record '{}' cannot be not-published",
+                    record.identifier
+                )));
+            }
+            PublicationStatus::PendingPublication | PublicationStatus::Published => {
+                if record.payload.is_none() {
+                    return Err(PaykitSdkError::Protocol(format!(
+                        "public endpoint record '{}' has no payload for status {:?}",
+                        record.identifier, record.status
+                    )));
+                }
+                if record.last_error.is_some() {
+                    return Err(PaykitSdkError::Protocol(format!(
+                        "public endpoint record '{}' has an error for status {:?}",
+                        record.identifier, record.status
+                    )));
+                }
+            }
+            PublicationStatus::PendingRemoval | PublicationStatus::Removed => {
+                if record.last_error.is_some() {
+                    return Err(PaykitSdkError::Protocol(format!(
+                        "public endpoint record '{}' has an error for status {:?}",
+                        record.identifier, record.status
+                    )));
+                }
+                if record.status == PublicationStatus::Removed && record.payload.is_some() {
+                    return Err(PaykitSdkError::Protocol(format!(
+                        "removed public endpoint record '{}' still has a payload",
+                        record.identifier
+                    )));
+                }
+            }
+            PublicationStatus::Failed => {
+                if record.last_error.is_none() {
+                    return Err(PaykitSdkError::Protocol(format!(
+                        "failed public endpoint record '{}' has no error",
+                        record.identifier
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_contact_records(
+    records: &HashMap<PubkyPublicKey, ContactRecord>,
+) -> Result<()> {
+    for record in records.values() {
+        if let Some(profile) = record.profile.as_ref() {
+            profile.validate()?;
+        }
+        if let Some(label) = record.label.as_deref() {
+            crate::ContactUpdate {
+                public_key: record.public_key.clone(),
+                label: Some(label.to_owned()),
+            }
+            .validate()?;
+        }
+        validate_contact_marker_state(record)?;
+    }
+    Ok(())
+}
+
+fn validate_contact_marker_state(record: &ContactRecord) -> Result<()> {
+    use crate::PublicationStatus::{
+        Failed, NotPublished, PendingPublication, PendingRemoval, Published, Removed,
+    };
+
+    if record.public_contact_published_at.is_some() && record.public_contact_removed_at.is_some() {
+        return Err(PaykitSdkError::Protocol(format!(
+            "local contact {} has inconsistent public contact marker timestamps",
+            record.public_key
+        )));
+    }
+
+    let invalid = match record.public_contact_marker_status {
+        NotPublished => {
+            record.public_contact_published_at.is_some()
+                || record.public_contact_removed_at.is_some()
+                || record.public_contact_last_error.is_some()
+        }
+        PendingPublication => record.public_contact_last_error.is_some(),
+        Published => {
+            record.public_contact_published_at.is_none()
+                || record.public_contact_removed_at.is_some()
+                || record.public_contact_last_error.is_some()
+        }
+        PendingRemoval => {
+            record.public_contact_published_at.is_none()
+                || record.public_contact_removed_at.is_some()
+                || record.public_contact_last_error.is_some()
+        }
+        Removed => {
+            record.public_contact_published_at.is_some()
+                || record.public_contact_removed_at.is_none()
+                || record.public_contact_last_error.is_some()
+        }
+        Failed => record.public_contact_last_error.is_none(),
+    };
+    if invalid {
+        return Err(PaykitSdkError::Protocol(format!(
+            "local contact {} has inconsistent public contact marker state",
+            record.public_key
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_payment_endpoint_reservations(
+    records: &HashMap<(PubkyPublicKey, String), PaymentEndpointReservationRecord>,
+    outbound_private_messages: &[OutboundPrivateMessageRecord],
+) -> Result<()> {
+    let outbound_by_id = outbound_private_messages
+        .iter()
+        .map(|record| (record.outbound_message_id, record))
+        .collect::<HashMap<_, _>>();
+
+    for record in records.values() {
+        validate_reservation_id(&record.reservation_id)?;
+        let identifier = PaymentEndpointIdentifier::new(&record.identifier)?;
+        let outbound = outbound_by_id
+            .get(&record.outbound_message_id)
+            .ok_or_else(|| {
+                PaykitSdkError::Protocol(format!(
+                    "Payment Endpoint Reservation '{}' references missing outbound message {}",
+                    record.reservation_id, record.outbound_message_id
+                ))
+            })?;
+        if outbound.counterparty != record.counterparty {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Payment Endpoint Reservation '{}' counterparty does not match outbound message {}",
+                record.reservation_id, record.outbound_message_id
+            )));
+        }
+        if outbound.kind != PrivateMessageKind::PrivatePaymentList.as_str() {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Payment Endpoint Reservation '{}' references non-list outbound message {}",
+                record.reservation_id, record.outbound_message_id
+            )));
+        }
+        let private_list = parse_private_payment_list_json(&outbound.raw_json)
+            .map_err(|err| PaykitSdkError::Protocol(err.to_string()))?;
+        let payload = private_list.get(&identifier).ok_or_else(|| {
+            PaykitSdkError::Protocol(format!(
+                "Payment Endpoint Reservation '{}' identifier is missing from outbound Private Payment List {}",
+                record.reservation_id, record.outbound_message_id
+            ))
+        })?;
+        let payload_hash = reservation_payload_hash(payload.as_str());
+        if record.payload_hash != payload_hash {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Payment Endpoint Reservation '{}' payload hash does not match outbound Private Payment List {}",
+                record.reservation_id, record.outbound_message_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_outbound_private_messages(
+    records: &[OutboundPrivateMessageRecord],
+) -> Result<()> {
+    for record in records {
+        validate_outbound_private_status(record)?;
+        if matches!(
+            record.status,
+            OutboundPrivateMessageStatus::Invalid | OutboundPrivateMessageStatus::RecoveryRequired
+        ) {
+            continue;
+        }
+        validate_queued_outbound_private_message(record)?;
+    }
+    Ok(())
+}
+
+fn validate_outbound_private_status(record: &OutboundPrivateMessageRecord) -> Result<()> {
+    let invalid = match record.status {
+        OutboundPrivateMessageStatus::Pending => {
+            record.attempt_count != 0
+                || record.last_attempt_at.is_some()
+                || record.sent_at.is_some()
+                || record.last_error.is_some()
+        }
+        OutboundPrivateMessageStatus::Sending => {
+            record.attempt_count == 0
+                || record.last_attempt_at.is_none()
+                || record.sent_at.is_some()
+                || record.last_error.is_some()
+        }
+        OutboundPrivateMessageStatus::Sent => {
+            record.attempt_count == 0
+                || record.last_attempt_at.is_none()
+                || record.sent_at.is_none()
+                || record.last_error.is_some()
+        }
+        OutboundPrivateMessageStatus::Failed => {
+            record.attempt_count == 0
+                || record.last_attempt_at.is_none()
+                || record.sent_at.is_some()
+                || record.last_error.is_none()
+        }
+        OutboundPrivateMessageStatus::Invalid | OutboundPrivateMessageStatus::RecoveryRequired => {
+            record.sent_at.is_some() || record.last_error.is_none()
+        }
+        OutboundPrivateMessageStatus::Superseded => {
+            record.sent_at.is_some() || record.last_error.is_some()
+        }
+    };
+    if invalid {
+        return Err(PaykitSdkError::Protocol(format!(
+            "outbound Private Application Message {} has inconsistent {:?} status metadata",
+            record.outbound_message_id, record.status
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_private_stream_items(records: &[PrivateStreamItemRecord]) -> Result<()> {
+    for record in records {
+        let (parsed_version, parsed_kind, known_kind) = private_message_header(&record.raw_json)?;
+        let classification =
+            classify_private_application_message(&private_application_message_from_raw(
+                record.raw_json.clone(),
+                parsed_version,
+                parsed_kind.clone(),
+            ));
+        if record.parsed_version != parsed_version {
+            return Err(PaykitSdkError::Protocol(format!(
+                "private stream item {} has stale parsed version metadata",
+                record.stream_item_id
+            )));
+        }
+        if record.parsed_kind.as_deref() != parsed_kind.as_deref() {
+            return Err(PaykitSdkError::Protocol(format!(
+                "private stream item {} has stale parsed kind metadata",
+                record.stream_item_id
+            )));
+        }
+        if record.known_paykit_kind.as_deref() != known_kind.map(PrivateMessageKind::as_str) {
+            return Err(PaykitSdkError::Protocol(format!(
+                "private stream item {} has stale known kind metadata",
+                record.stream_item_id
+            )));
+        }
+        if record.parse_status != classification.status {
+            return Err(PaykitSdkError::Protocol(format!(
+                "private stream item {} has stale parse status metadata",
+                record.stream_item_id
+            )));
+        }
+        if record.parse_error.as_deref() != classification.parse_error.as_deref() {
+            return Err(PaykitSdkError::Protocol(format!(
+                "private stream item {} has stale parse error metadata",
+                record.stream_item_id
+            )));
+        }
+        if record.parse_status == PrivateStreamParseStatus::Valid {
+            let Some(kind) = known_kind else {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "private stream item {} is marked valid without a recognized Paykit kind",
+                    record.stream_item_id
+                )));
+            };
+            validate_valid_private_stream_body(record, kind)?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_event_dedup_records(
+    records: &HashMap<(PubkyPublicKey, String), EventDedupRecord>,
+    stream_items: &[PrivateStreamItemRecord],
+) -> Result<()> {
+    let stream_by_id = stream_items
+        .iter()
+        .map(|item| (item.stream_item_id, item))
+        .collect::<HashMap<_, _>>();
+    for record in records.values() {
+        validate_event_dedup_membership(record)?;
+        let Some(first) = stream_by_id.get(&record.first_stream_item_id) else {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Event dedupe record '{}' references missing first stream item {}",
+                record.event_id, record.first_stream_item_id
+            )));
+        };
+        if first.counterparty != record.counterparty {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Event dedupe record '{}' counterparty does not match first stream item",
+                record.event_id
+            )));
+        }
+        if payload_hash(&first.raw_json) != record.payload_hash {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Event dedupe record '{}' payload hash does not match first stream item",
+                record.event_id
+            )));
+        }
+        validate_event_dedup_stream_item(record, first, EventDedupeItemKind::First)?;
+        for stream_item_id in &record.duplicate_stream_item_ids {
+            let Some(item) = stream_by_id.get(stream_item_id) else {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Event dedupe record '{}' references missing stream item {}",
+                    record.event_id, stream_item_id
+                )));
+            };
+            validate_event_dedup_stream_item(record, item, EventDedupeItemKind::Duplicate)?;
+        }
+        for stream_item_id in &record.conflicting_stream_item_ids {
+            let Some(item) = stream_by_id.get(stream_item_id) else {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Event dedupe record '{}' references missing stream item {}",
+                    record.event_id, stream_item_id
+                )));
+            };
+            validate_event_dedup_stream_item(record, item, EventDedupeItemKind::Conflict)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_event_dedup_membership(record: &EventDedupRecord) -> Result<()> {
+    let mut seen = HashSet::new();
+    seen.insert(record.first_stream_item_id);
+    for stream_item_id in record
+        .duplicate_stream_item_ids
+        .iter()
+        .chain(record.conflicting_stream_item_ids.iter())
+    {
+        if !seen.insert(*stream_item_id) {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Event dedupe record '{}' references stream item {} more than once",
+                record.event_id, stream_item_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum EventDedupeItemKind {
+    First,
+    Duplicate,
+    Conflict,
+}
+
+fn validate_event_dedup_stream_item(
+    record: &EventDedupRecord,
+    item: &PrivateStreamItemRecord,
+    item_kind: EventDedupeItemKind,
+) -> Result<()> {
+    if item.counterparty != record.counterparty {
+        return Err(PaykitSdkError::Protocol(format!(
+            "Event dedupe record '{}' counterparty does not match stream item {}",
+            record.event_id, item.stream_item_id
+        )));
+    }
+
+    let classification =
+        classify_private_application_message(&private_application_message_from_raw(
+            item.raw_json.clone(),
+            item.parsed_version,
+            item.parsed_kind.clone(),
+        ));
+    let Some(event) = classification.event else {
+        return Err(PaykitSdkError::Protocol(format!(
+            "Event dedupe record '{}' references non-event stream item {}",
+            record.event_id, item.stream_item_id
+        )));
+    };
+    if event.event_id != record.event_id {
+        return Err(PaykitSdkError::Protocol(format!(
+            "Event dedupe record '{}' does not match stream item {} event header",
+            record.event_id, item.stream_item_id
+        )));
+    }
+
+    let item_hash = payload_hash(&item.raw_json);
+    match item_kind {
+        EventDedupeItemKind::First | EventDedupeItemKind::Duplicate => {
+            if event.event_kind != record.event_kind {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Event dedupe record '{}' same-payload stream item {} has different event kind",
+                    record.event_id, item.stream_item_id
+                )));
+            }
+            if item_hash != record.payload_hash {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Event dedupe record '{}' same-payload stream item {} has different payload hash",
+                    record.event_id, item.stream_item_id
+                )));
+            }
+        }
+        EventDedupeItemKind::Conflict => {
+            if item_hash == record.payload_hash {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Event dedupe record '{}' conflict stream item {} has same payload hash",
+                    record.event_id, item.stream_item_id
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn validate_receipt_access_records(
+    records: &HashMap<(PubkyPublicKey, String), ReceiptAccessRecord>,
+    stream_items: &[PrivateStreamItemRecord],
+) -> Result<()> {
+    let stream_by_id = stream_items
+        .iter()
+        .map(|item| (item.stream_item_id, item))
+        .collect::<HashMap<_, _>>();
+    for record in records.values() {
+        validate_receipt_access_retrieval_status(record)?;
+        let Some(item) = stream_by_id.get(&record.stream_item_id) else {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt Access record '{}' references missing stream item {}",
+                record.event_id, record.stream_item_id
+            )));
+        };
+        if item.counterparty != record.counterparty
+            || item.receive_batch_id != record.receive_batch_id
+            || item.known_paykit_kind.as_deref() != Some(PrivateMessageKind::ReceiptAccess.as_str())
+        {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt Access record '{}' does not match its stream item",
+                record.event_id
+            )));
+        }
+        let event = paykit_lib::parse_receipt_access_event_message(&private_application_message(
+            item,
+            PrivateMessageKind::ReceiptAccess,
+        ))
+        .ok_or_else(|| {
+            PaykitSdkError::Protocol(format!(
+                "Receipt Access record '{}' stream item is not parseable",
+                record.event_id
+            ))
+        })?;
+        let Some(access) = event.parsed_access() else {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt Access record '{}' stream item is malformed",
+                record.event_id
+            )));
+        };
+        if access.event_id.as_str() != record.event_id
+            || access.receipt_id.as_str() != record.receipt_id
+            || access.payment_reference.as_str() != record.payment_reference
+            || access
+                .payment_request_id
+                .as_ref()
+                .map(|id| id.as_str().to_owned())
+                != record.payment_request_id
+            || access
+                .billing_period
+                .as_ref()
+                .map(BillingPeriodRecord::from)
+                != record.billing_period
+            || access.location != record.location
+            || access.key.as_str() != record.key
+        {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt Access record '{}' does not match parsed stream payload",
+                record.event_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_receipt_access_retrieval_status(record: &ReceiptAccessRecord) -> Result<()> {
+    match record.retrieval_status {
+        ReceiptRetrievalStatus::Pending => {
+            if record.retrieval_attempted_at.is_some()
+                || record.retrieved_at.is_some()
+                || record.last_retrieval_error.is_some()
+            {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "pending Receipt Access record '{}' has retrieval metadata",
+                    record.event_id
+                )));
+            }
+        }
+        ReceiptRetrievalStatus::Retrieved => {
+            if record.retrieval_attempted_at.is_none()
+                || record.retrieved_at.is_none()
+                || record.last_retrieval_error.is_some()
+            {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "retrieved Receipt Access record '{}' has inconsistent retrieval metadata",
+                    record.event_id
+                )));
+            }
+        }
+        ReceiptRetrievalStatus::NotFound | ReceiptRetrievalStatus::Failed => {
+            if record.retrieval_attempted_at.is_none()
+                || record.retrieved_at.is_some()
+                || record.last_retrieval_error.is_none()
+            {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "failed Receipt Access record '{}' has inconsistent retrieval metadata",
+                    record.event_id
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_required_private_stream_indexes(
+    stream_items: &[PrivateStreamItemRecord],
+    event_dedup_records: &HashMap<(PubkyPublicKey, String), EventDedupRecord>,
+    receipt_access_records: &HashMap<(PubkyPublicKey, String), ReceiptAccessRecord>,
+) -> Result<()> {
+    for item in stream_items {
+        let classification =
+            classify_private_application_message(&private_application_message_from_raw(
+                item.raw_json.clone(),
+                item.parsed_version,
+                item.parsed_kind.clone(),
+            ));
+        let Some(event) = classification.event else {
+            continue;
+        };
+        let key = (item.counterparty.clone(), event.event_id.clone());
+        let Some(dedupe) = event_dedup_records.get(&key) else {
+            return Err(PaykitSdkError::Protocol(format!(
+                "private stream item {} is missing required Event dedupe record '{}'",
+                item.stream_item_id, event.event_id
+            )));
+        };
+        if !event_dedup_record_contains_stream_event(dedupe, item, &event.event_kind) {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Event dedupe record '{}' does not include private stream item {}",
+                event.event_id, item.stream_item_id
+            )));
+        }
+        if classification.receipt_access.is_some()
+            && dedupe.first_stream_item_id == item.stream_item_id
+            && !receipt_access_records.contains_key(&key)
+        {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt Access event '{}' is missing required Receipt Access record",
+                event.event_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn event_dedup_record_contains_stream_event(
+    record: &EventDedupRecord,
+    item: &PrivateStreamItemRecord,
+    event_kind: &str,
+) -> bool {
+    let item_hash = payload_hash(&item.raw_json);
+    if record.first_stream_item_id == item.stream_item_id {
+        return event_kind == record.event_kind && item_hash == record.payload_hash;
+    }
+    if record
+        .duplicate_stream_item_ids
+        .contains(&item.stream_item_id)
+    {
+        return event_kind == record.event_kind && item_hash == record.payload_hash;
+    }
+    if record
+        .conflicting_stream_item_ids
+        .contains(&item.stream_item_id)
+    {
+        return item_hash != record.payload_hash;
+    }
+    false
+}
+
+pub(super) fn validate_receipt_records(
+    records: &HashMap<(PubkyPublicKey, String), ReceiptRecord>,
+    access_records: &HashMap<(PubkyPublicKey, String), ReceiptAccessRecord>,
+    expected_recipient: Option<&PubkyPublicKey>,
+) -> Result<()> {
+    for record in records.values() {
+        ReceiptId::new(&record.receipt_id)?;
+        if let Some(expected_recipient) = expected_recipient {
+            if &record.recipient_public_key != expected_recipient {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Receipt record '{}' recipient does not match backup identity",
+                    record.receipt_id
+                )));
+            }
+        }
+        if let Some(identifier) = record.payment_endpoint_identifier.as_ref() {
+            PaymentEndpointIdentifier::new(identifier)?;
+        }
+        let access_key = (
+            record.issuer.clone(),
+            record.receipt_access_event_id.clone(),
+        );
+        let Some(access) = access_records.get(&access_key) else {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt record '{}' references missing Receipt Access event '{}'",
+                record.receipt_id, record.receipt_access_event_id
+            )));
+        };
+        if access.receipt_id != record.receipt_id
+            || access.payment_reference != record.payment_reference
+            || access.payment_request_id != record.payment_request_id
+            || access.billing_period != record.billing_period
+            || access.location != record.location
+            || receipt_access_key_hash(&access.key) != record.receipt_access_key_hash
+        {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt record '{}' does not match its Receipt Access record",
+                record.receipt_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_receipt_issuance_records(
+    records: &HashMap<(PubkyPublicKey, String), ReceiptIssuanceRecord>,
+    outbound_private_messages: &[OutboundPrivateMessageRecord],
+) -> Result<()> {
+    let outbound_by_id = outbound_private_messages
+        .iter()
+        .map(|record| (record.outbound_message_id, record))
+        .collect::<HashMap<_, _>>();
+    let mut receipt_ids = HashSet::new();
+
+    for record in records.values() {
+        if !receipt_ids.insert(record.receipt_id.clone()) {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt issuance record '{}' is duplicated across counterparties",
+                record.receipt_id
+            )));
+        }
+        validate_receipt_issuance_status(record)?;
+        ReceiptId::new(&record.receipt_id)?;
+        if let Some(identifier) = record.payment_endpoint_identifier.as_ref() {
+            PaymentEndpointIdentifier::new(identifier)?;
+        }
+
+        let access = paykit_lib::parse_receipt_access_json(&record.access_json)
+            .map_err(|err| PaykitSdkError::Protocol(err.to_string()))?;
+        if access.event_id.as_str() != record.receipt_access_event_id
+            || access.receipt_id.as_str() != record.receipt_id
+            || access.payment_reference.as_str() != record.payment_reference
+            || access
+                .payment_request_id
+                .as_ref()
+                .map(|id| id.as_str().to_owned())
+                != record.payment_request_id
+            || access
+                .billing_period
+                .as_ref()
+                .map(BillingPeriodRecord::from)
+                != record.billing_period
+            || access.location != record.location
+        {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt issuance record '{}' does not match Receipt Access payload",
+                record.receipt_id
+            )));
+        }
+
+        let receipt =
+            paykit_lib::decrypt_receipt(&record.encrypted_receipt, &access.key, &access.location)
+                .map_err(|err| PaykitSdkError::Protocol(err.to_string()))?;
+        let recipient = PubkyPublicKey::from_public_key(&receipt.recipient_public_key);
+        if recipient != record.counterparty
+            || receipt.receipt_id.as_str() != record.receipt_id
+            || receipt.payment_reference.as_str() != record.payment_reference
+            || receipt
+                .payment_request_id
+                .as_ref()
+                .map(|id| id.as_str().to_owned())
+                != record.payment_request_id
+            || receipt
+                .billing_period
+                .as_ref()
+                .map(BillingPeriodRecord::from)
+                != record.billing_period
+            || receipt
+                .payment_endpoint_identifier
+                .as_ref()
+                .map(|identifier| identifier.as_str().to_owned())
+                != record.payment_endpoint_identifier
+            || receipt.amount.as_ref().map(AmountRecord::from) != record.amount
+        {
+            return Err(PaykitSdkError::Protocol(format!(
+                "Receipt issuance record '{}' does not match encrypted Receipt",
+                record.receipt_id
+            )));
+        }
+
+        if let Some(outbound_message_id) = record.outbound_message_id {
+            let Some(outbound) = outbound_by_id.get(&outbound_message_id) else {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Receipt issuance record '{}' references missing outbound message {}",
+                    record.receipt_id, outbound_message_id
+                )));
+            };
+            if outbound.counterparty != record.counterparty
+                || outbound.kind != PrivateMessageKind::ReceiptAccess.as_str()
+                || outbound.raw_json != record.access_json
+            {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Receipt issuance record '{}' does not match outbound message {}",
+                    record.receipt_id, outbound_message_id
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_receipt_issuance_status(record: &ReceiptIssuanceRecord) -> Result<()> {
+    if record.updated_at < record.created_at
+        || record
+            .stored_at
+            .is_some_and(|stored_at| stored_at < record.created_at)
+        || record
+            .access_queued_at
+            .is_some_and(|queued_at| queued_at < record.created_at)
+    {
+        return Err(PaykitSdkError::Protocol(format!(
+            "Receipt issuance record '{}' has inconsistent timestamps",
+            record.receipt_id
+        )));
+    }
+
+    let invalid = match record.status {
+        ReceiptIssuanceStatus::PendingStorage => {
+            record.stored_at.is_some()
+                || record.access_queued_at.is_some()
+                || record.outbound_message_id.is_some()
+                || record.last_error.is_some()
+        }
+        ReceiptIssuanceStatus::Stored => {
+            record.stored_at.is_none()
+                || record.access_queued_at.is_some()
+                || record.outbound_message_id.is_some()
+                || record.last_error.is_some()
+        }
+        ReceiptIssuanceStatus::AccessQueued => {
+            record.stored_at.is_none()
+                || record.access_queued_at.is_none()
+                || record.outbound_message_id.is_none()
+                || record.last_error.is_some()
+        }
+        ReceiptIssuanceStatus::Failed => {
+            record.access_queued_at.is_some()
+                || record.outbound_message_id.is_some()
+                || record.last_error.is_none()
+        }
+    };
+    if invalid {
+        return Err(PaykitSdkError::Protocol(format!(
+            "Receipt issuance record '{}' has inconsistent {:?} status metadata",
+            record.receipt_id, record.status
+        )));
+    }
+    Ok(())
+}
+
+fn private_message_header(
+    raw_json: &str,
+) -> Result<(Option<u32>, Option<String>, Option<PrivateMessageKind>)> {
+    let value = match serde_json::from_str::<serde_json::Value>(raw_json) {
+        Ok(value) => value,
+        Err(_) => return Ok((None, None, None)),
+    };
+    let parsed_version = value
+        .get("version")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|version| u8::try_from(version).ok())
+        .map(u32::from);
+    let parsed_kind = value
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned);
+    let known_kind = parsed_kind.as_deref().and_then(PrivateMessageKind::parse);
+    Ok((parsed_version, parsed_kind, known_kind))
+}
+
+fn validate_valid_private_stream_body(
+    record: &PrivateStreamItemRecord,
+    kind: PrivateMessageKind,
+) -> Result<()> {
+    match kind {
+        PrivateMessageKind::PrivatePaymentList => {
+            paykit_lib::parse_private_payment_list_json(&record.raw_json)?;
+        }
+        PrivateMessageKind::ReceiptAccess => {
+            let event = paykit_lib::parse_receipt_access_event_message(
+                &private_application_message(record, kind),
+            )
+            .ok_or_else(|| {
+                PaykitSdkError::Protocol(format!(
+                    "private stream item {} Receipt Access payload does not match its kind",
+                    record.stream_item_id
+                ))
+            })?;
+            if let Some(error) = event.validation_error() {
+                return Err(PaykitSdkError::Protocol(error.to_owned()));
+            }
+        }
+        PrivateMessageKind::PaymentRequest
+        | PrivateMessageKind::PaymentRequestAcceptance
+        | PrivateMessageKind::PaymentRequestRejection
+        | PrivateMessageKind::PaymentRequestCancellation
+        | PrivateMessageKind::PaymentProof => {
+            let event = paykit_lib::parse_payment_request_event_message(
+                &private_application_message(record, kind),
+            )
+            .ok_or_else(|| {
+                PaykitSdkError::Protocol(format!(
+                    "private stream item {} Payment Request payload does not match its kind",
+                    record.stream_item_id
+                ))
+            })?;
+            if let Some(error) = event.validation_error() {
+                return Err(PaykitSdkError::Protocol(error.to_owned()));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn private_application_message(
+    record: &PrivateStreamItemRecord,
+    kind: PrivateMessageKind,
+) -> PrivateApplicationMessage {
+    PrivateApplicationMessage {
+        version: record
+            .parsed_version
+            .and_then(|version| u8::try_from(version).ok()),
+        kind: Some(kind.as_str().to_owned()),
+        raw_json: record.raw_json.clone(),
+    }
+}
+
+fn private_application_message_from_raw(
+    raw_json: String,
+    parsed_version: Option<u32>,
+    parsed_kind: Option<String>,
+) -> PrivateApplicationMessage {
+    PrivateApplicationMessage {
+        version: parsed_version.and_then(|version| u8::try_from(version).ok()),
+        kind: parsed_kind,
+        raw_json,
+    }
+}

--- a/paykit-sdk/src/config.rs
+++ b/paykit-sdk/src/config.rs
@@ -1,0 +1,184 @@
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use crate::identity::PubkyPublicKey;
+
+/// Default namespace segment for SDK profile/contact public data.
+pub const DEFAULT_PROFILE_NAMESPACE: &str = "paykit";
+
+/// Policy for SDK-managed public Payment Endpoint cleanup.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EndpointManagementScope {
+    /// Manage only endpoints previously published by the SDK.
+    ManagedOnly,
+    /// Manage the full local Paykit public namespace.
+    FullPaykitNamespace,
+}
+
+/// Policy for public Encrypted Link recovery markers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EncryptedLinkRecoveryMarkerPolicy {
+    /// Publish and observe minimal public recovery markers.
+    Enabled,
+    /// Do not use public recovery markers.
+    Disabled,
+}
+
+/// Policy for publishing saved contacts to public Pubky storage.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PublicContactSharingPolicy {
+    /// Keep saved contacts only in local SDK storage. This is the default.
+    LocalOnly,
+    /// Allow explicit public contact marker publication in the configured namespace.
+    #[serde(alias = "PublicPaykitNamespace")]
+    ConfiguredPublicNamespace,
+}
+
+/// Runtime configuration for Paykit SDK.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaykitSdkConfig {
+    /// Namespace segment for SDK profile/contact public data under `/pub/`.
+    #[serde(default = "default_profile_namespace")]
+    pub profile_namespace: String,
+    /// Public endpoint management scope.
+    pub endpoint_management_scope: EndpointManagementScope,
+    /// Public recovery marker behavior.
+    #[serde(default = "default_encrypted_link_recovery_marker_policy")]
+    pub encrypted_link_recovery_markers: EncryptedLinkRecoveryMarkerPolicy,
+    /// Public contact marker behavior.
+    #[serde(default = "default_public_contact_sharing_policy")]
+    pub public_contact_sharing: PublicContactSharingPolicy,
+    /// Time after which an in-progress peer link operation can be retried.
+    pub peer_link_operation_lease_timeout: Duration,
+    /// Time after which an in-progress outbound private send is considered stale.
+    ///
+    /// Stale `Sending` records can be reclaimed for retry by another worker.
+    pub outbound_private_send_lease_timeout: Duration,
+    /// Minimum delay before retrying a failed outbound private send.
+    #[serde(default = "default_outbound_private_retry_backoff")]
+    pub outbound_private_retry_backoff: Duration,
+}
+
+impl Default for PaykitSdkConfig {
+    fn default() -> Self {
+        Self {
+            profile_namespace: DEFAULT_PROFILE_NAMESPACE.into(),
+            endpoint_management_scope: EndpointManagementScope::ManagedOnly,
+            encrypted_link_recovery_markers: EncryptedLinkRecoveryMarkerPolicy::Enabled,
+            public_contact_sharing: PublicContactSharingPolicy::LocalOnly,
+            peer_link_operation_lease_timeout: Duration::from_secs(60),
+            outbound_private_send_lease_timeout: Duration::from_secs(60),
+            outbound_private_retry_backoff: Duration::from_secs(30),
+        }
+    }
+}
+
+impl PaykitSdkConfig {
+    /// Validate runtime configuration values.
+    pub fn validate(&self) -> crate::Result<()> {
+        validate_profile_namespace(&self.profile_namespace)?;
+        validate_runtime_duration(
+            "peer link operation lease timeout",
+            self.peer_link_operation_lease_timeout,
+        )?;
+        validate_runtime_duration(
+            "outbound private send lease timeout",
+            self.outbound_private_send_lease_timeout,
+        )?;
+        validate_runtime_duration(
+            "outbound private retry backoff",
+            self.outbound_private_retry_backoff,
+        )?;
+        Ok(())
+    }
+
+    /// Return the configured Paykit Profile path.
+    pub fn paykit_profile_path(&self) -> String {
+        format!("/pub/{}/profile.json", self.profile_namespace)
+    }
+
+    /// Return the configured Paykit Profile blob path prefix.
+    pub fn paykit_profile_blob_path_prefix(&self) -> String {
+        format!("/pub/{}/blobs/", self.profile_namespace)
+    }
+
+    /// Return the configured public contact marker path prefix.
+    pub fn public_contact_path_prefix(&self) -> String {
+        format!("/pub/{}/contacts/", self.profile_namespace)
+    }
+
+    /// Return the configured public contact marker path for one contact.
+    pub fn public_contact_path(&self, public_key: &PubkyPublicKey) -> String {
+        format!(
+            "{}{}.json",
+            self.public_contact_path_prefix(),
+            public_key.as_str()
+        )
+    }
+}
+
+fn validate_profile_namespace(namespace: &str) -> crate::Result<()> {
+    if namespace.is_empty() {
+        return Err(crate::PaykitSdkError::Policy(
+            "profile namespace must not be empty".into(),
+        ));
+    }
+    if namespace.len() > 128 {
+        return Err(crate::PaykitSdkError::Policy(
+            "profile namespace must not exceed 128 bytes".into(),
+        ));
+    }
+    if namespace.starts_with('.') || namespace.ends_with('.') {
+        return Err(crate::PaykitSdkError::Policy(
+            "profile namespace must not start or end with '.'".into(),
+        ));
+    }
+    if namespace == "pubky.app" {
+        return Err(crate::PaykitSdkError::Policy(
+            "profile namespace 'pubky.app' is reserved for Pubky app data".into(),
+        ));
+    }
+    if namespace
+        .chars()
+        .any(|ch| !(ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' || ch == '_'))
+    {
+        return Err(crate::PaykitSdkError::Policy(
+            "profile namespace may only contain ASCII letters, digits, '.', '-' and '_'".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_runtime_duration(label: &str, duration: Duration) -> crate::Result<()> {
+    if duration.is_zero() {
+        return Err(crate::PaykitSdkError::Policy(format!(
+            "{label} must be greater than zero"
+        )));
+    }
+    chrono::Duration::from_std(duration).map_err(|err| {
+        crate::PaykitSdkError::Policy(format!("{label} must fit SDK runtime duration: {err}"))
+    })?;
+    Ok(())
+}
+
+fn default_encrypted_link_recovery_marker_policy() -> EncryptedLinkRecoveryMarkerPolicy {
+    EncryptedLinkRecoveryMarkerPolicy::Enabled
+}
+
+fn default_public_contact_sharing_policy() -> PublicContactSharingPolicy {
+    PublicContactSharingPolicy::LocalOnly
+}
+
+fn default_profile_namespace() -> String {
+    DEFAULT_PROFILE_NAMESPACE.into()
+}
+
+fn default_outbound_private_retry_backoff() -> Duration {
+    Duration::from_secs(30)
+}
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/config/tests.rs
+++ b/paykit-sdk/src/config/tests.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+#[test]
+fn test_config_validate_rejects_zero_timeouts() {
+    let config = PaykitSdkConfig {
+        peer_link_operation_lease_timeout: Duration::ZERO,
+        ..PaykitSdkConfig::default()
+    };
+
+    assert!(config.validate().is_err());
+}
+
+#[test]
+fn test_config_validate_rejects_oversized_timeouts() {
+    let config = PaykitSdkConfig {
+        outbound_private_send_lease_timeout: Duration::MAX,
+        ..PaykitSdkConfig::default()
+    };
+
+    assert!(config.validate().is_err());
+}
+
+#[test]
+fn test_config_builds_default_profile_namespace_paths() {
+    let config = PaykitSdkConfig::default();
+    let public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+
+    assert_eq!(config.paykit_profile_path(), "/pub/paykit/profile.json");
+    assert_eq!(
+        config.paykit_profile_blob_path_prefix(),
+        "/pub/paykit/blobs/"
+    );
+    assert_eq!(
+        config.public_contact_path(&public_key),
+        format!("/pub/paykit/contacts/{}.json", public_key.as_str())
+    );
+}
+
+#[test]
+fn test_config_allows_custom_profile_namespace_segment() {
+    let config = PaykitSdkConfig {
+        profile_namespace: "bitkit.to".into(),
+        ..PaykitSdkConfig::default()
+    };
+
+    config.validate().unwrap();
+    assert_eq!(config.paykit_profile_path(), "/pub/bitkit.to/profile.json");
+    assert_eq!(
+        config.paykit_profile_blob_path_prefix(),
+        "/pub/bitkit.to/blobs/"
+    );
+    assert_eq!(
+        config.public_contact_path_prefix(),
+        "/pub/bitkit.to/contacts/"
+    );
+}
+
+#[test]
+fn test_config_rejects_profile_namespace_path_segments() {
+    let config = PaykitSdkConfig {
+        profile_namespace: "bitkit/to".into(),
+        ..PaykitSdkConfig::default()
+    };
+
+    assert!(config.validate().is_err());
+}
+
+#[test]
+fn test_config_rejects_pubky_app_profile_namespace() {
+    let config = PaykitSdkConfig {
+        profile_namespace: "pubky.app".into(),
+        ..PaykitSdkConfig::default()
+    };
+
+    assert!(config.validate().is_err());
+}
+
+#[test]
+fn test_public_contact_sharing_policy_accepts_old_variant_name() {
+    let parsed =
+        serde_json::from_str::<PublicContactSharingPolicy>(r#""PublicPaykitNamespace""#).unwrap();
+
+    assert_eq!(
+        parsed,
+        PublicContactSharingPolicy::ConfiguredPublicNamespace
+    );
+}

--- a/paykit-sdk/src/contacts.rs
+++ b/paykit-sdk/src/contacts.rs
@@ -1,0 +1,752 @@
+//! Contact, profile, and contact payment resolution types.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use crate::{
+    publication::PublicationStatus, PaykitSdkError, PaymentAmountContext, PaymentEndpointCandidate,
+    PaymentTarget, PubkyPublicKey, Result,
+};
+
+/// Default public Paykit profile path.
+pub const PAYKIT_PROFILE_PATH: &str = "/pub/paykit/profile.json";
+/// Default public Paykit blob prefix.
+pub const PAYKIT_PROFILE_BLOB_PATH_PREFIX: &str = "/pub/paykit/blobs/";
+/// Default public Paykit contact marker prefix.
+pub const PAYKIT_PUBLIC_CONTACT_PATH_PREFIX: &str = "/pub/paykit/contacts/";
+/// Pubky app profile path used by read-only helper APIs.
+pub const PUBKY_PROFILE_PATH: &str = "/pub/pubky.app/profile.json";
+/// Pubky app follows path used by read-only helper APIs.
+pub const PUBKY_FOLLOWS_PATH_PREFIX: &str = "/pub/pubky.app/follows/";
+
+const PROFILE_KIND: &str = "paykit.profile";
+const PUBLIC_CONTACT_KIND: &str = "paykit.contact";
+const PROFILE_VERSION: u32 = 1;
+const PUBLIC_CONTACT_VERSION: u32 = 1;
+const MAX_DISPLAY_NAME_CHARS: usize = 128;
+const MAX_IMAGE_URI_CHARS: usize = 2048;
+const MAX_PROFILE_EXTRA_BYTES: usize = 16 * 1024;
+const MAX_PAYKIT_BLOB_NAME_BYTES: usize = 128;
+const MAX_LOCAL_LABEL_CHARS: usize = 128;
+const MAX_PUBKY_PROFILE_NAME_CHARS: usize = 128;
+const MAX_PUBKY_PROFILE_TEXT_CHARS: usize = 4096;
+const MAX_PUBKY_PROFILE_URI_CHARS: usize = 2048;
+const MAX_PUBKY_PROFILE_LINKS: usize = 32;
+
+/// Public Paykit-facing profile metadata.
+///
+/// This record is public. Product-specific metadata can be carried in `extra`
+/// when it is safe to publish.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaykitProfile {
+    /// Public display name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// Public image pointer such as a Pubky path or URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_uri: Option<String>,
+    /// App-specific public profile fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+/// Public profile metadata from the Pubky app namespace.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PubkyProfile {
+    /// Public display name.
+    pub name: String,
+    /// Optional profile bio.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bio: Option<String>,
+    /// Optional public image pointer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    /// Optional public profile links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<PubkyProfileLink>>,
+    /// Optional public status text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+impl PubkyProfile {
+    /// Validate Pubky profile field bounds.
+    pub fn validate(&self) -> Result<()> {
+        validate_text(
+            &self.name,
+            "Pubky profile name",
+            MAX_PUBKY_PROFILE_NAME_CHARS,
+            false,
+        )?;
+        validate_optional_text(
+            self.bio.as_deref(),
+            "Pubky profile bio",
+            MAX_PUBKY_PROFILE_TEXT_CHARS,
+            true,
+        )?;
+        validate_optional_text(
+            self.image.as_deref(),
+            "Pubky profile image",
+            MAX_PUBKY_PROFILE_URI_CHARS,
+            false,
+        )?;
+        validate_optional_text(
+            self.status.as_deref(),
+            "Pubky profile status",
+            MAX_PUBKY_PROFILE_TEXT_CHARS,
+            true,
+        )?;
+        if let Some(links) = self.links.as_ref() {
+            if links.len() > MAX_PUBKY_PROFILE_LINKS {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "Pubky profile links must not exceed {MAX_PUBKY_PROFILE_LINKS} entries"
+                )));
+            }
+            for link in links {
+                link.validate()?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Public profile link from the Pubky app namespace.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PubkyProfileLink {
+    /// Link title.
+    pub title: String,
+    /// Link URL.
+    pub url: String,
+}
+
+impl PubkyProfileLink {
+    /// Validate Pubky profile link field bounds.
+    pub fn validate(&self) -> Result<()> {
+        validate_text(
+            &self.title,
+            "Pubky profile link title",
+            MAX_PUBKY_PROFILE_NAME_CHARS,
+            true,
+        )?;
+        validate_text(
+            &self.url,
+            "Pubky profile link URL",
+            MAX_PUBKY_PROFILE_URI_CHARS,
+            false,
+        )
+    }
+}
+
+/// Pubky profile record fetched through the SDK.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PubkyProfileRecord {
+    /// Profile owner.
+    pub public_key: PubkyPublicKey,
+    /// Public profile metadata.
+    pub profile: PubkyProfile,
+    /// Pubky path used for the profile.
+    pub path: String,
+    /// Local observation time.
+    pub fetched_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Source used for a resolved contact profile.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ContactProfileSource {
+    /// Resolved from the configured Paykit Profile path.
+    PaykitProfile,
+    /// Resolved from `/pub/pubky.app/profile.json`.
+    PubkyProfile,
+}
+
+/// Contact display profile resolved by trying Paykit Profile first.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContactProfileResolution {
+    /// Profile owner.
+    pub public_key: PubkyPublicKey,
+    /// Source that produced this profile.
+    pub source: ContactProfileSource,
+    /// Normalized display name for app contact lists.
+    pub display_name: Option<String>,
+    /// Normalized image pointer for app contact lists.
+    pub image_uri: Option<String>,
+    /// Paykit Profile payload when the source is Paykit Profile.
+    pub paykit_profile: Option<PaykitProfile>,
+    /// Pubky Profile payload when the source is Pubky Profile.
+    pub pubky_profile: Option<PubkyProfile>,
+    /// Local observation time.
+    pub fetched_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl fmt::Debug for ContactProfileResolution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContactProfileResolution")
+            .field("public_key", &"<redacted>")
+            .field("source", &self.source)
+            .field(
+                "display_name",
+                &self.display_name.as_ref().map(|_| "<redacted>"),
+            )
+            .field("image_uri", &self.image_uri.as_ref().map(|_| "<redacted>"))
+            .field(
+                "paykit_profile",
+                &self.paykit_profile.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "pubky_profile",
+                &self.pubky_profile.as_ref().map(|_| "<redacted>"),
+            )
+            .field("fetched_at", &self.fetched_at)
+            .finish()
+    }
+}
+
+impl ContactProfileResolution {
+    pub(crate) fn from_paykit(record: PaykitProfileRecord) -> Self {
+        Self {
+            public_key: record.public_key,
+            source: ContactProfileSource::PaykitProfile,
+            display_name: record.profile.display_name.clone(),
+            image_uri: record.profile.image_uri.clone(),
+            paykit_profile: Some(record.profile),
+            pubky_profile: None,
+            fetched_at: record.updated_at,
+        }
+    }
+
+    pub(crate) fn from_pubky(record: PubkyProfileRecord) -> Self {
+        Self {
+            public_key: record.public_key,
+            source: ContactProfileSource::PubkyProfile,
+            display_name: Some(record.profile.name.clone()),
+            image_uri: record.profile.image.clone(),
+            paykit_profile: None,
+            pubky_profile: Some(record.profile),
+            fetched_at: record.fetched_at,
+        }
+    }
+}
+
+impl PaykitProfile {
+    /// Validate profile field bounds.
+    pub fn validate(&self) -> Result<()> {
+        validate_optional_text(
+            self.display_name.as_deref(),
+            "profile display name",
+            MAX_DISPLAY_NAME_CHARS,
+            false,
+        )?;
+        validate_optional_text(
+            self.image_uri.as_deref(),
+            "profile image URI",
+            MAX_IMAGE_URI_CHARS,
+            false,
+        )?;
+        if let Some(extra) = self.extra.as_ref() {
+            let extra_json = serde_json::to_vec(extra).map_err(|err| {
+                PaykitSdkError::Protocol(format!("profile extra must be valid JSON: {err}"))
+            })?;
+            if extra_json.len() > MAX_PROFILE_EXTRA_BYTES {
+                return Err(PaykitSdkError::Protocol(format!(
+                    "profile extra must not exceed {MAX_PROFILE_EXTRA_BYTES} bytes"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Profile record fetched or published through the SDK.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaykitProfileRecord {
+    /// Profile owner.
+    pub public_key: PubkyPublicKey,
+    /// Public profile metadata.
+    pub profile: PaykitProfile,
+    /// Pubky path used for the profile.
+    pub path: String,
+    /// Local observation/publication time.
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Public blob published under the configured Paykit namespace.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaykitBlobRecord {
+    /// Blob owner.
+    pub public_key: PubkyPublicKey,
+    /// Pubky path used for the blob.
+    pub path: String,
+    /// Canonical `pubky://` URI for the blob.
+    pub uri: String,
+    /// Blob size in bytes.
+    pub size_bytes: u64,
+    /// Local publication time.
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Local SDK contact update.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContactUpdate {
+    /// Contact public key.
+    pub public_key: PubkyPublicKey,
+    /// Optional local display label.
+    pub label: Option<String>,
+}
+
+impl fmt::Debug for ContactUpdate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContactUpdate")
+            .field("public_key", &"<redacted>")
+            .field("label", &self.label.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
+impl ContactUpdate {
+    /// Validate contact update fields.
+    pub fn validate(&self) -> Result<()> {
+        validate_optional_text(
+            self.label.as_deref(),
+            "contact label",
+            MAX_LOCAL_LABEL_CHARS,
+            true,
+        )
+    }
+}
+
+/// Local SDK contact record.
+///
+/// Contact Records are local/private SDK state by default. Publishing a Public
+/// Contact Marker requires explicit runtime policy and a separate method call.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContactRecord {
+    /// Contact public key.
+    pub public_key: PubkyPublicKey,
+    /// Optional local display label.
+    pub label: Option<String>,
+    /// Cached public profile, when fetched.
+    pub profile: Option<PaykitProfile>,
+    /// Time the cached public profile was fetched.
+    pub profile_fetched_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Time the contact was first saved locally.
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Time the local contact record last changed.
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    /// Public Contact Marker publication state.
+    pub public_contact_marker_status: PublicationStatus,
+    /// Time the contact was last published publicly by explicit opt-in.
+    pub public_contact_published_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Time the public contact marker was last removed.
+    pub public_contact_removed_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Last public contact marker publication/removal error.
+    pub public_contact_last_error: Option<String>,
+}
+
+impl fmt::Debug for ContactRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContactRecord")
+            .field("public_key", &"<redacted>")
+            .field("label", &self.label.as_ref().map(|_| "<redacted>"))
+            .field("profile", &self.profile.as_ref().map(|_| "<redacted>"))
+            .field("profile_fetched_at", &self.profile_fetched_at)
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .field(
+                "public_contact_marker_status",
+                &self.public_contact_marker_status,
+            )
+            .field(
+                "public_contact_published_at",
+                &self.public_contact_published_at,
+            )
+            .field("public_contact_removed_at", &self.public_contact_removed_at)
+            .field(
+                "public_contact_last_error",
+                &self
+                    .public_contact_last_error
+                    .as_ref()
+                    .map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+impl ContactRecord {
+    pub(crate) fn from_update(
+        update: ContactUpdate,
+        existing: Option<ContactRecord>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        let label = normalize_label(update.label);
+        match existing {
+            Some(mut existing) => {
+                existing.label = label;
+                existing.updated_at = now;
+                existing
+            }
+            None => Self {
+                public_key: update.public_key,
+                label,
+                profile: None,
+                profile_fetched_at: None,
+                created_at: now,
+                updated_at: now,
+                public_contact_marker_status: PublicationStatus::NotPublished,
+                public_contact_published_at: None,
+                public_contact_removed_at: None,
+                public_contact_last_error: None,
+            },
+        }
+    }
+
+    pub(crate) fn with_profile(
+        mut self,
+        profile: Option<PaykitProfile>,
+        fetched_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.profile = profile;
+        self.profile_fetched_at = Some(fetched_at);
+        self.updated_at = fetched_at;
+        self
+    }
+
+    pub(crate) fn mark_public_contact_publication_pending(
+        mut self,
+        updated_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.public_contact_marker_status = PublicationStatus::PendingPublication;
+        self.public_contact_last_error = None;
+        self.updated_at = updated_at;
+        self
+    }
+
+    pub(crate) fn mark_public_contact_published(
+        mut self,
+        published_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.public_contact_marker_status = PublicationStatus::Published;
+        self.public_contact_published_at = Some(published_at);
+        self.public_contact_removed_at = None;
+        self.public_contact_last_error = None;
+        self.updated_at = published_at;
+        self
+    }
+
+    pub(crate) fn mark_public_contact_removal_pending(
+        mut self,
+        updated_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.public_contact_marker_status = PublicationStatus::PendingRemoval;
+        self.public_contact_last_error = None;
+        self.updated_at = updated_at;
+        self
+    }
+
+    pub(crate) fn mark_public_contact_removed(
+        mut self,
+        removed_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.public_contact_marker_status = PublicationStatus::Removed;
+        self.public_contact_published_at = None;
+        self.public_contact_removed_at = Some(removed_at);
+        self.public_contact_last_error = None;
+        self.updated_at = removed_at;
+        self
+    }
+
+    pub(crate) fn mark_public_contact_failed(
+        mut self,
+        error: String,
+        failed_at: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        self.public_contact_marker_status = PublicationStatus::Failed;
+        self.public_contact_last_error = Some(error);
+        self.updated_at = failed_at;
+        self
+    }
+
+    pub(crate) fn can_remove_locally(&self) -> bool {
+        matches!(
+            self.public_contact_marker_status,
+            PublicationStatus::NotPublished | PublicationStatus::Removed
+        )
+    }
+
+    pub(crate) fn may_have_public_marker(&self) -> bool {
+        matches!(
+            self.public_contact_marker_status,
+            PublicationStatus::PendingPublication
+                | PublicationStatus::PendingRemoval
+                | PublicationStatus::Published
+        ) || (self.public_contact_published_at.is_some()
+            && self.public_contact_removed_at.is_none())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PaykitProfileDocument {
+    version: u32,
+    kind: String,
+    #[serde(flatten)]
+    profile: PaykitProfile,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PublicContactDocument {
+    version: u32,
+    kind: String,
+    public_key: PubkyPublicKey,
+}
+
+pub(crate) fn profile_json(profile: &PaykitProfile) -> Result<String> {
+    profile.validate()?;
+    serde_json::to_string(&PaykitProfileDocument {
+        version: PROFILE_VERSION,
+        kind: PROFILE_KIND.into(),
+        profile: profile.clone(),
+    })
+    .map_err(|err| PaykitSdkError::Protocol(format!("failed to serialize Paykit profile: {err}")))
+}
+
+pub(crate) fn parse_profile_json(raw_json: &str) -> Result<PaykitProfile> {
+    let document = serde_json::from_str::<PaykitProfileDocument>(raw_json)
+        .map_err(|err| PaykitSdkError::Protocol(format!("invalid Paykit profile JSON: {err}")))?;
+    if document.version != PROFILE_VERSION {
+        return Err(PaykitSdkError::Protocol(format!(
+            "unsupported Paykit profile version {}",
+            document.version
+        )));
+    }
+    if document.kind != PROFILE_KIND {
+        return Err(PaykitSdkError::Protocol(format!(
+            "unexpected Paykit profile kind '{}'",
+            document.kind
+        )));
+    }
+    document.profile.validate()?;
+    Ok(document.profile)
+}
+
+pub(crate) fn validate_paykit_blob_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(PaykitSdkError::Protocol(
+            "Paykit blob name must not be empty".into(),
+        ));
+    }
+    if name.len() > MAX_PAYKIT_BLOB_NAME_BYTES {
+        return Err(PaykitSdkError::Protocol(format!(
+            "Paykit blob name must not exceed {MAX_PAYKIT_BLOB_NAME_BYTES} bytes"
+        )));
+    }
+    if name == "." || name == ".." {
+        return Err(PaykitSdkError::Protocol(
+            "Paykit blob name must not be a path traversal segment".into(),
+        ));
+    }
+    if name
+        .chars()
+        .any(|ch| !(ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' || ch == '_'))
+    {
+        return Err(PaykitSdkError::Protocol(
+            "Paykit blob name may only contain ASCII letters, digits, '.', '-' and '_'".into(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn paykit_blob_path(blob_prefix: &str, name: &str) -> Result<String> {
+    validate_paykit_blob_name(name)?;
+    Ok(format!("{blob_prefix}{name}"))
+}
+
+pub(crate) fn paykit_blob_uri(public_key: &PubkyPublicKey, path: &str) -> String {
+    format!("pubky://{}{}", public_key.as_str(), path)
+}
+
+pub(crate) fn paykit_blob_path_from_uri_or_path(
+    public_key: &PubkyPublicKey,
+    blob_prefix: &str,
+    uri_or_path: &str,
+) -> Result<String> {
+    if uri_or_path.starts_with("pubky://") || uri_or_path.starts_with("pubky") {
+        let resource = uri_or_path
+            .parse::<pubky::PubkyResource>()
+            .map_err(|err| PaykitSdkError::Protocol(format!("invalid Pubky blob URI: {err}")))?;
+        let owner = PubkyPublicKey::from_public_key(&resource.owner);
+        if &owner != public_key {
+            return Err(PaykitSdkError::Protocol(
+                "Paykit blob URI owner does not match local identity".into(),
+            ));
+        }
+        return validate_paykit_blob_path(blob_prefix, resource.path.as_str());
+    }
+    validate_paykit_blob_path(blob_prefix, uri_or_path)
+}
+
+fn validate_paykit_blob_path(blob_prefix: &str, path: &str) -> Result<String> {
+    let name = path.strip_prefix(blob_prefix).ok_or_else(|| {
+        PaykitSdkError::Protocol("Paykit blob path is outside configured blob prefix".into())
+    })?;
+    validate_paykit_blob_name(name)?;
+    Ok(path.to_owned())
+}
+
+pub(crate) fn parse_pubky_profile_json(raw_json: &str) -> Result<PubkyProfile> {
+    let profile = serde_json::from_str::<PubkyProfile>(raw_json)
+        .map_err(|err| PaykitSdkError::Protocol(format!("invalid Pubky profile JSON: {err}")))?;
+    profile.validate()?;
+    Ok(profile)
+}
+
+pub(crate) fn pubky_follow_keys_from_follow_entries(
+    entries: Vec<pubky::PubkyResource>,
+) -> Vec<PubkyPublicKey> {
+    let mut contacts = entries
+        .into_iter()
+        .filter_map(|entry| {
+            direct_pubky_follow_key(entry.path.as_str())
+                .and_then(|value| PubkyPublicKey::new(value.to_owned()).ok())
+        })
+        .collect::<Vec<_>>();
+    contacts.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+    contacts.dedup_by(|left, right| left == right);
+    contacts
+}
+
+fn direct_pubky_follow_key(path: &str) -> Option<&str> {
+    let value = path.strip_prefix(PUBKY_FOLLOWS_PATH_PREFIX)?;
+    if value.is_empty() || value.contains('/') {
+        return None;
+    }
+    Some(value)
+}
+
+pub(crate) fn public_contact_json(public_key: &PubkyPublicKey) -> Result<String> {
+    serde_json::to_string(&PublicContactDocument {
+        version: PUBLIC_CONTACT_VERSION,
+        kind: PUBLIC_CONTACT_KIND.into(),
+        public_key: public_key.clone(),
+    })
+    .map_err(|err| {
+        PaykitSdkError::Protocol(format!("failed to serialize Paykit public contact: {err}"))
+    })
+}
+
+/// Result category for contact payment resolution.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ContactPaymentResolutionStatus {
+    /// A payable endpoint was found.
+    Payable,
+    /// No endpoint was found.
+    NoEndpoint,
+    /// Endpoints exist but are unsupported.
+    UnsupportedEndpoint,
+}
+
+/// Private-payment state observed while resolving a contact payment.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ContactPaymentResolutionPrivateState {
+    /// Private Payment List candidates were available for resolution.
+    Available,
+    /// No Private Payment List candidate was available.
+    NoPrivateEndpoint,
+    /// Private payment state is blocked by link recovery.
+    RecoveryPending,
+    /// The local identity cannot establish private links.
+    PublicOnlySession,
+}
+
+/// Request to resolve payable endpoints for one counterparty.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContactPaymentResolutionRequest {
+    /// Counterparty to pay.
+    pub counterparty: PubkyPublicKey,
+    /// Optional amount context used by the payment adapter.
+    pub amount: Option<PaymentAmountContext>,
+    /// Include public Payment Endpoints after private candidates.
+    pub include_public_endpoints: bool,
+}
+
+/// Payment Endpoint paired with the target needed to pay through it.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedPaymentEndpoint {
+    /// Payable endpoint returned by the payment adapter.
+    pub endpoint: PaymentEndpointCandidate,
+    /// Adapter-built target for executing payment through this endpoint.
+    pub target: PaymentTarget,
+}
+
+impl fmt::Debug for ResolvedPaymentEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResolvedPaymentEndpoint")
+            .field("endpoint", &self.endpoint)
+            .field("target", &self.target)
+            .finish()
+    }
+}
+
+/// Result of resolving contact Payment Endpoints.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContactPaymentResolution {
+    /// General payment resolution outcome.
+    pub status: ContactPaymentResolutionStatus,
+    /// Private-payment-specific state for this resolution.
+    pub private_state: ContactPaymentResolutionPrivateState,
+    /// Payable Payment Endpoints in adapter-preferred order.
+    pub payable_endpoints: Vec<ResolvedPaymentEndpoint>,
+}
+
+impl fmt::Debug for ContactPaymentResolution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContactPaymentResolution")
+            .field("status", &self.status)
+            .field("private_state", &self.private_state)
+            .field("payable_endpoints", &self.payable_endpoints)
+            .finish()
+    }
+}
+
+fn validate_optional_text(
+    value: Option<&str>,
+    label: &str,
+    max_chars: usize,
+    allow_empty: bool,
+) -> Result<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    if !allow_empty && value.trim().is_empty() {
+        return Err(PaykitSdkError::Protocol(format!(
+            "{label} must not be empty"
+        )));
+    }
+    if value.chars().count() > max_chars {
+        return Err(PaykitSdkError::Protocol(format!(
+            "{label} must not exceed {max_chars} characters"
+        )));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(PaykitSdkError::Protocol(format!(
+            "{label} must not contain control characters"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, label: &str, max_chars: usize, allow_empty: bool) -> Result<()> {
+    validate_optional_text(Some(value), label, max_chars, allow_empty)
+}
+
+fn normalize_label(label: Option<String>) -> Option<String> {
+    label.and_then(|label| {
+        let label = label.trim();
+        if label.is_empty() {
+            None
+        } else {
+            Some(label.to_owned())
+        }
+    })
+}

--- a/paykit-sdk/src/endpoint_reservations.rs
+++ b/paykit-sdk/src/endpoint_reservations.rs
@@ -1,0 +1,393 @@
+//! Payment Endpoint Reservation records.
+
+use std::{collections::HashMap, fmt};
+
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    adapters::{
+        PaymentEndpointReservation, PaymentEndpointReservationCancellation, ReceivingDetail,
+    },
+    endpoints::normalize_receiving_details,
+    outbound_private::{validate_outbound_private_message, OutboundPrivateMessageStatus},
+    storage::{
+        require_peer_link_operation_lease, NewOutboundPrivateMessage, OutboundPrivateMessageRecord,
+        PaymentEndpointReservationRecord, PeerLinkOperationLease, StorageAdapter,
+    },
+    PaykitSdkError, PubkyPublicKey, Result,
+};
+use paykit_lib::{serialize_private_payment_list_json, PrivateMessageKind, PrivatePaymentList};
+
+const MAX_RESERVATION_ID_LEN: usize = 128;
+
+/// SDK cleanup record for a reserved endpoint tied to a queued private list.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PaymentEndpointReservationCancellationRecord {
+    pub(crate) outbound_message_id: u64,
+    pub(crate) cancellation: PaymentEndpointReservationCancellation,
+}
+
+/// Load Payment Endpoint Reservation records for one counterparty.
+#[cfg(test)]
+pub(crate) async fn payment_endpoint_reservations<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Vec<PaymentEndpointReservationRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.payment_endpoint_reservations(counterparty)))
+        .await
+}
+
+/// Load reservation cancellations for superseded Private Payment Lists that were never attempted.
+///
+/// Attempted private lists are left for adapter expiry or explicit cleanup because
+/// the SDK cannot prove the counterparty did not receive their reserved details.
+pub(crate) async fn unattempted_superseded_reservation_cancellations<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Vec<PaymentEndpointReservationCancellationRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| {
+            let outbound = tx.outbound_private_messages(counterparty);
+            let superseded_unattempted = outbound
+                .iter()
+                .filter(|message| {
+                    message.kind == PrivateMessageKind::PrivatePaymentList.as_str()
+                        && message.status == OutboundPrivateMessageStatus::Superseded
+                        && message.last_attempt_at.is_none()
+                })
+                .map(|message| message.outbound_message_id)
+                .collect::<std::collections::HashSet<_>>();
+
+            let cancellations = tx
+                .payment_endpoint_reservations(counterparty)
+                .into_iter()
+                .filter(|record| superseded_unattempted.contains(&record.outbound_message_id))
+                .map(cancellation_record_from_reservation_record)
+                .collect();
+            Ok(cancellations)
+        })
+        .await
+}
+
+/// Load reservation cancellations for invalid Private Payment Lists that can no
+/// longer use their linked reservations.
+pub(crate) async fn invalid_private_list_reservation_cancellations<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Vec<PaymentEndpointReservationCancellationRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| {
+            let outbound = tx.outbound_private_messages(counterparty);
+            let invalid_private_lists = outbound
+                .iter()
+                .filter(|message| {
+                    message.kind == PrivateMessageKind::PrivatePaymentList.as_str()
+                        && message.status == OutboundPrivateMessageStatus::Invalid
+                })
+                .map(|message| message.outbound_message_id)
+                .collect::<std::collections::HashSet<_>>();
+
+            let cancellations = tx
+                .payment_endpoint_reservations(counterparty)
+                .into_iter()
+                .filter(|record| invalid_private_lists.contains(&record.outbound_message_id))
+                .map(cancellation_record_from_reservation_record)
+                .collect();
+            Ok(cancellations)
+        })
+        .await
+}
+
+/// Load reservation cancellations for one outbound Private Payment List if any linked
+/// reservation expired before it was sent.
+pub(crate) async fn expired_outbound_reservation_cancellations<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    outbound_message_id: u64,
+    now: DateTime<Utc>,
+) -> Result<Vec<PaymentEndpointReservationCancellationRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| {
+            let records = tx
+                .payment_endpoint_reservations(counterparty)
+                .into_iter()
+                .filter(|record| record.outbound_message_id == outbound_message_id)
+                .collect::<Vec<_>>();
+            let has_expired = records.iter().any(|record| {
+                record
+                    .expires_at
+                    .is_some_and(|expires_at| expires_at <= now)
+            });
+            let cancellations = if has_expired {
+                records
+                    .into_iter()
+                    .map(cancellation_record_from_reservation_record)
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            Ok(cancellations)
+        })
+        .await
+}
+
+fn cancellation_record_from_reservation_record(
+    record: PaymentEndpointReservationRecord,
+) -> PaymentEndpointReservationCancellationRecord {
+    PaymentEndpointReservationCancellationRecord {
+        outbound_message_id: record.outbound_message_id,
+        cancellation: PaymentEndpointReservationCancellation {
+            reservation_id: record.reservation_id,
+            counterparty: record.counterparty,
+            identifier: record.identifier,
+            payload_hash: record.payload_hash,
+            attribution: record.attribution,
+        },
+    }
+}
+
+/// Queue a Private Payment List and persist linked reservation records atomically.
+#[cfg(test)]
+pub(crate) async fn queue_private_payment_list_with_reservations<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    reservations: Vec<PaymentEndpointReservation>,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    queue_private_payment_list_with_reservations_inner(
+        storage,
+        counterparty,
+        reservations,
+        now,
+        None,
+    )
+    .await
+}
+
+/// Queue a Private Payment List with linked reservations while a peer operation
+/// lease is active.
+pub(crate) async fn queue_private_payment_list_with_reservations_with_link_lease<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    reservations: Vec<PaymentEndpointReservation>,
+    now: DateTime<Utc>,
+    lease: &PeerLinkOperationLease,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    queue_private_payment_list_with_reservations_inner(
+        storage,
+        counterparty,
+        reservations,
+        now,
+        Some(lease.clone()),
+    )
+    .await
+}
+
+async fn queue_private_payment_list_with_reservations_inner<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    reservations: Vec<PaymentEndpointReservation>,
+    now: DateTime<Utc>,
+    lease: Option<PeerLinkOperationLease>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let (receiving_details, drafts) = build_reservation_records(counterparty, reservations, now)?;
+    let payment_endpoints = normalize_receiving_details(receiving_details)?;
+    let list = PrivatePaymentList::new(payment_endpoints);
+    let raw_json = serialize_private_payment_list_json(&list)?;
+    let kind = validate_outbound_private_message(&raw_json)?;
+    let counterparty = counterparty.clone();
+
+    storage
+        .transaction(move |tx| {
+            if let Some(lease) = lease.as_ref() {
+                require_peer_link_operation_lease(tx, lease)?;
+            }
+            let mut checked_drafts = Vec::with_capacity(drafts.len());
+            for draft in drafts {
+                let existing =
+                    tx.payment_endpoint_reservation(&draft.counterparty, &draft.reservation_id);
+                if let Some(existing) = existing.as_ref() {
+                    if existing.cancellation_started_at.is_some() {
+                        return Err(PaykitSdkError::Policy(format!(
+                            "Payment Endpoint Reservation id '{}' is being canceled",
+                            draft.reservation_id
+                        )));
+                    }
+                    if !draft.matches_existing(existing) {
+                        return Err(PaykitSdkError::Protocol(format!(
+                            "Payment Endpoint Reservation id '{}' already exists with different details",
+                            draft.reservation_id
+                        )));
+                    }
+                }
+                checked_drafts.push((draft, existing));
+            }
+
+            let outbound = tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                counterparty,
+                kind,
+                raw_json,
+                now,
+            ));
+            for (draft, existing) in checked_drafts {
+                let record = draft.into_record(outbound.outbound_message_id, existing);
+                tx.save_payment_endpoint_reservation(record);
+            }
+            Ok(outbound)
+        })
+        .await
+}
+
+#[derive(Clone)]
+struct PaymentEndpointReservationRecordDraft {
+    reservation_id: String,
+    counterparty: PubkyPublicKey,
+    identifier: String,
+    payload_hash: String,
+    attribution: HashMap<String, String>,
+    expires_at: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
+}
+
+impl PaymentEndpointReservationRecordDraft {
+    fn matches_existing(&self, existing: &PaymentEndpointReservationRecord) -> bool {
+        existing.counterparty == self.counterparty
+            && existing.identifier == self.identifier
+            && existing.payload_hash == self.payload_hash
+    }
+
+    fn into_record(
+        self,
+        outbound_message_id: u64,
+        existing: Option<PaymentEndpointReservationRecord>,
+    ) -> PaymentEndpointReservationRecord {
+        let (attribution, expires_at, created_at) = existing
+            .map(|record| (record.attribution, record.expires_at, record.created_at))
+            .unwrap_or((self.attribution, self.expires_at, self.created_at));
+        PaymentEndpointReservationRecord {
+            reservation_id: self.reservation_id,
+            counterparty: self.counterparty,
+            identifier: self.identifier,
+            payload_hash: self.payload_hash,
+            outbound_message_id,
+            attribution,
+            expires_at,
+            cancellation_started_at: None,
+            created_at,
+        }
+    }
+}
+
+fn build_reservation_records(
+    counterparty: &PubkyPublicKey,
+    reservations: Vec<PaymentEndpointReservation>,
+    now: DateTime<Utc>,
+) -> Result<(
+    Vec<ReceivingDetail>,
+    Vec<PaymentEndpointReservationRecordDraft>,
+)> {
+    let mut reservation_ids = HashMap::new();
+    let mut records = Vec::with_capacity(reservations.len());
+    let mut receiving_details = Vec::with_capacity(reservations.len());
+
+    for reservation in reservations {
+        validate_reservation_id(&reservation.reservation_id)?;
+        if reservation_ids
+            .insert(reservation.reservation_id.clone(), ())
+            .is_some()
+        {
+            return Err(PaykitSdkError::Protocol(format!(
+                "duplicate Payment Endpoint Reservation id '{}'",
+                reservation.reservation_id
+            )));
+        }
+        receiving_details.push(reservation.receiving_detail.clone());
+        records.push(record_from_reservation(counterparty, reservation, now));
+    }
+
+    normalize_receiving_details(receiving_details.clone())?;
+    Ok((receiving_details, records))
+}
+
+pub(crate) fn validate_reservation_id(reservation_id: &str) -> Result<()> {
+    if reservation_id.trim().is_empty() {
+        return Err(PaykitSdkError::Protocol(
+            "Payment Endpoint Reservation id must not be empty".into(),
+        ));
+    }
+    if reservation_id.len() > MAX_RESERVATION_ID_LEN {
+        return Err(PaykitSdkError::Protocol(format!(
+            "Payment Endpoint Reservation id must be at most {MAX_RESERVATION_ID_LEN} bytes"
+        )));
+    }
+    if reservation_id.chars().any(char::is_control) {
+        return Err(PaykitSdkError::Protocol(
+            "Payment Endpoint Reservation id must not contain control characters".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn record_from_reservation(
+    counterparty: &PubkyPublicKey,
+    reservation: PaymentEndpointReservation,
+    now: DateTime<Utc>,
+) -> PaymentEndpointReservationRecordDraft {
+    let payload_hash = reservation_payload_hash(&reservation.receiving_detail.payload);
+    PaymentEndpointReservationRecordDraft {
+        reservation_id: reservation.reservation_id,
+        counterparty: counterparty.clone(),
+        identifier: reservation.receiving_detail.identifier,
+        payload_hash,
+        attribution: reservation.attribution,
+        expires_at: reservation.expires_at,
+        created_at: now,
+    }
+}
+
+pub(crate) fn reservation_payload_hash(payload: &str) -> String {
+    let digest = Sha256::digest(payload.as_bytes());
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+impl fmt::Debug for PaymentEndpointReservationRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentEndpointReservationRecord")
+            .field("reservation_id", &self.reservation_id)
+            .field("counterparty", &self.counterparty)
+            .field("identifier", &self.identifier)
+            .field("payload_hash", &self.payload_hash)
+            .field("outbound_message_id", &self.outbound_message_id)
+            .field(
+                "attribution",
+                &format_args!("<redacted:{} fields>", self.attribution.len()),
+            )
+            .field("expires_at", &self.expires_at)
+            .field("cancellation_started_at", &self.cancellation_started_at)
+            .field("created_at", &self.created_at)
+            .finish()
+    }
+}

--- a/paykit-sdk/src/endpoints.rs
+++ b/paykit-sdk/src/endpoints.rs
@@ -1,0 +1,133 @@
+//! Public Payment Endpoint sync records.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use paykit_lib::{PaymentEndpointIdentifier, PaymentEndpointPayload};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    adapters::ReceivingDetail,
+    publication::PublicationStatus,
+    storage::{PublicEndpointRecord, StorageAdapter},
+    PaykitSdkError, Result,
+};
+
+/// One public endpoint changed during sync.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EndpointSyncChange {
+    /// Payment Endpoint Identifier.
+    pub identifier: String,
+    /// Resulting local publication status.
+    pub status: PublicationStatus,
+    /// Error text for failed changes.
+    pub error: Option<String>,
+}
+
+/// Summary returned after public Payment Endpoint sync.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EndpointSyncReport {
+    /// Endpoints successfully published or updated.
+    pub published: Vec<EndpointSyncChange>,
+    /// Endpoints successfully removed.
+    pub removed: Vec<EndpointSyncChange>,
+    /// Endpoints that failed to publish or remove.
+    pub failed: Vec<EndpointSyncChange>,
+}
+
+pub(crate) fn normalize_receiving_details(
+    details: Vec<ReceivingDetail>,
+) -> Result<HashMap<PaymentEndpointIdentifier, PaymentEndpointPayload>> {
+    let mut desired = HashMap::with_capacity(details.len());
+
+    for detail in details {
+        let identifier = PaymentEndpointIdentifier::new(detail.identifier)?;
+        if desired.contains_key(&identifier) {
+            return Err(PaykitSdkError::Protocol(format!(
+                "duplicate Payment Endpoint identifier '{}'",
+                identifier.as_str()
+            )));
+        }
+
+        desired.insert(identifier, PaymentEndpointPayload::new(detail.payload));
+    }
+
+    Ok(desired)
+}
+
+/// Load SDK-managed public endpoint records.
+pub async fn load_public_endpoint_records<S>(storage: &S) -> Result<Vec<PublicEndpointRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.public_endpoint_records()))
+        .await
+}
+
+pub(crate) fn published_record(
+    identifier: &PaymentEndpointIdentifier,
+    payload: &PaymentEndpointPayload,
+    now: DateTime<Utc>,
+) -> PublicEndpointRecord {
+    PublicEndpointRecord {
+        identifier: identifier.as_str().to_owned(),
+        payload: Some(payload.as_str().to_owned()),
+        status: PublicationStatus::Published,
+        updated_at: now,
+        last_error: None,
+    }
+}
+
+pub(crate) fn pending_publication_record(
+    identifier: &PaymentEndpointIdentifier,
+    payload: &PaymentEndpointPayload,
+    now: DateTime<Utc>,
+) -> PublicEndpointRecord {
+    PublicEndpointRecord {
+        identifier: identifier.as_str().to_owned(),
+        payload: Some(payload.as_str().to_owned()),
+        status: PublicationStatus::PendingPublication,
+        updated_at: now,
+        last_error: None,
+    }
+}
+
+pub(crate) fn pending_removal_record(
+    identifier: String,
+    payload: Option<String>,
+    now: DateTime<Utc>,
+) -> PublicEndpointRecord {
+    PublicEndpointRecord {
+        identifier,
+        payload,
+        status: PublicationStatus::PendingRemoval,
+        updated_at: now,
+        last_error: None,
+    }
+}
+
+pub(crate) fn removed_record(identifier: String, now: DateTime<Utc>) -> PublicEndpointRecord {
+    PublicEndpointRecord {
+        identifier,
+        payload: None,
+        status: PublicationStatus::Removed,
+        updated_at: now,
+        last_error: None,
+    }
+}
+
+pub(crate) fn failed_record(
+    identifier: String,
+    payload: Option<String>,
+    error: String,
+    now: DateTime<Utc>,
+) -> PublicEndpointRecord {
+    PublicEndpointRecord {
+        identifier,
+        payload,
+        status: PublicationStatus::Failed,
+        updated_at: now,
+        last_error: Some(error),
+    }
+}

--- a/paykit-sdk/src/error.rs
+++ b/paykit-sdk/src/error.rs
@@ -1,0 +1,83 @@
+use thiserror::Error;
+
+/// Error type for stateful Paykit SDK workflows.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PaykitSdkError {
+    /// Durable storage failed.
+    #[error("storage error: {context}")]
+    Storage {
+        /// Human-readable failure context.
+        context: String,
+        /// Underlying cause, when available.
+        #[source]
+        source: Option<anyhow::Error>,
+    },
+
+    /// Pubky identity, session, or key capability failed.
+    #[error("identity error: {context}")]
+    Identity {
+        /// Human-readable failure context.
+        context: String,
+        /// Underlying cause, when available.
+        #[source]
+        source: Option<anyhow::Error>,
+    },
+
+    /// Pubky or Encrypted Link transport failed.
+    #[error("transport error: {context}")]
+    Transport {
+        /// Human-readable failure context.
+        context: String,
+        /// Underlying cause, when available.
+        #[source]
+        source: Option<anyhow::Error>,
+    },
+
+    /// Requested Paykit or Pubky resource was not found.
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// Paykit protocol data is invalid, conflicting, or unsupported.
+    #[error("protocol error: {0}")]
+    Protocol(String),
+
+    /// Operation is blocked by configured SDK policy.
+    #[error("policy error: {0}")]
+    Policy(String),
+
+    /// Payment adapter failed.
+    #[error("payment adapter error: {context}")]
+    PaymentAdapter {
+        /// Human-readable failure context.
+        context: String,
+        /// Underlying cause, when available.
+        #[source]
+        source: Option<anyhow::Error>,
+    },
+
+    /// Local state needs explicit recovery before automation can continue.
+    #[error("recovery required: {0}")]
+    RecoveryRequired(String),
+}
+
+impl From<paykit_lib::PaykitError> for PaykitSdkError {
+    fn from(err: paykit_lib::PaykitError) -> Self {
+        match err {
+            paykit_lib::PaykitError::Transport { context, source } => Self::Transport {
+                context,
+                source: Some(source),
+            },
+            paykit_lib::PaykitError::NotFound(msg) => Self::NotFound(msg),
+            paykit_lib::PaykitError::InvalidData { context, source } => Self::Protocol(
+                source
+                    .map(|source| format!("{context}: {source}"))
+                    .unwrap_or(context),
+            ),
+            paykit_lib::PaykitError::Validation(msg) => Self::Protocol(msg),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/error/tests.rs
+++ b/paykit-sdk/src/error/tests.rs
@@ -1,0 +1,8 @@
+use super::*;
+
+#[test]
+fn test_paykit_not_found_maps_to_sdk_not_found() {
+    let err = PaykitSdkError::from(paykit_lib::PaykitError::NotFound("missing receipt".into()));
+
+    assert!(matches!(err, PaykitSdkError::NotFound(message) if message == "missing receipt"));
+}

--- a/paykit-sdk/src/identity.rs
+++ b/paykit-sdk/src/identity.rs
@@ -1,0 +1,215 @@
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use paykit_lib::PublicKey;
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+/// Pubky public key string used by SDK records.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct PubkyPublicKey(String);
+
+impl PubkyPublicKey {
+    /// Create a public key wrapper from canonical z-base32 text.
+    pub fn new(value: impl Into<String>) -> crate::Result<Self> {
+        let value = value.into();
+        let public_key =
+            PublicKey::try_from_z32(&value).map_err(|err| crate::PaykitSdkError::Identity {
+                context: "invalid Pubky public key".into(),
+                source: Some(err.into()),
+            })?;
+        Ok(Self::from_public_key(&public_key))
+    }
+
+    /// Create a wrapper from a parsed Pubky public key.
+    pub fn from_public_key(public_key: &PublicKey) -> Self {
+        Self(public_key.z32())
+    }
+
+    /// Parse this wrapper back into a Pubky public key.
+    pub fn to_public_key(&self) -> crate::Result<PublicKey> {
+        PublicKey::try_from_z32(&self.0).map_err(|err| crate::PaykitSdkError::Identity {
+            context: "invalid Pubky public key".into(),
+            source: Some(err.into()),
+        })
+    }
+
+    /// Access the inner public key string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PubkyPublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for PubkyPublicKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for PubkyPublicKey {
+    type Error = crate::PaykitSdkError;
+
+    fn try_from(value: String) -> crate::Result<Self> {
+        Self::new(value)
+    }
+}
+
+impl From<PubkyPublicKey> for String {
+    fn from(value: PubkyPublicKey) -> Self {
+        value.0
+    }
+}
+
+/// Pubky capability state visible to Paykit workflows.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PubkyIdentityCapability {
+    /// No Pubky identity is initialized, or explicit sign-out completed.
+    SignedOut,
+    /// Public Pubky operations may work, but private links cannot be established.
+    PublicOnly,
+    /// Public operations and Encrypted Links can work.
+    PrivateLinkCapable,
+}
+
+/// Local Pubky secret key used for Encrypted Links.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PubkyLocalSecretKey([u8; 32]);
+
+impl PubkyLocalSecretKey {
+    /// Wrap a 32-byte local secret key.
+    pub fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the secret key bytes.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Consume the wrapper and return the secret key bytes.
+    pub fn into_inner(mut self) -> [u8; 32] {
+        let bytes = self.0;
+        self.0.zeroize();
+        bytes
+    }
+}
+
+impl fmt::Debug for PubkyLocalSecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PubkyLocalSecretKey(<redacted>)")
+    }
+}
+
+impl Drop for PubkyLocalSecretKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl From<[u8; 32]> for PubkyLocalSecretKey {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self::new(bytes)
+    }
+}
+
+/// Live Pubky access used by SDK workflows that touch Pubky storage or links.
+///
+/// Providers must ensure the optional local secret key belongs to the local
+/// session public key. The SDK treats a present secret key as private-link
+/// capability.
+#[derive(Clone)]
+pub struct PubkySessionAccess {
+    /// Authenticated Pubky session for local homeserver writes.
+    pub session: pubky::PubkySession,
+    /// Pubky client used for counterparty homeserver access.
+    pub outbox_client: pubky::Pubky,
+    /// Local secret key required for Encrypted Links, when available.
+    pub local_secret_key: Option<PubkyLocalSecretKey>,
+}
+
+impl PubkySessionAccess {
+    /// Return the local Pubky public key.
+    pub fn public_key(&self) -> crate::Result<PubkyPublicKey> {
+        Ok(PubkyPublicKey::from_public_key(
+            self.session.info().public_key(),
+        ))
+    }
+
+    /// Return the Paykit capability implied by this access.
+    pub fn capability(&self) -> PubkyIdentityCapability {
+        if self.private_link_capable() {
+            PubkyIdentityCapability::PrivateLinkCapable
+        } else {
+            PubkyIdentityCapability::PublicOnly
+        }
+    }
+
+    /// Whether this access can establish Encrypted Links.
+    pub fn private_link_capable(&self) -> bool {
+        self.local_secret_key.is_some()
+    }
+}
+
+impl fmt::Debug for PubkySessionAccess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PubkySessionAccess")
+            .field("session", &"<redacted>")
+            .field("outbox_client", &self.outbox_client)
+            .field("local_secret_key", &self.local_secret_key)
+            .finish()
+    }
+}
+
+/// Durable identity state tracked by the SDK.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityState {
+    /// Current local public key, when signed in.
+    pub public_key: Option<PubkyPublicKey>,
+    /// Current Pubky capability.
+    pub capability: PubkyIdentityCapability,
+    /// Whether the local secret key is available to the SDK.
+    pub local_secret_available: bool,
+    /// Last successful initialization time.
+    pub initialized_at: DateTime<Utc>,
+    /// Monotonic generation used to separate state across sign-outs.
+    pub sign_out_generation: u64,
+}
+
+/// Current identity status returned to apps.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityStatus {
+    /// Current local public key, when signed in.
+    pub public_key: Option<PubkyPublicKey>,
+    /// Current Pubky capability.
+    pub capability: PubkyIdentityCapability,
+    /// Whether live Pubky session access is available for this identity.
+    pub live_session_available: bool,
+    /// Whether private Paykit workflows can run with the live session.
+    pub private_link_capable: bool,
+}
+
+impl IdentityStatus {
+    pub(crate) fn from_state(
+        state: &IdentityState,
+        live_session_available: bool,
+        private_link_capable: bool,
+    ) -> Self {
+        Self {
+            public_key: state.public_key.clone(),
+            capability: state.capability,
+            live_session_available,
+            private_link_capable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/identity/tests.rs
+++ b/paykit-sdk/src/identity/tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[test]
+fn test_pubky_local_secret_key_debug_is_redacted() {
+    let key = PubkyLocalSecretKey::new([7; 32]);
+
+    assert_eq!(format!("{key:?}"), "PubkyLocalSecretKey(<redacted>)");
+}
+
+#[test]
+fn test_pubky_public_key_validates_and_round_trips_z32() {
+    let public_key = pubky::Keypair::random().public_key();
+    let wrapped = PubkyPublicKey::new(public_key.z32()).unwrap();
+
+    assert_eq!(wrapped.to_public_key().unwrap(), public_key);
+    assert_eq!(wrapped.as_str(), public_key.z32());
+}
+
+#[test]
+fn test_pubky_public_key_rejects_invalid_text() {
+    let result = PubkyPublicKey::new("pk-peer");
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_pubky_public_key_deserialization_validates() {
+    let result = serde_json::from_str::<PubkyPublicKey>(r#""pk-peer""#);
+
+    assert!(result.is_err());
+}

--- a/paykit-sdk/src/lib.rs
+++ b/paykit-sdk/src/lib.rs
@@ -1,0 +1,98 @@
+#![doc = "Stateful runtime layer for Paykit integrations."]
+#![deny(rustdoc::broken_intra_doc_links)]
+
+mod adapters;
+mod backup;
+mod config;
+mod contacts;
+mod endpoints;
+mod error;
+mod identity;
+mod linked_peers;
+mod outbound_private;
+mod payment_requests;
+mod private_lists;
+mod private_stream;
+mod publication;
+mod receipts;
+mod records;
+mod recovery;
+mod runtime;
+/// Durable storage traits and in-memory test storage.
+pub mod storage;
+
+mod endpoint_reservations;
+
+#[doc(inline)]
+pub use adapters::{
+    PaymentAdapter, PaymentAmountContext, PaymentEndpointCandidate, PaymentEndpointReservation,
+    PaymentEndpointReservationCancellation, PaymentEndpointSelectionRequest, PaymentEndpointSource,
+    PaymentTarget, PubkySessionProvider, ReceivingDetail, ReceivingDetailScope,
+};
+#[doc(inline)]
+pub use backup::{export_backup_state, RestoreReport, SdkBackupState, SDK_BACKUP_VERSION};
+#[doc(inline)]
+pub use config::{
+    EncryptedLinkRecoveryMarkerPolicy, EndpointManagementScope, PaykitSdkConfig,
+    PublicContactSharingPolicy, DEFAULT_PROFILE_NAMESPACE,
+};
+#[doc(inline)]
+pub use contacts::{
+    ContactPaymentResolution, ContactPaymentResolutionPrivateState,
+    ContactPaymentResolutionRequest, ContactPaymentResolutionStatus, ContactProfileResolution,
+    ContactProfileSource, ContactRecord, ContactUpdate, PaykitBlobRecord, PaykitProfile,
+    PaykitProfileRecord, PubkyProfile, PubkyProfileLink, PubkyProfileRecord,
+    ResolvedPaymentEndpoint, PAYKIT_PROFILE_BLOB_PATH_PREFIX, PAYKIT_PROFILE_PATH,
+    PAYKIT_PUBLIC_CONTACT_PATH_PREFIX, PUBKY_FOLLOWS_PATH_PREFIX, PUBKY_PROFILE_PATH,
+};
+#[doc(inline)]
+pub use endpoints::{load_public_endpoint_records, EndpointSyncChange, EndpointSyncReport};
+#[doc(inline)]
+pub use error::PaykitSdkError;
+#[doc(inline)]
+pub use identity::{
+    IdentityState, IdentityStatus, PubkyIdentityCapability, PubkyLocalSecretKey, PubkyPublicKey,
+    PubkySessionAccess,
+};
+#[doc(inline)]
+pub use linked_peers::{
+    load_encrypted_link_state, load_linked_peer, EncryptedLinkHandshakeRole,
+    LinkedPeerHandshakeReport, LinkedPeerState,
+};
+#[doc(inline)]
+pub use outbound_private::{
+    OutboundPrivateCounterpartySendReport, OutboundPrivateMessageStatus,
+    OutboundPrivateSendFailure, OutboundPrivateSendReport, RecoveryMarkerPublishFailure,
+    ReservationCleanupFailure,
+};
+#[doc(inline)]
+pub use payment_requests::{
+    PaymentProofRecord, PaymentRequestFilter, PaymentRequestLifecycleState,
+    PaymentRequestLocalRole, PaymentRequestRecord, PaymentRequestRecurrenceRecord,
+    PaymentRequestTermsRecord,
+};
+#[doc(inline)]
+pub use private_lists::PrivatePaymentListView;
+#[doc(inline)]
+pub use private_stream::{
+    EventIdConflict, PrivateStreamCounterpartyIntakeReport, PrivateStreamIntakeReport,
+    PrivateStreamParseStatus,
+};
+#[doc(inline)]
+pub use publication::PublicationStatus;
+#[doc(inline)]
+pub use receipts::{
+    ReceiptAccessView, ReceiptDraftBuilder, ReceiptIssuanceStatus, ReceiptIssuanceView,
+    ReceiptRecord, ReceiptRetrievalStatus,
+};
+#[doc(inline)]
+pub use records::{AmountRecord, BillingPeriodRecord};
+#[doc(inline)]
+pub use recovery::EncryptedLinkRecoveryMarkerReport;
+#[doc(inline)]
+pub use runtime::{Clock, InitializationReport, PaykitSdk, SystemClock};
+#[doc(inline)]
+pub use storage::{InMemoryStorage, StorageAdapter, StorageTransaction};
+
+/// Common result alias for Paykit SDK operations.
+pub type Result<T> = std::result::Result<T, PaykitSdkError>;

--- a/paykit-sdk/src/linked_peers.rs
+++ b/paykit-sdk/src/linked_peers.rs
@@ -1,0 +1,634 @@
+//! Linked Peer state records.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    storage::{
+        require_peer_link_operation_lease, EncryptedLinkStateRecord, LinkedPeerRecord,
+        PeerLinkOperationLease, StorageAdapter, StorageTransaction,
+    },
+    PaykitSdkError, PubkyPublicKey, Result,
+};
+
+/// Local role for an in-progress Encrypted Link Handshake.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum EncryptedLinkHandshakeRole {
+    /// Local peer initiated the handshake.
+    Initiator,
+    /// Local peer accepted a handshake initiated by the counterparty.
+    Responder,
+}
+
+/// Local relationship state for a counterparty.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum LinkedPeerState {
+    /// The SDK tracks this counterparty, but no active Encrypted Link exists.
+    NotLinked,
+    /// An Encrypted Link Handshake is in progress.
+    Linking,
+    /// An Encrypted Link is established.
+    Linked,
+    /// Local state cannot safely continue without recovery.
+    RecoveryRequired,
+    /// Local policy blocks this peer.
+    Blocked,
+}
+
+/// Result of starting or advancing an Encrypted Link Handshake.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinkedPeerHandshakeReport {
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Current Linked Peer state after the operation.
+    pub state: LinkedPeerState,
+    /// Current Encrypted Link state generation.
+    pub generation: u64,
+    /// In-progress handshake role, when a handshake remains pending.
+    pub handshake_role: Option<EncryptedLinkHandshakeRole>,
+}
+
+pub(crate) struct RecoveryRequiredMark {
+    pub new_episode: bool,
+}
+
+/// Load the durable Linked Peer record for a counterparty.
+pub async fn load_linked_peer<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Option<LinkedPeerRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.linked_peer(counterparty)))
+        .await
+}
+
+fn default_linked_peer(counterparty: PubkyPublicKey) -> LinkedPeerRecord {
+    LinkedPeerRecord {
+        counterparty,
+        state: LinkedPeerState::NotLinked,
+        last_sync_at: None,
+        last_private_receive_at: None,
+        failure_count: 0,
+        local_recovery_attempt_id: None,
+        local_recovery_marker_created_at: None,
+        local_recovery_marker_last_error: None,
+        remote_recovery_attempt_id: None,
+        remote_recovery_marker_observed_at: None,
+    }
+}
+
+fn ensure_not_blocked(peer: &LinkedPeerRecord) -> Result<()> {
+    if peer.state == LinkedPeerState::Blocked {
+        return Err(PaykitSdkError::Policy(format!(
+            "Linked Peer {} is blocked",
+            peer.counterparty
+        )));
+    }
+    Ok(())
+}
+
+fn report_current_link_state(
+    counterparty: PubkyPublicKey,
+    peer: &mut LinkedPeerRecord,
+    link_state: &EncryptedLinkStateRecord,
+    now: DateTime<Utc>,
+) -> LinkedPeerHandshakeReport {
+    if link_state.link_snapshot.is_some() {
+        peer.state = LinkedPeerState::Linked;
+        peer.last_sync_at = Some(now);
+        peer.failure_count = 0;
+        LinkedPeerHandshakeReport {
+            counterparty,
+            state: LinkedPeerState::Linked,
+            generation: link_state.generation,
+            handshake_role: None,
+        }
+    } else if link_state.handshake_snapshot.is_some() {
+        peer.state = LinkedPeerState::Linking;
+        peer.last_sync_at = Some(now);
+        peer.failure_count = 0;
+        LinkedPeerHandshakeReport {
+            counterparty,
+            state: LinkedPeerState::Linking,
+            generation: link_state.generation,
+            handshake_role: link_state.handshake_role,
+        }
+    } else {
+        peer.state = LinkedPeerState::RecoveryRequired;
+        if peer.last_sync_at.is_none() {
+            peer.last_sync_at = Some(now);
+        }
+        LinkedPeerHandshakeReport {
+            counterparty,
+            state: LinkedPeerState::RecoveryRequired,
+            generation: link_state.generation,
+            handshake_role: None,
+        }
+    }
+}
+
+/// Save a Linked Peer state update.
+#[cfg(test)]
+pub(crate) async fn save_linked_peer_state<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    state: LinkedPeerState,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerRecord>
+where
+    S: StorageAdapter,
+{
+    save_linked_peer_state_inner(storage, counterparty, state, None, now).await
+}
+
+pub(crate) async fn save_linked_peer_state_with_lease<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    state: LinkedPeerState,
+    lease: PeerLinkOperationLease,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerRecord>
+where
+    S: StorageAdapter,
+{
+    save_linked_peer_state_inner(storage, counterparty, state, Some(lease), now).await
+}
+
+async fn save_linked_peer_state_inner<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    state: LinkedPeerState,
+    lease: Option<PeerLinkOperationLease>,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerRecord>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(move |tx| {
+            if let Some(lease) = lease.as_ref() {
+                require_peer_link_operation_lease(tx, lease)?;
+            } else if tx.peer_link_operation_lease(&counterparty).is_some() {
+                return Err(PaykitSdkError::Policy(format!(
+                    "peer link operation already in progress for counterparty {counterparty}"
+                )));
+            }
+            let mut record = tx
+                .linked_peer(&counterparty)
+                .unwrap_or_else(|| default_linked_peer(counterparty.clone()));
+            if record.state == LinkedPeerState::Blocked && state != LinkedPeerState::Blocked {
+                return Err(PaykitSdkError::Policy(format!(
+                    "Linked Peer {counterparty} is blocked"
+                )));
+            }
+            record.state = state;
+            record.last_sync_at = Some(now);
+            if matches!(
+                record.state,
+                LinkedPeerState::NotLinked | LinkedPeerState::Linking | LinkedPeerState::Linked
+            ) {
+                record.failure_count = 0;
+            }
+            tx.save_linked_peer(record.clone());
+            Ok(record)
+        })
+        .await
+}
+
+/// Mark a Linked Peer as requiring recovery.
+pub(crate) async fn mark_recovery_required_with_lease<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    lease: PeerLinkOperationLease,
+    now: DateTime<Utc>,
+) -> Result<RecoveryRequiredMark>
+where
+    S: StorageAdapter,
+{
+    mark_recovery_required_inner(storage, counterparty, Some(lease), now).await
+}
+
+pub(crate) fn mark_recovery_required_in_transaction<T>(
+    tx: &mut T,
+    counterparty: &PubkyPublicKey,
+    now: DateTime<Utc>,
+) -> Result<RecoveryRequiredMark>
+where
+    T: StorageTransaction + ?Sized,
+{
+    mark_recovery_required_in_transaction_inner(tx, counterparty, now, true)
+}
+
+pub(crate) fn mark_recovery_required_for_marker_in_transaction<T>(
+    tx: &mut T,
+    counterparty: &PubkyPublicKey,
+    now: DateTime<Utc>,
+) -> Result<RecoveryRequiredMark>
+where
+    T: StorageTransaction + ?Sized,
+{
+    mark_recovery_required_in_transaction_inner(tx, counterparty, now, false)
+}
+
+fn mark_recovery_required_in_transaction_inner<T>(
+    tx: &mut T,
+    counterparty: &PubkyPublicKey,
+    now: DateTime<Utc>,
+    bump_existing_episode: bool,
+) -> Result<RecoveryRequiredMark>
+where
+    T: StorageTransaction + ?Sized,
+{
+    let mut record = tx
+        .linked_peer(counterparty)
+        .unwrap_or_else(|| default_linked_peer(counterparty.clone()));
+    ensure_not_blocked(&record)?;
+    let new_episode = record.state != LinkedPeerState::RecoveryRequired;
+    record.state = LinkedPeerState::RecoveryRequired;
+    if new_episode || record.last_sync_at.is_none() {
+        record.last_sync_at = Some(now);
+    }
+    if new_episode || bump_existing_episode {
+        record.failure_count = record.failure_count.saturating_add(1);
+    }
+    tx.save_linked_peer(record);
+    if let Some(link_state) = tx.encrypted_link_state(counterparty) {
+        tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+            counterparty: counterparty.clone(),
+            link_snapshot: None,
+            handshake_snapshot: None,
+            handshake_role: None,
+            generation: link_state.generation.saturating_add(1),
+            checkpointed_at: now,
+        });
+    }
+    Ok(RecoveryRequiredMark { new_episode })
+}
+
+async fn mark_recovery_required_inner<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    lease: Option<PeerLinkOperationLease>,
+    now: DateTime<Utc>,
+) -> Result<RecoveryRequiredMark>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(move |tx| {
+            if let Some(lease) = lease.as_ref() {
+                require_peer_link_operation_lease(tx, lease)?;
+            } else if tx.peer_link_operation_lease(&counterparty).is_some() {
+                return Err(PaykitSdkError::Policy(format!(
+                    "peer link operation already in progress for counterparty {counterparty}"
+                )));
+            }
+            mark_recovery_required_in_transaction(tx, &counterparty, now)
+        })
+        .await
+}
+
+/// Persist an in-progress Encrypted Link Handshake snapshot.
+#[cfg(test)]
+pub(crate) async fn save_link_handshake_state<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    handshake_role: EncryptedLinkHandshakeRole,
+    handshake_snapshot: Vec<u8>,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerHandshakeReport>
+where
+    S: StorageAdapter,
+{
+    save_link_handshake_state_inner(
+        storage,
+        counterparty,
+        handshake_role,
+        handshake_snapshot,
+        None,
+        now,
+    )
+    .await
+}
+
+/// Persist an in-progress handshake only if the peer link lease is active.
+pub(crate) async fn save_link_handshake_state_with_lease<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    handshake_role: EncryptedLinkHandshakeRole,
+    handshake_snapshot: Vec<u8>,
+    lease: PeerLinkOperationLease,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerHandshakeReport>
+where
+    S: StorageAdapter,
+{
+    save_link_handshake_state_inner(
+        storage,
+        counterparty,
+        handshake_role,
+        handshake_snapshot,
+        Some(lease),
+        now,
+    )
+    .await
+}
+
+async fn save_link_handshake_state_inner<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    handshake_role: EncryptedLinkHandshakeRole,
+    handshake_snapshot: Vec<u8>,
+    lease: Option<PeerLinkOperationLease>,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerHandshakeReport>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(move |tx| {
+            if let Some(lease) = lease.as_ref() {
+                require_peer_link_operation_lease(tx, lease)?;
+            }
+            let mut peer = tx
+                .linked_peer(&counterparty)
+                .unwrap_or_else(|| default_linked_peer(counterparty.clone()));
+            ensure_not_blocked(&peer)?;
+            peer.state = LinkedPeerState::Linking;
+            peer.last_sync_at = Some(now);
+            peer.failure_count = 0;
+
+            let existing = tx.encrypted_link_state(&counterparty);
+            let generation = existing
+                .as_ref()
+                .map(|record| record.generation.saturating_add(1))
+                .unwrap_or_default();
+            let link_state = EncryptedLinkStateRecord {
+                counterparty: counterparty.clone(),
+                link_snapshot: None,
+                handshake_snapshot: Some(handshake_snapshot),
+                handshake_role: Some(handshake_role),
+                generation,
+                checkpointed_at: now,
+            };
+
+            tx.save_linked_peer(peer.clone());
+            tx.save_encrypted_link_state(link_state.clone());
+            Ok(LinkedPeerHandshakeReport {
+                counterparty,
+                state: peer.state,
+                generation: link_state.generation,
+                handshake_role: link_state.handshake_role,
+            })
+        })
+        .await
+}
+
+/// Persist an in-progress handshake only if the stored generation is unchanged.
+#[cfg(test)]
+pub(crate) async fn save_link_handshake_state_if_generation<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    handshake_role: EncryptedLinkHandshakeRole,
+    handshake_snapshot: Vec<u8>,
+    expected_generation: u64,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerHandshakeReport>
+where
+    S: StorageAdapter,
+{
+    save_link_handshake_state_if_generation_inner(
+        storage,
+        counterparty,
+        handshake_role,
+        handshake_snapshot,
+        expected_generation,
+        None,
+        now,
+    )
+    .await
+}
+
+/// Persist an in-progress handshake if generation and lease still match.
+pub(crate) async fn save_link_handshake_state_if_generation_with_lease<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    handshake_role: EncryptedLinkHandshakeRole,
+    handshake_snapshot: Vec<u8>,
+    expected_generation: u64,
+    lease: PeerLinkOperationLease,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerHandshakeReport>
+where
+    S: StorageAdapter,
+{
+    save_link_handshake_state_if_generation_inner(
+        storage,
+        counterparty,
+        handshake_role,
+        handshake_snapshot,
+        expected_generation,
+        Some(lease),
+        now,
+    )
+    .await
+}
+
+async fn save_link_handshake_state_if_generation_inner<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    handshake_role: EncryptedLinkHandshakeRole,
+    handshake_snapshot: Vec<u8>,
+    expected_generation: u64,
+    lease: Option<PeerLinkOperationLease>,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerHandshakeReport>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(move |tx| {
+            if let Some(lease) = lease.as_ref() {
+                require_peer_link_operation_lease(tx, lease)?;
+            }
+            let mut peer = tx
+                .linked_peer(&counterparty)
+                .unwrap_or_else(|| default_linked_peer(counterparty.clone()));
+            ensure_not_blocked(&peer)?;
+
+            if let Some(existing) = tx.encrypted_link_state(&counterparty) {
+                if existing.generation != expected_generation {
+                    let report =
+                        report_current_link_state(counterparty.clone(), &mut peer, &existing, now);
+                    tx.save_linked_peer(peer);
+                    return Ok(report);
+                }
+            }
+
+            peer.state = LinkedPeerState::Linking;
+            peer.last_sync_at = Some(now);
+            peer.failure_count = 0;
+
+            let link_state = EncryptedLinkStateRecord {
+                counterparty: counterparty.clone(),
+                link_snapshot: None,
+                handshake_snapshot: Some(handshake_snapshot),
+                handshake_role: Some(handshake_role),
+                generation: expected_generation.saturating_add(1),
+                checkpointed_at: now,
+            };
+
+            tx.save_linked_peer(peer.clone());
+            tx.save_encrypted_link_state(link_state.clone());
+            Ok(LinkedPeerHandshakeReport {
+                counterparty,
+                state: peer.state,
+                generation: link_state.generation,
+                handshake_role: link_state.handshake_role,
+            })
+        })
+        .await
+}
+
+/// Persist an established Encrypted Link snapshot.
+#[cfg(test)]
+pub(crate) async fn save_linked_peer_link_state<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    link_snapshot: Vec<u8>,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerHandshakeReport>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(move |tx| {
+            let mut peer = tx
+                .linked_peer(&counterparty)
+                .unwrap_or_else(|| default_linked_peer(counterparty.clone()));
+            ensure_not_blocked(&peer)?;
+            peer.state = LinkedPeerState::Linked;
+            peer.last_sync_at = Some(now);
+            peer.failure_count = 0;
+
+            let existing = tx.encrypted_link_state(&counterparty);
+            let generation = existing
+                .as_ref()
+                .map(|record| record.generation.saturating_add(1))
+                .unwrap_or_default();
+            let link_state = EncryptedLinkStateRecord {
+                counterparty: counterparty.clone(),
+                link_snapshot: Some(link_snapshot),
+                handshake_snapshot: None,
+                handshake_role: None,
+                generation,
+                checkpointed_at: now,
+            };
+
+            tx.save_linked_peer(peer.clone());
+            tx.save_encrypted_link_state(link_state.clone());
+            Ok(LinkedPeerHandshakeReport {
+                counterparty,
+                state: peer.state,
+                generation: link_state.generation,
+                handshake_role: link_state.handshake_role,
+            })
+        })
+        .await
+}
+
+/// Persist an established link if generation and lease still match.
+pub(crate) async fn save_linked_peer_link_state_if_generation_with_lease<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    link_snapshot: Vec<u8>,
+    expected_generation: u64,
+    lease: PeerLinkOperationLease,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerHandshakeReport>
+where
+    S: StorageAdapter,
+{
+    save_linked_peer_link_state_if_generation_inner(
+        storage,
+        counterparty,
+        link_snapshot,
+        expected_generation,
+        Some(lease),
+        now,
+    )
+    .await
+}
+
+async fn save_linked_peer_link_state_if_generation_inner<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    link_snapshot: Vec<u8>,
+    expected_generation: u64,
+    lease: Option<PeerLinkOperationLease>,
+    now: DateTime<Utc>,
+) -> Result<LinkedPeerHandshakeReport>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(move |tx| {
+            if let Some(lease) = lease.as_ref() {
+                require_peer_link_operation_lease(tx, lease)?;
+            }
+            let mut peer = tx
+                .linked_peer(&counterparty)
+                .unwrap_or_else(|| default_linked_peer(counterparty.clone()));
+            ensure_not_blocked(&peer)?;
+
+            if let Some(existing) = tx.encrypted_link_state(&counterparty) {
+                if existing.generation != expected_generation {
+                    let report =
+                        report_current_link_state(counterparty.clone(), &mut peer, &existing, now);
+                    tx.save_linked_peer(peer);
+                    return Ok(report);
+                }
+            }
+
+            peer.state = LinkedPeerState::Linked;
+            peer.last_sync_at = Some(now);
+            peer.failure_count = 0;
+
+            let link_state = EncryptedLinkStateRecord {
+                counterparty: counterparty.clone(),
+                link_snapshot: Some(link_snapshot),
+                handshake_snapshot: None,
+                handshake_role: None,
+                generation: expected_generation.saturating_add(1),
+                checkpointed_at: now,
+            };
+
+            tx.save_linked_peer(peer.clone());
+            tx.save_encrypted_link_state(link_state.clone());
+            Ok(LinkedPeerHandshakeReport {
+                counterparty,
+                state: peer.state,
+                generation: link_state.generation,
+                handshake_role: link_state.handshake_role,
+            })
+        })
+        .await
+}
+
+/// Load the durable Encrypted Link state for a counterparty.
+pub async fn load_encrypted_link_state<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Option<EncryptedLinkStateRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.encrypted_link_state(counterparty)))
+        .await
+}

--- a/paykit-sdk/src/outbound_private.rs
+++ b/paykit-sdk/src/outbound_private.rs
@@ -1,0 +1,381 @@
+//! Durable outbound Private Application Message queue.
+
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use paykit_lib::PrivateMessageKind;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    storage::{
+        require_peer_link_operation_lease, NewOutboundPrivateMessage, OutboundPrivateMessageRecord,
+        PeerLinkOperationLease, StorageAdapter,
+    },
+    PaykitSdkError, PubkyPublicKey, Result,
+};
+
+/// Delivery status for one outbound Private Application Message.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum OutboundPrivateMessageStatus {
+    /// Message is queued and has not been sent.
+    Pending,
+    /// A worker is sending this message.
+    Sending,
+    /// Message was sent successfully.
+    Sent,
+    /// Last send attempt failed.
+    Failed,
+    /// The stored payload is invalid and must not be retried automatically.
+    Invalid,
+    /// Automatic retry is paused because local Encrypted Link state is not trustworthy.
+    RecoveryRequired,
+    /// Newer latest-state data made this message unnecessary to send.
+    Superseded,
+}
+
+/// Failed outbound private send attempt.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboundPrivateSendFailure {
+    /// Outbound message id.
+    pub outbound_message_id: u64,
+    /// Error from the send attempt.
+    pub error: String,
+}
+
+impl fmt::Debug for OutboundPrivateSendFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let error = redacted_error(&self.error);
+        f.debug_struct("OutboundPrivateSendFailure")
+            .field("outbound_message_id", &self.outbound_message_id)
+            .field("error", &error)
+            .finish()
+    }
+}
+
+/// Failed cleanup of a superseded Payment Endpoint Reservation.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReservationCleanupFailure {
+    /// Reservation id, when the failure is tied to a specific reservation.
+    pub reservation_id: Option<String>,
+    /// Cleanup error.
+    pub error: String,
+}
+
+impl fmt::Debug for ReservationCleanupFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let error = redacted_error(&self.error);
+        f.debug_struct("ReservationCleanupFailure")
+            .field("reservation_id", &self.reservation_id)
+            .field("error", &error)
+            .finish()
+    }
+}
+
+/// Failed recovery marker publication during outbound private send recovery.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoveryMarkerPublishFailure {
+    /// Outbound message id that triggered recovery, when available.
+    pub outbound_message_id: Option<u64>,
+    /// Recovery marker publication error.
+    pub error: String,
+}
+
+impl fmt::Debug for RecoveryMarkerPublishFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let error = redacted_error(&self.error);
+        f.debug_struct("RecoveryMarkerPublishFailure")
+            .field("outbound_message_id", &self.outbound_message_id)
+            .field("error", &error)
+            .finish()
+    }
+}
+
+/// Summary returned after processing outbound private messages.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboundPrivateSendReport {
+    /// Messages attempted in this run.
+    pub attempted: Vec<u64>,
+    /// Messages marked sent in this run.
+    pub sent: Vec<u64>,
+    /// Messages that failed in this run.
+    pub failed: Vec<OutboundPrivateSendFailure>,
+    /// Superseded reservation cleanup failures observed in this run.
+    pub reservation_cleanup_failures: Vec<ReservationCleanupFailure>,
+    /// Recovery marker publication failures observed after fail-closed recovery.
+    #[serde(default)]
+    pub recovery_marker_failures: Vec<RecoveryMarkerPublishFailure>,
+}
+
+/// Summary for processing outbound private messages for one counterparty.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboundPrivateCounterpartySendReport {
+    /// Counterparty whose queue was processed.
+    pub counterparty: PubkyPublicKey,
+    /// Successful send report, when processing completed.
+    pub report: Option<OutboundPrivateSendReport>,
+    /// Error text, when processing failed for this counterparty.
+    pub error: Option<String>,
+}
+
+impl fmt::Debug for OutboundPrivateCounterpartySendReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let error = self.error.as_deref().map(redacted_error);
+        f.debug_struct("OutboundPrivateCounterpartySendReport")
+            .field("counterparty", &self.counterparty)
+            .field("report", &self.report)
+            .field("error", &error)
+            .finish()
+    }
+}
+
+fn redacted_error(error: &str) -> String {
+    format!("<redacted:{} bytes>", error.len())
+}
+
+/// Enqueue one raw JSON Private Application Message.
+pub(crate) async fn enqueue_private_message<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    raw_json: String,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let kind = validate_outbound_private_message(&raw_json)?;
+    storage
+        .transaction(move |tx| {
+            let record = tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                counterparty,
+                kind,
+                raw_json,
+                now,
+            ));
+            Ok(record)
+        })
+        .await
+}
+
+/// Enqueue one raw JSON Private Application Message while a peer operation
+/// lease is still active.
+pub(crate) async fn enqueue_private_message_with_link_lease<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    raw_json: String,
+    now: DateTime<Utc>,
+    lease: &PeerLinkOperationLease,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let kind = validate_outbound_private_message(&raw_json)?;
+    storage
+        .transaction(move |tx| {
+            require_peer_link_operation_lease(tx, lease)?;
+            let record = tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                counterparty,
+                kind,
+                raw_json,
+                now,
+            ));
+            Ok(record)
+        })
+        .await
+}
+
+/// Load private messages that should be attempted for one counterparty.
+pub(crate) async fn queued_outbound_private_messages<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Vec<OutboundPrivateMessageRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.queued_outbound_private_messages(counterparty)))
+        .await
+}
+
+#[cfg(test)]
+pub(crate) async fn claim_next_outbound_private_message<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    now: DateTime<Utc>,
+    stale_before: DateTime<Utc>,
+    failed_retry_after: DateTime<Utc>,
+) -> Result<Option<OutboundPrivateMessageRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| {
+            Ok(tx.claim_next_outbound_private_message(
+                counterparty,
+                now,
+                stale_before,
+                failed_retry_after,
+            ))
+        })
+        .await
+}
+
+pub(crate) async fn claim_next_outbound_private_message_with_peer_lease<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    now: DateTime<Utc>,
+    stale_before: DateTime<Utc>,
+    failed_retry_after: DateTime<Utc>,
+    lease: PeerLinkOperationLease,
+) -> Result<Option<OutboundPrivateMessageRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(move |tx| {
+            require_peer_link_operation_lease(tx, &lease)?;
+            Ok(tx.claim_next_outbound_private_message(
+                counterparty,
+                now,
+                stale_before,
+                failed_retry_after,
+            ))
+        })
+        .await
+}
+
+pub(crate) fn mark_outbound_sent(
+    mut record: OutboundPrivateMessageRecord,
+    now: DateTime<Utc>,
+) -> OutboundPrivateMessageRecord {
+    record.status = OutboundPrivateMessageStatus::Sent;
+    record.sent_at = Some(now);
+    record.updated_at = now;
+    record.last_error = None;
+    record
+}
+
+pub(crate) fn mark_outbound_failed(
+    mut record: OutboundPrivateMessageRecord,
+    error: String,
+    now: DateTime<Utc>,
+) -> OutboundPrivateMessageRecord {
+    record.status = OutboundPrivateMessageStatus::Failed;
+    record.updated_at = now;
+    record.last_error = Some(error);
+    record
+}
+
+pub(crate) fn mark_outbound_invalid(
+    mut record: OutboundPrivateMessageRecord,
+    error: String,
+    now: DateTime<Utc>,
+) -> OutboundPrivateMessageRecord {
+    record.status = OutboundPrivateMessageStatus::Invalid;
+    record.updated_at = now;
+    record.last_error = Some(error);
+    record
+}
+
+pub(crate) fn mark_outbound_recovery_required(
+    mut record: OutboundPrivateMessageRecord,
+    error: String,
+    now: DateTime<Utc>,
+) -> OutboundPrivateMessageRecord {
+    record.status = OutboundPrivateMessageStatus::RecoveryRequired;
+    record.updated_at = now;
+    record.last_error = Some(error);
+    record
+}
+
+pub(crate) fn validate_queued_outbound_private_message(
+    record: &OutboundPrivateMessageRecord,
+) -> Result<()> {
+    let kind = validate_outbound_private_message(&record.raw_json)?;
+    if kind != record.kind {
+        return Err(PaykitSdkError::Protocol(format!(
+            "queued private message kind '{}' does not match payload kind '{kind}'",
+            record.kind
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_outbound_private_message(raw_json: &str) -> Result<String> {
+    if raw_json.len() > paykit_lib::pubky_noise::snow_crypto::PUBKY_NOISE_MSG_LEN {
+        return Err(PaykitSdkError::Protocol(
+            "Private Application Message exceeds pubky-noise message size".into(),
+        ));
+    }
+
+    let value: serde_json::Value = serde_json::from_str(raw_json)
+        .map_err(|err| PaykitSdkError::Protocol(format!("invalid private message JSON: {err}")))?;
+    let version = value
+        .get("version")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| PaykitSdkError::Protocol("private message version is missing".into()))?;
+    if version != 1 {
+        return Err(PaykitSdkError::Protocol(format!(
+            "unsupported private message version {version}"
+        )));
+    }
+    let kind = value
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| PaykitSdkError::Protocol("private message kind is missing".into()))?;
+    let parsed_kind = PrivateMessageKind::parse(kind).ok_or_else(|| {
+        PaykitSdkError::Protocol(format!("unsupported private message kind '{kind}'"))
+    })?;
+    validate_outbound_private_message_body(parsed_kind, raw_json)?;
+
+    Ok(kind.to_owned())
+}
+
+fn validate_outbound_private_message_body(kind: PrivateMessageKind, raw_json: &str) -> Result<()> {
+    match kind {
+        PrivateMessageKind::PrivatePaymentList => {
+            paykit_lib::parse_private_payment_list_json(raw_json)?;
+        }
+        PrivateMessageKind::ReceiptAccess => {
+            let message = private_application_message(kind, raw_json);
+            let event =
+                paykit_lib::parse_receipt_access_event_message(&message).ok_or_else(|| {
+                    PaykitSdkError::Protocol(
+                        "Receipt Access payload does not match private message kind".into(),
+                    )
+                })?;
+            if let Some(error) = event.validation_error() {
+                return Err(PaykitSdkError::Protocol(error.to_owned()));
+            }
+        }
+        PrivateMessageKind::PaymentRequest
+        | PrivateMessageKind::PaymentRequestAcceptance
+        | PrivateMessageKind::PaymentRequestRejection
+        | PrivateMessageKind::PaymentRequestCancellation
+        | PrivateMessageKind::PaymentProof => {
+            let message = private_application_message(kind, raw_json);
+            let event =
+                paykit_lib::parse_payment_request_event_message(&message).ok_or_else(|| {
+                    PaykitSdkError::Protocol(
+                        "Payment Request event payload does not match private message kind".into(),
+                    )
+                })?;
+            if let Some(error) = event.validation_error() {
+                return Err(PaykitSdkError::Protocol(error.to_owned()));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn private_application_message(
+    kind: PrivateMessageKind,
+    raw_json: &str,
+) -> paykit_lib::PrivateApplicationMessage {
+    paykit_lib::PrivateApplicationMessage {
+        version: Some(1),
+        kind: Some(kind.as_str().to_owned()),
+        raw_json: raw_json.to_owned(),
+    }
+}

--- a/paykit-sdk/src/payment_requests.rs
+++ b/paykit-sdk/src/payment_requests.rs
@@ -1,0 +1,460 @@
+//! Payment Request lifecycle derivation.
+//!
+//! Derived records can include Payment Request metadata. Treat them as private
+//! SDK state.
+
+use std::{
+    cmp::{Ordering, Reverse},
+    collections::{HashMap, HashSet},
+    fmt,
+};
+
+use chrono::{DateTime, Utc};
+use paykit_lib::{
+    parse_payment_request_event_message, serialize_payment_request_event, PaymentProof,
+    PaymentRequest, PaymentRequestAcceptance, PaymentRequestCancellation, PaymentRequestEvent,
+    PaymentRequestRejection, PrivateApplicationMessage,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+use crate::{
+    outbound_private::enqueue_private_message,
+    outbound_private::OutboundPrivateMessageStatus,
+    private_stream::payload_hash,
+    records::{AmountRecord, BillingPeriodRecord},
+    storage::{
+        EventDedupRecord, OutboundPrivateMessageRecord, PrivateStreamItemRecord, StorageAdapter,
+    },
+    PubkyPublicKey, Result,
+};
+
+mod derivation;
+
+use derivation::recurrence_unit_to_str;
+pub(crate) use derivation::{
+    payment_request_records, received_payment_request_records, request_from_record,
+};
+
+/// Local role for one Payment Request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PaymentRequestLocalRole {
+    /// Local identity is expected to pay.
+    Payer,
+    /// Local identity expects to receive payment.
+    Payee,
+}
+
+/// SDK-derived Payment Request lifecycle state.
+///
+/// States are derived from the local durable stream and outbound queue. They do
+/// not imply counterparty visibility unless the related outbound status is
+/// [`OutboundPrivateMessageStatus::Sent`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PaymentRequestLifecycleState {
+    /// Proposal is known locally and remains actionable.
+    Proposed,
+    /// Proposal is past its expiry.
+    ProposalExpired,
+    /// Acceptance is present locally.
+    Accepted,
+    /// Rejection is present locally.
+    Rejected,
+    /// Cancellation is present locally.
+    Canceled,
+    /// A one-time Payment Proof is present locally.
+    ProofSubmitted,
+    /// Recurring request acceptance is present locally.
+    ActiveRecurring,
+    /// A local outbound event may have advanced the private link without a durable checkpoint.
+    RecoveryRequired,
+    /// Event ordering, dedupe, or lifecycle validation found an invalid state.
+    InvalidConflict,
+}
+
+/// Filter for listing SDK-derived Payment Requests.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentRequestFilter {
+    /// Restrict results to one counterparty. `None` lists across all known
+    /// counterparties with Payment Request activity.
+    pub counterparty: Option<PubkyPublicKey>,
+    /// Restrict results to one local role.
+    pub local_role: Option<PaymentRequestLocalRole>,
+    /// Restrict results to lifecycle states. An empty list means all states.
+    pub states: Vec<PaymentRequestLifecycleState>,
+    /// Restrict results by whether the request has recurrence terms.
+    pub recurring: Option<bool>,
+    /// Include only inbound Payment Requests received from counterparties.
+    pub received_only: bool,
+}
+
+impl PaymentRequestFilter {
+    pub(crate) fn matches(&self, record: &PaymentRequestRecord) -> bool {
+        if let Some(counterparty) = &self.counterparty {
+            if &record.counterparty != counterparty {
+                return false;
+            }
+        }
+        if let Some(local_role) = self.local_role {
+            if record.local_role != Some(local_role) {
+                return false;
+            }
+        }
+        if !self.states.is_empty() && !self.states.contains(&record.state) {
+            return false;
+        }
+        if let Some(recurring) = self.recurring {
+            let record_recurring = record
+                .terms
+                .as_ref()
+                .and_then(|terms| terms.recurrence.as_ref())
+                .is_some();
+            if record_recurring != recurring {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// Recurrence fields copied from Payment Request terms.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentRequestRecurrenceRecord {
+    /// Positive interval count.
+    pub every: u32,
+    /// Recurrence unit string.
+    pub unit: String,
+    /// RFC3339 UTC timestamp using `Z`.
+    pub starts_at: String,
+    /// RFC3339 UTC timestamp using `Z`.
+    pub anchor: String,
+    /// Optional RFC3339 UTC timestamp using `Z`.
+    pub ends_at: Option<String>,
+}
+
+/// Immutable Payment Request terms copied into an SDK record.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct PaymentRequestTermsRecord {
+    /// Requested amount.
+    pub amount: AmountRecord,
+    /// Payee-provided payment correlation value.
+    pub payment_reference: String,
+    /// Proposal expiry before acceptance.
+    pub proposal_expires_at: Option<String>,
+    /// Optional recurrence.
+    pub recurrence: Option<PaymentRequestRecurrenceRecord>,
+    /// Accepted Payment Endpoint Identifiers.
+    pub accepted_payment_endpoint_identifiers: Vec<String>,
+    /// Application-specific metadata.
+    pub metadata: JsonMap<String, JsonValue>,
+}
+
+impl fmt::Debug for PaymentRequestTermsRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentRequestTermsRecord")
+            .field("amount", &"<redacted>")
+            .field("payment_reference", &"<redacted>")
+            .field("proposal_expires_at", &self.proposal_expires_at)
+            .field("recurrence", &self.recurrence)
+            .field(
+                "accepted_payment_endpoint_identifiers",
+                &self.accepted_payment_endpoint_identifiers,
+            )
+            .field(
+                "metadata",
+                &format_args!("<redacted:{} fields>", self.metadata.len()),
+            )
+            .finish()
+    }
+}
+
+impl From<&paykit_lib::PaymentRequestTerms> for PaymentRequestTermsRecord {
+    fn from(terms: &paykit_lib::PaymentRequestTerms) -> Self {
+        Self {
+            amount: AmountRecord::from(&terms.amount),
+            payment_reference: terms.payment_reference.as_str().to_owned(),
+            proposal_expires_at: terms.proposal_expires_at.clone(),
+            recurrence: terms.recurrence.as_ref().map(|recurrence| {
+                PaymentRequestRecurrenceRecord {
+                    every: recurrence.every,
+                    unit: recurrence_unit_to_str(recurrence.unit).to_owned(),
+                    starts_at: recurrence.starts_at.clone(),
+                    anchor: recurrence.anchor.clone(),
+                    ends_at: recurrence.ends_at.clone(),
+                }
+            }),
+            accepted_payment_endpoint_identifiers: terms
+                .accepted_payment_endpoint_identifiers
+                .iter()
+                .map(|identifier| identifier.as_str().to_owned())
+                .collect(),
+            metadata: terms.metadata.clone(),
+        }
+    }
+}
+
+/// Payment Proof captured in a derived Payment Request record.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct PaymentProofRecord {
+    /// Event ID.
+    pub event_id: String,
+    /// Outbound message id, when proof was sent locally.
+    pub outbound_message_id: Option<u64>,
+    /// Local outbound delivery status, when proof was queued locally.
+    pub outbound_status: Option<OutboundPrivateMessageStatus>,
+    /// Stream item id, when proof was received from the counterparty.
+    pub stream_item_id: Option<u64>,
+    /// Payment Reference copied from the proof.
+    pub payment_reference: String,
+    /// Optional Billing Period copied from the proof.
+    pub billing_period: Option<BillingPeriodRecord>,
+    /// Payment Endpoint Identifier used for payment.
+    pub payment_endpoint_identifier: String,
+    /// Method-specific proof object.
+    pub proof: JsonMap<String, JsonValue>,
+    /// Local record time for this proof.
+    pub recorded_at: DateTime<Utc>,
+}
+
+impl fmt::Debug for PaymentProofRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentProofRecord")
+            .field("event_id", &self.event_id)
+            .field("outbound_message_id", &self.outbound_message_id)
+            .field("outbound_status", &self.outbound_status)
+            .field("stream_item_id", &self.stream_item_id)
+            .field("payment_reference", &"<redacted>")
+            .field("billing_period", &self.billing_period)
+            .field(
+                "payment_endpoint_identifier",
+                &self.payment_endpoint_identifier,
+            )
+            .field(
+                "proof",
+                &format_args!("<redacted:{} fields>", self.proof.len()),
+            )
+            .field("recorded_at", &self.recorded_at)
+            .finish()
+    }
+}
+
+/// SDK-derived Payment Request lifecycle record.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct PaymentRequestRecord {
+    /// Counterparty associated with the private stream.
+    pub counterparty: PubkyPublicKey,
+    /// Stable Payment Request ID.
+    pub payment_request_id: String,
+    /// Local role, when known.
+    pub local_role: Option<PaymentRequestLocalRole>,
+    /// Derived local lifecycle state.
+    pub state: PaymentRequestLifecycleState,
+    /// Stream item id of the proposal event.
+    pub proposal_stream_item_id: Option<u64>,
+    /// Outbound message id of the proposal event.
+    pub proposal_outbound_message_id: Option<u64>,
+    /// Local outbound delivery status for the proposal event.
+    pub proposal_outbound_status: Option<OutboundPrivateMessageStatus>,
+    /// Proposal Event ID.
+    pub proposal_event_id: Option<String>,
+    /// Immutable terms from the proposal.
+    pub terms: Option<PaymentRequestTermsRecord>,
+    /// Acceptance Event ID.
+    pub accepted_event_id: Option<String>,
+    /// Local outbound delivery status for an acceptance event.
+    pub accepted_outbound_status: Option<OutboundPrivateMessageStatus>,
+    /// Rejection Event ID.
+    pub rejected_event_id: Option<String>,
+    /// Local outbound delivery status for a rejection event.
+    pub rejected_outbound_status: Option<OutboundPrivateMessageStatus>,
+    /// Cancellation Event ID.
+    pub canceled_event_id: Option<String>,
+    /// Local outbound delivery status for a cancellation event.
+    pub canceled_outbound_status: Option<OutboundPrivateMessageStatus>,
+    /// Payment Proof records in local record order.
+    pub payment_proofs: Vec<PaymentProofRecord>,
+    /// Last inbound stream item applied to this record.
+    pub last_stream_item_id: Option<u64>,
+    /// Last outbound message applied to this record.
+    pub last_outbound_message_id: Option<u64>,
+    /// Local delivery status of the last outbound message applied to this record.
+    pub last_outbound_status: Option<OutboundPrivateMessageStatus>,
+    /// Last event local record time.
+    pub last_event_at: Option<DateTime<Utc>>,
+    /// Invalid state reason, when available.
+    pub invalid_reason: Option<String>,
+}
+
+impl fmt::Debug for PaymentRequestRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PaymentRequestRecord")
+            .field("counterparty", &self.counterparty)
+            .field("payment_request_id", &self.payment_request_id)
+            .field("local_role", &self.local_role)
+            .field("state", &self.state)
+            .field("proposal_stream_item_id", &self.proposal_stream_item_id)
+            .field(
+                "proposal_outbound_message_id",
+                &self.proposal_outbound_message_id,
+            )
+            .field("proposal_outbound_status", &self.proposal_outbound_status)
+            .field("proposal_event_id", &self.proposal_event_id)
+            .field("accepted_event_id", &self.accepted_event_id)
+            .field("accepted_outbound_status", &self.accepted_outbound_status)
+            .field("rejected_event_id", &self.rejected_event_id)
+            .field("rejected_outbound_status", &self.rejected_outbound_status)
+            .field("canceled_event_id", &self.canceled_event_id)
+            .field("canceled_outbound_status", &self.canceled_outbound_status)
+            .field("payment_proof_count", &self.payment_proofs.len())
+            .field("last_stream_item_id", &self.last_stream_item_id)
+            .field("last_outbound_message_id", &self.last_outbound_message_id)
+            .field("last_outbound_status", &self.last_outbound_status)
+            .field("last_event_at", &self.last_event_at)
+            .field("invalid_reason", &self.invalid_reason)
+            .finish()
+    }
+}
+
+impl PaymentRequestRecord {
+    fn new(counterparty: PubkyPublicKey, payment_request_id: String) -> Self {
+        Self {
+            counterparty,
+            payment_request_id,
+            local_role: None,
+            state: PaymentRequestLifecycleState::InvalidConflict,
+            proposal_stream_item_id: None,
+            proposal_outbound_message_id: None,
+            proposal_outbound_status: None,
+            proposal_event_id: None,
+            terms: None,
+            accepted_event_id: None,
+            accepted_outbound_status: None,
+            rejected_event_id: None,
+            rejected_outbound_status: None,
+            canceled_event_id: None,
+            canceled_outbound_status: None,
+            payment_proofs: Vec::new(),
+            last_stream_item_id: None,
+            last_outbound_message_id: None,
+            last_outbound_status: None,
+            last_event_at: None,
+            invalid_reason: None,
+        }
+    }
+
+    fn touch(&mut self, item: &PrivateStreamItemRecord) {
+        self.last_stream_item_id = Some(item.stream_item_id);
+        self.touch_at(item.received_at);
+    }
+
+    fn touch_outbound(&mut self, message: &OutboundPrivateMessageRecord) {
+        self.last_outbound_message_id = Some(message.outbound_message_id);
+        self.last_outbound_status = Some(message.status.clone());
+        self.touch_at(message.updated_at);
+    }
+
+    fn touch_at(&mut self, timestamp: DateTime<Utc>) {
+        self.last_event_at = Some(
+            self.last_event_at
+                .map(|current| current.max(timestamp))
+                .unwrap_or(timestamp),
+        );
+    }
+
+    fn mark_invalid(&mut self, item: &PrivateStreamItemRecord, reason: impl Into<String>) {
+        self.state = PaymentRequestLifecycleState::InvalidConflict;
+        if self.invalid_reason.is_none() {
+            self.invalid_reason = Some(reason.into());
+        }
+        self.touch(item);
+    }
+}
+
+/// Queue one raw Payment Request protocol event for outbound delivery.
+///
+/// The exact canonical JSON payload is serialized before it is stored, so retry
+/// workers can resend the same Event ID and payload.
+pub(crate) async fn enqueue_payment_request_event<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentRequestEvent,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let raw_json = serialize_payment_request_event(event)?;
+    enqueue_private_message(storage, counterparty, raw_json, now).await
+}
+
+/// Queue a raw Payment Request proposal for outbound delivery.
+pub(crate) async fn enqueue_payment_request<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentRequest,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let event = PaymentRequestEvent::Request(event.clone());
+    enqueue_payment_request_event(storage, counterparty, &event, now).await
+}
+
+/// Queue a raw Payment Request acceptance for outbound delivery.
+pub(crate) async fn enqueue_payment_request_acceptance<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentRequestAcceptance,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let event = PaymentRequestEvent::Acceptance(event.clone());
+    enqueue_payment_request_event(storage, counterparty, &event, now).await
+}
+
+/// Queue a raw Payment Request rejection for outbound delivery.
+pub(crate) async fn enqueue_payment_request_rejection<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentRequestRejection,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let event = PaymentRequestEvent::Rejection(event.clone());
+    enqueue_payment_request_event(storage, counterparty, &event, now).await
+}
+
+/// Queue a raw Payment Request cancellation for outbound delivery.
+pub(crate) async fn enqueue_payment_request_cancellation<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentRequestCancellation,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let event = PaymentRequestEvent::Cancellation(event.clone());
+    enqueue_payment_request_event(storage, counterparty, &event, now).await
+}
+
+/// Queue a raw Payment Proof for outbound delivery.
+pub(crate) async fn enqueue_payment_proof<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    event: &PaymentProof,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let event = PaymentRequestEvent::Proof(event.clone());
+    enqueue_payment_request_event(storage, counterparty, &event, now).await
+}

--- a/paykit-sdk/src/payment_requests/derivation.rs
+++ b/paykit-sdk/src/payment_requests/derivation.rs
@@ -1,0 +1,986 @@
+use super::*;
+
+/// Derive received Payment Request lifecycle records for one counterparty.
+///
+/// Records are derived from the persisted inbound private stream and returned
+/// newest-first by the last applied stream item. Malformed recognized Payment
+/// Request events without a valid `payment_request_id` remain available in the
+/// raw private stream log but cannot be attached to a request-scoped record.
+pub(crate) async fn received_payment_request_records<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    now: DateTime<Utc>,
+) -> Result<Vec<PaymentRequestRecord>>
+where
+    S: StorageAdapter,
+{
+    let (items, dedupe_records) = storage
+        .transaction(|tx| {
+            let items = tx.private_stream_items(counterparty);
+            let mut dedupe_records = HashMap::new();
+            for item in &items {
+                let Some(message) = payment_request_message_from_item(item) else {
+                    continue;
+                };
+                let Some(parsed) = parse_payment_request_event_message(&message) else {
+                    continue;
+                };
+                let Some(event_id) = parsed.event_id() else {
+                    continue;
+                };
+                if let Some(record) = tx.event_dedup_record(counterparty, event_id.as_str()) {
+                    dedupe_records.insert(event_id.as_str().to_owned(), record);
+                }
+            }
+            Ok((items, dedupe_records))
+        })
+        .await?;
+    derive_received_payment_request_records(counterparty.clone(), items, dedupe_records, now)
+}
+
+/// Derive local Payment Request records for one counterparty.
+///
+/// Records merge received Payment Request events from the private stream with
+/// local outbound Payment Request events from the outbound private-message log.
+/// Returned records are newest-first by local record time.
+pub(crate) async fn payment_request_records<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    now: DateTime<Utc>,
+) -> Result<Vec<PaymentRequestRecord>>
+where
+    S: StorageAdapter,
+{
+    let (items, outbound, dedupe_records) = storage
+        .transaction(|tx| {
+            let items = tx.private_stream_items(counterparty);
+            let outbound = tx.outbound_private_messages(counterparty);
+            let mut dedupe_records = HashMap::new();
+            for item in &items {
+                let Some(message) = payment_request_message_from_item(item) else {
+                    continue;
+                };
+                let Some(parsed) = parse_payment_request_event_message(&message) else {
+                    continue;
+                };
+                let Some(event_id) = parsed.event_id() else {
+                    continue;
+                };
+                if let Some(record) = tx.event_dedup_record(counterparty, event_id.as_str()) {
+                    dedupe_records.insert(event_id.as_str().to_owned(), record);
+                }
+            }
+            Ok((items, outbound, dedupe_records))
+        })
+        .await?;
+    derive_payment_request_records(counterparty.clone(), items, outbound, dedupe_records, now)
+}
+fn derive_received_payment_request_records(
+    counterparty: PubkyPublicKey,
+    mut items: Vec<PrivateStreamItemRecord>,
+    dedupe_records: HashMap<String, EventDedupRecord>,
+    now: DateTime<Utc>,
+) -> Result<Vec<PaymentRequestRecord>> {
+    items.sort_by_key(|item| item.stream_item_id);
+    let mut records = HashMap::<String, PaymentRequestRecord>::new();
+
+    for item in items {
+        let Some(message) = payment_request_message_from_item(&item) else {
+            continue;
+        };
+        let Some(parsed) = parse_payment_request_event_message(&message) else {
+            continue;
+        };
+        let payment_request_id = parsed.payment_request_id().map(|id| id.as_str().to_owned());
+        let event_id = parsed.event_id().map(|id| id.as_str().to_owned());
+
+        if let Some(event_id) = event_id.as_deref() {
+            if let Some(dedupe) = dedupe_records.get(event_id) {
+                if dedupe
+                    .duplicate_stream_item_ids
+                    .contains(&item.stream_item_id)
+                {
+                    continue;
+                }
+                if dedupe
+                    .conflicting_stream_item_ids
+                    .contains(&item.stream_item_id)
+                    || (dedupe.first_stream_item_id == item.stream_item_id
+                        && !dedupe.conflicting_stream_item_ids.is_empty())
+                {
+                    if let Some(payment_request_id) = payment_request_id {
+                        record_for(&mut records, &counterparty, payment_request_id)
+                            .mark_invalid(&item, "Event ID reused with different payload");
+                    }
+                    continue;
+                }
+            }
+        }
+
+        let Some(payment_request_id) = payment_request_id else {
+            continue;
+        };
+        let record = record_for(&mut records, &counterparty, payment_request_id);
+        if !parsed.is_valid() {
+            record.mark_invalid(
+                &item,
+                parsed
+                    .validation_error()
+                    .unwrap_or("malformed Payment Request event"),
+            );
+            continue;
+        }
+        let event = parsed.parsed_event().expect("valid event");
+        apply_event(record, event, &item, now);
+    }
+
+    for record in records.values_mut() {
+        if record.state == PaymentRequestLifecycleState::Proposed && proposal_expired(record, now) {
+            record.state = PaymentRequestLifecycleState::ProposalExpired;
+        }
+    }
+
+    let mut records = records.into_values().collect::<Vec<_>>();
+    records.sort_by_key(|record| {
+        Reverse(
+            record
+                .last_stream_item_id
+                .or(record.proposal_stream_item_id),
+        )
+    });
+    Ok(records)
+}
+
+#[derive(Clone)]
+enum StoredPaymentRequestEvent {
+    Received {
+        item: PrivateStreamItemRecord,
+        event: PaymentRequestEvent,
+    },
+    Outbound {
+        message: OutboundPrivateMessageRecord,
+        event: PaymentRequestEvent,
+    },
+}
+
+impl StoredPaymentRequestEvent {
+    fn record_time(&self) -> DateTime<Utc> {
+        match self {
+            Self::Received { item, .. } => item.received_at,
+            Self::Outbound { message, .. } => message.created_at,
+        }
+    }
+
+    fn phase_order(&self) -> u8 {
+        match self.event() {
+            PaymentRequestEvent::Request(_) => 0,
+            PaymentRequestEvent::Acceptance(_)
+            | PaymentRequestEvent::Rejection(_)
+            | PaymentRequestEvent::Cancellation(_)
+            | PaymentRequestEvent::Proof(_) => 1,
+        }
+    }
+
+    fn source_order(&self) -> u64 {
+        match self {
+            Self::Received { item, .. } => item.stream_item_id,
+            Self::Outbound { message, .. } => message.outbound_message_id,
+        }
+    }
+
+    fn source_rank(&self) -> u8 {
+        match self {
+            Self::Received { .. } => 0,
+            Self::Outbound { .. } => 1,
+        }
+    }
+
+    fn payload_hash(&self) -> String {
+        match self {
+            Self::Received { item, .. } => payload_hash(&item.raw_json),
+            Self::Outbound { message, .. } => payload_hash(&message.raw_json),
+        }
+    }
+
+    fn event(&self) -> &PaymentRequestEvent {
+        match self {
+            Self::Received { event, .. } | Self::Outbound { event, .. } => event,
+        }
+    }
+
+    fn payment_request_id(&self) -> String {
+        self.event().payment_request_id().as_str().to_owned()
+    }
+
+    fn event_id(&self) -> String {
+        self.event().event_id().as_str().to_owned()
+    }
+}
+
+fn derive_payment_request_records(
+    counterparty: PubkyPublicKey,
+    mut items: Vec<PrivateStreamItemRecord>,
+    outbound: Vec<OutboundPrivateMessageRecord>,
+    dedupe_records: HashMap<String, EventDedupRecord>,
+    now: DateTime<Utc>,
+) -> Result<Vec<PaymentRequestRecord>> {
+    let mut records = HashMap::<String, PaymentRequestRecord>::new();
+    let mut events = Vec::<StoredPaymentRequestEvent>::new();
+    let mut pre_invalid_request_ids = HashSet::<String>::new();
+    let mut tainted_event_seeds = Vec::<TaintedEventSeed>::new();
+
+    items.sort_by_key(|item| item.stream_item_id);
+    for item in items {
+        let Some(message) = payment_request_message_from_item(&item) else {
+            continue;
+        };
+        let Some(parsed) = parse_payment_request_event_message(&message) else {
+            continue;
+        };
+        let payment_request_id = parsed.payment_request_id().map(|id| id.as_str().to_owned());
+        let event_id = parsed.event_id().map(|id| id.as_str().to_owned());
+
+        if let Some(event_id) = event_id.as_deref() {
+            if let Some(dedupe) = dedupe_records.get(event_id) {
+                if dedupe
+                    .duplicate_stream_item_ids
+                    .contains(&item.stream_item_id)
+                {
+                    continue;
+                }
+                if dedupe
+                    .conflicting_stream_item_ids
+                    .contains(&item.stream_item_id)
+                    || (dedupe.first_stream_item_id == item.stream_item_id
+                        && !dedupe.conflicting_stream_item_ids.is_empty())
+                {
+                    if let Some(payment_request_id) = payment_request_id {
+                        tainted_event_seeds.push(TaintedEventSeed {
+                            event_id: event_id.to_owned(),
+                            payment_request_id: payment_request_id.clone(),
+                            payload_hash: payload_hash(&item.raw_json),
+                            source_rank: 0,
+                        });
+                        pre_invalid_request_ids.insert(payment_request_id.clone());
+                        record_for(&mut records, &counterparty, payment_request_id)
+                            .mark_invalid(&item, "Event ID reused with different payload");
+                    } else {
+                        tainted_event_seeds.push(TaintedEventSeed {
+                            event_id: event_id.to_owned(),
+                            payment_request_id: String::new(),
+                            payload_hash: payload_hash(&item.raw_json),
+                            source_rank: 0,
+                        });
+                    }
+                    continue;
+                }
+            }
+        }
+
+        let Some(payment_request_id) = payment_request_id else {
+            if let Some(event_id) = event_id {
+                tainted_event_seeds.push(TaintedEventSeed {
+                    event_id,
+                    payment_request_id: String::new(),
+                    payload_hash: payload_hash(&item.raw_json),
+                    source_rank: 0,
+                });
+            }
+            continue;
+        };
+        if !parsed.is_valid() {
+            if let Some(event_id) = event_id {
+                tainted_event_seeds.push(TaintedEventSeed {
+                    event_id,
+                    payment_request_id: payment_request_id.clone(),
+                    payload_hash: payload_hash(&item.raw_json),
+                    source_rank: 0,
+                });
+            }
+            pre_invalid_request_ids.insert(payment_request_id.clone());
+            record_for(&mut records, &counterparty, payment_request_id).mark_invalid(
+                &item,
+                parsed
+                    .validation_error()
+                    .unwrap_or("malformed Payment Request event"),
+            );
+            continue;
+        }
+        events.push(StoredPaymentRequestEvent::Received {
+            item,
+            event: parsed.parsed_event().expect("valid event").clone(),
+        });
+    }
+
+    for message in outbound {
+        if matches!(
+            message.status,
+            OutboundPrivateMessageStatus::Invalid | OutboundPrivateMessageStatus::Superseded
+        ) {
+            continue;
+        }
+        let Some(parsed) = parse_payment_request_event_message(&PrivateApplicationMessage {
+            version: Some(1),
+            kind: Some(message.kind.clone()),
+            raw_json: message.raw_json.clone(),
+        }) else {
+            continue;
+        };
+        let Some(event) = parsed.parsed_event() else {
+            continue;
+        };
+        let stored = StoredPaymentRequestEvent::Outbound {
+            message,
+            event: event.clone(),
+        };
+        if dedupe_records
+            .get(event.event_id().as_str())
+            .is_some_and(|dedupe| !dedupe.conflicting_stream_item_ids.is_empty())
+        {
+            let record = record_for(&mut records, &counterparty, stored.payment_request_id());
+            mark_invalid_stored(record, &stored, "Event ID reused with different payload");
+            continue;
+        }
+        events.push(stored);
+    }
+
+    events.sort_by(compare_stored_events);
+    let tainted_events = events
+        .iter()
+        .filter(|event| pre_invalid_request_ids.contains(&event.payment_request_id()))
+        .cloned()
+        .collect::<Vec<_>>();
+    events.retain(|event| !pre_invalid_request_ids.contains(&event.payment_request_id()));
+    events = dedupe_stored_events(
+        &counterparty,
+        &mut records,
+        events,
+        tainted_events,
+        tainted_event_seeds,
+    );
+    for event in events {
+        let payment_request_id = event.payment_request_id();
+        let record = record_for(&mut records, &counterparty, payment_request_id);
+        apply_stored_event(record, &event);
+    }
+
+    for record in records.values_mut() {
+        if record.state == PaymentRequestLifecycleState::Proposed && proposal_expired(record, now) {
+            record.state = PaymentRequestLifecycleState::ProposalExpired;
+        }
+    }
+
+    let mut records = records.into_values().collect::<Vec<_>>();
+    records.sort_by_key(|record| {
+        Reverse((
+            record.last_event_at,
+            record
+                .last_outbound_message_id
+                .or(record.last_stream_item_id),
+        ))
+    });
+    Ok(records)
+}
+
+fn compare_stored_events(a: &StoredPaymentRequestEvent, b: &StoredPaymentRequestEvent) -> Ordering {
+    if a.source_rank() == b.source_rank() {
+        return a
+            .source_order()
+            .cmp(&b.source_order())
+            .then_with(|| a.record_time().cmp(&b.record_time()));
+    }
+
+    let phase_order = a.phase_order().cmp(&b.phase_order());
+    if phase_order != Ordering::Equal {
+        return phase_order;
+    }
+
+    a.record_time()
+        .cmp(&b.record_time())
+        .then_with(|| a.source_rank().cmp(&b.source_rank()))
+        .then_with(|| a.source_order().cmp(&b.source_order()))
+}
+
+#[derive(Clone)]
+struct StoredEventDedupeEntry {
+    payload_hash: String,
+    event: Option<StoredPaymentRequestEvent>,
+    payment_request_id: String,
+    source_rank: u8,
+    tainted: bool,
+}
+
+struct TaintedEventSeed {
+    event_id: String,
+    payment_request_id: String,
+    payload_hash: String,
+    source_rank: u8,
+}
+
+fn dedupe_stored_events(
+    counterparty: &PubkyPublicKey,
+    records: &mut HashMap<String, PaymentRequestRecord>,
+    events: Vec<StoredPaymentRequestEvent>,
+    tainted_events: Vec<StoredPaymentRequestEvent>,
+    tainted_event_seeds: Vec<TaintedEventSeed>,
+) -> Vec<StoredPaymentRequestEvent> {
+    let mut first_by_event_id = HashMap::<String, StoredEventDedupeEntry>::new();
+    let mut conflicted_event_ids = HashSet::<String>::new();
+    let mut conflicted_request_ids = HashSet::<String>::new();
+    let mut deduped = Vec::new();
+
+    for event in tainted_events {
+        first_by_event_id
+            .entry(event.event_id())
+            .or_insert_with(|| {
+                let payload_hash = event.payload_hash();
+                let payment_request_id = event.payment_request_id();
+                let source_rank = event.source_rank();
+                StoredEventDedupeEntry {
+                    payload_hash,
+                    event: Some(event),
+                    payment_request_id,
+                    source_rank,
+                    tainted: true,
+                }
+            });
+    }
+    for seed in tainted_event_seeds {
+        first_by_event_id
+            .entry(seed.event_id)
+            .or_insert_with(|| StoredEventDedupeEntry {
+                payload_hash: seed.payload_hash,
+                event: None,
+                payment_request_id: seed.payment_request_id,
+                source_rank: seed.source_rank,
+                tainted: true,
+            });
+    }
+
+    for event in events {
+        let event_id = event.event_id();
+        let current_hash = event.payload_hash();
+        if let Some(first) = first_by_event_id.get(&event_id) {
+            if first.payload_hash == current_hash
+                && !first.tainted
+                && first.source_rank == event.source_rank()
+            {
+                continue;
+            }
+            if !first.tainted {
+                let first_event = first.event.as_ref().expect("valid stored event");
+                let first_record =
+                    record_for(records, counterparty, first.payment_request_id.clone());
+                mark_invalid_stored(
+                    first_record,
+                    first_event,
+                    "Event ID reused with different payload",
+                );
+                conflicted_request_ids.insert(first.payment_request_id.clone());
+            }
+            let current_record = record_for(records, counterparty, event.payment_request_id());
+            mark_invalid_stored(
+                current_record,
+                &event,
+                "Event ID reused with different payload",
+            );
+            conflicted_event_ids.insert(event_id);
+            conflicted_request_ids.insert(event.payment_request_id());
+            continue;
+        }
+
+        first_by_event_id.insert(
+            event_id,
+            StoredEventDedupeEntry {
+                payload_hash: current_hash,
+                payment_request_id: event.payment_request_id(),
+                source_rank: event.source_rank(),
+                event: Some(event.clone()),
+                tainted: false,
+            },
+        );
+        deduped.push(event);
+    }
+
+    deduped.retain(|event| {
+        !conflicted_event_ids.contains(&event.event_id())
+            && !conflicted_request_ids.contains(&event.payment_request_id())
+    });
+    deduped
+}
+
+fn record_for<'a>(
+    records: &'a mut HashMap<String, PaymentRequestRecord>,
+    counterparty: &PubkyPublicKey,
+    payment_request_id: String,
+) -> &'a mut PaymentRequestRecord {
+    records
+        .entry(payment_request_id.clone())
+        .or_insert_with(|| PaymentRequestRecord::new(counterparty.clone(), payment_request_id))
+}
+
+fn payment_request_message_from_item(
+    item: &PrivateStreamItemRecord,
+) -> Option<PrivateApplicationMessage> {
+    let kind = item.known_paykit_kind.as_deref()?;
+    if !is_payment_request_kind(kind) {
+        return None;
+    }
+    Some(PrivateApplicationMessage {
+        version: item
+            .parsed_version
+            .and_then(|version| u8::try_from(version).ok()),
+        kind: item.parsed_kind.clone(),
+        raw_json: item.raw_json.clone(),
+    })
+}
+
+fn is_payment_request_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "paykit.payment_request"
+            | "paykit.payment_request_acceptance"
+            | "paykit.payment_request_rejection"
+            | "paykit.payment_request_cancellation"
+            | "paykit.payment_proof"
+    )
+}
+
+fn apply_event(
+    record: &mut PaymentRequestRecord,
+    event: &PaymentRequestEvent,
+    item: &PrivateStreamItemRecord,
+    now: DateTime<Utc>,
+) {
+    if record.state == PaymentRequestLifecycleState::InvalidConflict
+        && record.last_stream_item_id.is_some()
+    {
+        record.touch(item);
+        return;
+    }
+
+    match event {
+        PaymentRequestEvent::Request(request) => apply_request(record, request, item),
+        PaymentRequestEvent::Acceptance(_) => {
+            if record.terms.is_none() {
+                record.mark_invalid(item, "Payment Request acceptance arrived before proposal");
+                return;
+            }
+            record.mark_invalid(
+                item,
+                "Payment Request acceptance is an outbound payer event for a received proposal",
+            );
+        }
+        PaymentRequestEvent::Rejection(_) => {
+            if record.terms.is_none() {
+                record.mark_invalid(item, "Payment Request rejection arrived before proposal");
+                return;
+            }
+            record.mark_invalid(
+                item,
+                "Payment Request rejection is an outbound payer event for a received proposal",
+            );
+        }
+        PaymentRequestEvent::Cancellation(cancellation) => {
+            if record.terms.is_none() {
+                record.mark_invalid(item, "Payment Request cancellation arrived before proposal");
+                return;
+            }
+            if matches!(
+                record.state,
+                PaymentRequestLifecycleState::Canceled
+                    | PaymentRequestLifecycleState::InvalidConflict
+            ) {
+                record.mark_invalid(
+                    item,
+                    "Payment Request cancellation arrived after terminal state",
+                );
+                return;
+            }
+            record.canceled_event_id = Some(cancellation.event_id.as_str().to_owned());
+            record.state = PaymentRequestLifecycleState::Canceled;
+            record.touch(item);
+        }
+        PaymentRequestEvent::Proof(_) => {
+            if record.terms.is_none() {
+                record.mark_invalid(item, "Payment Proof arrived before acceptance");
+                return;
+            }
+            record.mark_invalid(
+                item,
+                "Payment Proof is an outbound payer event for a received proposal",
+            );
+        }
+    }
+
+    if record.state == PaymentRequestLifecycleState::Proposed && proposal_expired(record, now) {
+        record.state = PaymentRequestLifecycleState::ProposalExpired;
+    }
+}
+
+fn apply_request(
+    record: &mut PaymentRequestRecord,
+    request: &PaymentRequest,
+    item: &PrivateStreamItemRecord,
+) {
+    if record.state == PaymentRequestLifecycleState::InvalidConflict
+        && record.last_stream_item_id.is_some()
+    {
+        record.touch(item);
+        return;
+    }
+    if record.terms.is_some() {
+        record.mark_invalid(
+            item,
+            "multiple Payment Request proposals used the same Payment Request ID",
+        );
+        return;
+    }
+    record.local_role = Some(PaymentRequestLocalRole::Payer);
+    record.state = PaymentRequestLifecycleState::Proposed;
+    record.proposal_stream_item_id = Some(item.stream_item_id);
+    record.proposal_event_id = Some(request.event_id.as_str().to_owned());
+    record.terms = Some(PaymentRequestTermsRecord::from(&request.request));
+    record.touch(item);
+}
+
+fn apply_stored_event(record: &mut PaymentRequestRecord, stored: &StoredPaymentRequestEvent) {
+    if record.state == PaymentRequestLifecycleState::InvalidConflict
+        && (record.last_stream_item_id.is_some() || record.last_outbound_message_id.is_some())
+    {
+        touch_stored(record, stored);
+        return;
+    }
+
+    match stored.event() {
+        PaymentRequestEvent::Request(request) => apply_stored_request(record, stored, request),
+        PaymentRequestEvent::Acceptance(acceptance) => {
+            if !payer_action_source_allowed(record, stored) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request acceptance came from the wrong side",
+                );
+                return;
+            }
+            if !has_terms(
+                record,
+                stored,
+                "Payment Request acceptance arrived before proposal",
+            ) {
+                return;
+            }
+            if proposal_expired(record, stored.record_time()) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request acceptance arrived after proposal expiry",
+                );
+                return;
+            }
+            if !matches!(record.state, PaymentRequestLifecycleState::Proposed) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request acceptance arrived after transition",
+                );
+                return;
+            }
+            record.accepted_event_id = Some(acceptance.event_id.as_str().to_owned());
+            record.accepted_outbound_status = outbound_status(stored);
+            record.state = if record
+                .terms
+                .as_ref()
+                .and_then(|terms| terms.recurrence.as_ref())
+                .is_some()
+            {
+                PaymentRequestLifecycleState::ActiveRecurring
+            } else {
+                PaymentRequestLifecycleState::Accepted
+            };
+            touch_stored(record, stored);
+        }
+        PaymentRequestEvent::Rejection(rejection) => {
+            if !payer_action_source_allowed(record, stored) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request rejection came from the wrong side",
+                );
+                return;
+            }
+            if !has_terms(
+                record,
+                stored,
+                "Payment Request rejection arrived before proposal",
+            ) {
+                return;
+            }
+            if !matches!(record.state, PaymentRequestLifecycleState::Proposed) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request rejection arrived after transition",
+                );
+                return;
+            }
+            record.rejected_event_id = Some(rejection.event_id.as_str().to_owned());
+            record.rejected_outbound_status = outbound_status(stored);
+            record.state = PaymentRequestLifecycleState::Rejected;
+            touch_stored(record, stored);
+        }
+        PaymentRequestEvent::Cancellation(cancellation) => {
+            if !has_terms(
+                record,
+                stored,
+                "Payment Request cancellation arrived before proposal",
+            ) {
+                return;
+            }
+            if matches!(
+                record.state,
+                PaymentRequestLifecycleState::Rejected
+                    | PaymentRequestLifecycleState::Canceled
+                    | PaymentRequestLifecycleState::RecoveryRequired
+                    | PaymentRequestLifecycleState::InvalidConflict
+            ) {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Request cancellation arrived after terminal state",
+                );
+                return;
+            }
+            record.canceled_event_id = Some(cancellation.event_id.as_str().to_owned());
+            record.canceled_outbound_status = outbound_status(stored);
+            record.state = PaymentRequestLifecycleState::Canceled;
+            touch_stored(record, stored);
+        }
+        PaymentRequestEvent::Proof(proof) => {
+            if !payer_action_source_allowed(record, stored) {
+                mark_invalid_stored(record, stored, "Payment Proof came from the wrong side");
+                return;
+            }
+            if !matches!(
+                record.state,
+                PaymentRequestLifecycleState::Accepted
+                    | PaymentRequestLifecycleState::ActiveRecurring
+            ) {
+                mark_invalid_stored(record, stored, "Payment Proof arrived before acceptance");
+                return;
+            }
+            let Some(request) = request_from_record(record) else {
+                mark_invalid_stored(
+                    record,
+                    stored,
+                    "Payment Proof cannot be correlated without proposal",
+                );
+                return;
+            };
+            if let Err(err) = proof.validate_for_request(&request) {
+                mark_invalid_stored(record, stored, err.to_string());
+                return;
+            }
+            record.payment_proofs.push(PaymentProofRecord {
+                event_id: proof.event_id.as_str().to_owned(),
+                outbound_message_id: match stored {
+                    StoredPaymentRequestEvent::Outbound { message, .. } => {
+                        Some(message.outbound_message_id)
+                    }
+                    StoredPaymentRequestEvent::Received { .. } => None,
+                },
+                outbound_status: outbound_status(stored),
+                stream_item_id: match stored {
+                    StoredPaymentRequestEvent::Received { item, .. } => Some(item.stream_item_id),
+                    StoredPaymentRequestEvent::Outbound { .. } => None,
+                },
+                payment_reference: proof.payment_reference.as_str().to_owned(),
+                billing_period: proof.billing_period.as_ref().map(BillingPeriodRecord::from),
+                payment_endpoint_identifier: proof.payment_endpoint_identifier.as_str().to_owned(),
+                proof: proof.proof.clone(),
+                recorded_at: stored.record_time(),
+            });
+            record.state = if record
+                .terms
+                .as_ref()
+                .and_then(|terms| terms.recurrence.as_ref())
+                .is_some()
+            {
+                PaymentRequestLifecycleState::ActiveRecurring
+            } else {
+                PaymentRequestLifecycleState::ProofSubmitted
+            };
+            touch_stored(record, stored);
+        }
+    }
+}
+
+fn apply_stored_request(
+    record: &mut PaymentRequestRecord,
+    stored: &StoredPaymentRequestEvent,
+    request: &PaymentRequest,
+) {
+    if record.state == PaymentRequestLifecycleState::InvalidConflict
+        && (record.last_stream_item_id.is_some() || record.last_outbound_message_id.is_some())
+    {
+        touch_stored(record, stored);
+        return;
+    }
+    if record.terms.is_some() {
+        mark_invalid_stored(
+            record,
+            stored,
+            "multiple Payment Request proposals used the same Payment Request ID",
+        );
+        return;
+    }
+    record.local_role = Some(match stored {
+        StoredPaymentRequestEvent::Received { .. } => PaymentRequestLocalRole::Payer,
+        StoredPaymentRequestEvent::Outbound { .. } => PaymentRequestLocalRole::Payee,
+    });
+    record.state = PaymentRequestLifecycleState::Proposed;
+    match stored {
+        StoredPaymentRequestEvent::Received { item, .. } => {
+            record.proposal_stream_item_id = Some(item.stream_item_id);
+        }
+        StoredPaymentRequestEvent::Outbound { message, .. } => {
+            record.proposal_outbound_message_id = Some(message.outbound_message_id);
+            record.proposal_outbound_status = Some(message.status.clone());
+        }
+    }
+    record.proposal_event_id = Some(request.event_id.as_str().to_owned());
+    record.terms = Some(PaymentRequestTermsRecord::from(&request.request));
+    touch_stored(record, stored);
+}
+
+fn has_terms(
+    record: &mut PaymentRequestRecord,
+    stored: &StoredPaymentRequestEvent,
+    reason: &str,
+) -> bool {
+    if record.terms.is_some() {
+        true
+    } else {
+        mark_invalid_stored(record, stored, reason);
+        false
+    }
+}
+
+fn payer_action_source_allowed(
+    record: &PaymentRequestRecord,
+    stored: &StoredPaymentRequestEvent,
+) -> bool {
+    matches!(
+        (record.local_role, stored),
+        (
+            Some(PaymentRequestLocalRole::Payer),
+            StoredPaymentRequestEvent::Outbound { .. }
+        ) | (
+            Some(PaymentRequestLocalRole::Payee),
+            StoredPaymentRequestEvent::Received { .. }
+        )
+    )
+}
+
+fn touch_stored(record: &mut PaymentRequestRecord, stored: &StoredPaymentRequestEvent) {
+    match stored {
+        StoredPaymentRequestEvent::Received { item, .. } => record.touch(item),
+        StoredPaymentRequestEvent::Outbound { message, .. } => {
+            record.touch_outbound(message);
+            if message.status == OutboundPrivateMessageStatus::RecoveryRequired
+                && record.state != PaymentRequestLifecycleState::InvalidConflict
+            {
+                record.state = PaymentRequestLifecycleState::RecoveryRequired;
+            }
+        }
+    }
+}
+
+fn outbound_status(stored: &StoredPaymentRequestEvent) -> Option<OutboundPrivateMessageStatus> {
+    match stored {
+        StoredPaymentRequestEvent::Outbound { message, .. } => Some(message.status.clone()),
+        StoredPaymentRequestEvent::Received { .. } => None,
+    }
+}
+
+fn mark_invalid_stored(
+    record: &mut PaymentRequestRecord,
+    stored: &StoredPaymentRequestEvent,
+    reason: impl Into<String>,
+) {
+    record.state = PaymentRequestLifecycleState::InvalidConflict;
+    if record.invalid_reason.is_none() {
+        record.invalid_reason = Some(reason.into());
+    }
+    touch_stored(record, stored);
+}
+
+pub(crate) fn request_from_record(record: &PaymentRequestRecord) -> Option<PaymentRequest> {
+    let terms = record.terms.as_ref()?;
+    let proposal_event_id = record.proposal_event_id.as_ref()?;
+    let recurrence = if let Some(recurrence) = &terms.recurrence {
+        Some(paykit_lib::Recurrence {
+            every: recurrence.every,
+            unit: parse_recurrence_unit(&recurrence.unit)?,
+            starts_at: recurrence.starts_at.clone(),
+            anchor: recurrence.anchor.clone(),
+            ends_at: recurrence.ends_at.clone(),
+        })
+    } else {
+        None
+    };
+    Some(PaymentRequest::new(
+        paykit_lib::EventId::new(proposal_event_id).ok()?,
+        paykit_lib::PaymentRequestId::new(record.payment_request_id.clone()).ok()?,
+        paykit_lib::PaymentRequestTerms {
+            amount: paykit_lib::PaymentAmount::new(
+                terms.amount.value.clone(),
+                terms.amount.asset.clone(),
+            )
+            .ok()?,
+            payment_reference: paykit_lib::PaymentReference::new(terms.payment_reference.clone())
+                .ok()?,
+            proposal_expires_at: terms.proposal_expires_at.clone(),
+            recurrence,
+            accepted_payment_endpoint_identifiers: terms
+                .accepted_payment_endpoint_identifiers
+                .iter()
+                .map(|identifier| paykit_lib::PaymentEndpointIdentifier::new(identifier).ok())
+                .collect::<Option<Vec<_>>>()?,
+            metadata: terms.metadata.clone(),
+        },
+    ))
+}
+
+fn proposal_expired(record: &PaymentRequestRecord, now: DateTime<Utc>) -> bool {
+    record
+        .terms
+        .as_ref()
+        .and_then(|terms| terms.proposal_expires_at.as_ref())
+        .and_then(|expires_at| DateTime::parse_from_rfc3339(expires_at).ok())
+        .map(|expires_at| now >= expires_at.with_timezone(&Utc))
+        .unwrap_or(false)
+}
+
+pub(super) fn recurrence_unit_to_str(unit: paykit_lib::RecurrenceUnit) -> &'static str {
+    match unit {
+        paykit_lib::RecurrenceUnit::Minute => "minute",
+        paykit_lib::RecurrenceUnit::Hour => "hour",
+        paykit_lib::RecurrenceUnit::Day => "day",
+        paykit_lib::RecurrenceUnit::Week => "week",
+        paykit_lib::RecurrenceUnit::Month => "month",
+        paykit_lib::RecurrenceUnit::Year => "year",
+    }
+}
+
+fn parse_recurrence_unit(unit: &str) -> Option<paykit_lib::RecurrenceUnit> {
+    match unit {
+        "minute" => Some(paykit_lib::RecurrenceUnit::Minute),
+        "hour" => Some(paykit_lib::RecurrenceUnit::Hour),
+        "day" => Some(paykit_lib::RecurrenceUnit::Day),
+        "week" => Some(paykit_lib::RecurrenceUnit::Week),
+        "month" => Some(paykit_lib::RecurrenceUnit::Month),
+        "year" => Some(paykit_lib::RecurrenceUnit::Year),
+        _ => None,
+    }
+}

--- a/paykit-sdk/src/private_lists.rs
+++ b/paykit-sdk/src/private_lists.rs
@@ -1,0 +1,127 @@
+//! Private Payment List latest-state records.
+
+use std::{collections::HashMap, fmt};
+
+use chrono::{DateTime, Utc};
+use paykit_lib::{
+    parse_private_payment_list_json, serialize_private_payment_list_json, PrivateMessageKind,
+    PrivatePaymentList,
+};
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+use crate::outbound_private::enqueue_private_message;
+use crate::{
+    adapters::ReceivingDetail,
+    endpoints::normalize_receiving_details,
+    outbound_private::enqueue_private_message_with_link_lease,
+    private_stream::PrivateStreamParseStatus,
+    storage::{
+        OutboundPrivateMessageRecord, PeerLinkOperationLease, PrivateStreamItemRecord,
+        StorageAdapter,
+    },
+    PubkyPublicKey, Result,
+};
+
+/// Derived latest-state view of a counterparty's Private Payment List.
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrivatePaymentListView {
+    /// Stream item id of the latest valid list.
+    pub latest_stream_item_id: Option<u64>,
+    /// Current endpoint payloads keyed by identifier string.
+    pub payment_endpoints: HashMap<String, String>,
+    /// Receive time of the latest valid list.
+    pub last_refresh_at: Option<DateTime<Utc>>,
+}
+
+impl fmt::Debug for PrivatePaymentListView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let identifiers = self.payment_endpoints.keys().collect::<Vec<_>>();
+        f.debug_struct("PrivatePaymentListView")
+            .field("latest_stream_item_id", &self.latest_stream_item_id)
+            .field("payment_endpoint_identifiers", &identifiers)
+            .field("last_refresh_at", &self.last_refresh_at)
+            .finish()
+    }
+}
+
+/// Load the current Private Payment List view for one counterparty.
+pub(crate) async fn current_private_payment_list<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Option<PrivatePaymentListView>>
+where
+    S: StorageAdapter,
+{
+    let items = storage
+        .transaction(|tx| Ok(tx.private_stream_items(counterparty)))
+        .await?;
+    derive_private_payment_list_view(items)
+}
+
+/// Queue a complete Private Payment List for delivery to one counterparty.
+///
+/// The list replaces the counterparty's latest Private Payment List view when
+/// received, so callers should pass every endpoint they want to share.
+#[cfg(test)]
+pub(crate) async fn enqueue_private_payment_list<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    receiving_details: Vec<ReceivingDetail>,
+    now: DateTime<Utc>,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let payment_endpoints = normalize_receiving_details(receiving_details)?;
+    let list = PrivatePaymentList::new(payment_endpoints);
+    let raw_json = serialize_private_payment_list_json(&list)?;
+    enqueue_private_message(storage, counterparty, raw_json, now).await
+}
+
+/// Queue a complete Private Payment List while a peer operation lease is active.
+pub(crate) async fn enqueue_private_payment_list_with_link_lease<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    receiving_details: Vec<ReceivingDetail>,
+    now: DateTime<Utc>,
+    lease: &PeerLinkOperationLease,
+) -> Result<OutboundPrivateMessageRecord>
+where
+    S: StorageAdapter,
+{
+    let payment_endpoints = normalize_receiving_details(receiving_details)?;
+    let list = PrivatePaymentList::new(payment_endpoints);
+    let raw_json = serialize_private_payment_list_json(&list)?;
+    enqueue_private_message_with_link_lease(storage, counterparty, raw_json, now, lease).await
+}
+
+/// Derive the latest valid Private Payment List view from private stream items.
+pub(crate) fn derive_private_payment_list_view(
+    mut items: Vec<PrivateStreamItemRecord>,
+) -> Result<Option<PrivatePaymentListView>> {
+    items.sort_by_key(|item| item.stream_item_id);
+
+    let latest = items.into_iter().rev().find(|item| {
+        item.parse_status == PrivateStreamParseStatus::Valid
+            && item.known_paykit_kind.as_deref()
+                == Some(PrivateMessageKind::PrivatePaymentList.as_str())
+    });
+
+    let Some(item) = latest else {
+        return Ok(None);
+    };
+
+    let list = parse_private_payment_list_json(&item.raw_json)?;
+    let payment_endpoints = list
+        .payment_endpoints
+        .into_iter()
+        .map(|(identifier, payload)| (identifier.as_str().to_owned(), payload.as_str().to_owned()))
+        .collect();
+
+    Ok(Some(PrivatePaymentListView {
+        latest_stream_item_id: Some(item.stream_item_id),
+        payment_endpoints,
+        last_refresh_at: Some(item.received_at),
+    }))
+}

--- a/paykit-sdk/src/private_stream.rs
+++ b/paykit-sdk/src/private_stream.rs
@@ -1,0 +1,336 @@
+//! Durable private stream records.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    receipts::ReceiptAccessRecord,
+    storage::{
+        require_peer_link_operation_lease, EncryptedLinkStateRecord, EventDedupRecord,
+        NewPrivateStreamItem, NewPrivateStreamItemDetails, PeerLinkOperationLease, StorageAdapter,
+    },
+    PubkyPublicKey, Result,
+};
+
+use paykit_lib::{
+    parse_payment_request_event_message, parse_private_payment_list_json,
+    parse_receipt_access_event_message, PrivateApplicationMessage, PrivateMessageKind,
+    ReceiptAccess,
+};
+
+/// Parse status for one received Private Application Message.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PrivateStreamParseStatus {
+    /// Message parsed as a valid recognized Paykit message.
+    Valid,
+    /// Message kind is recognized, but payload is malformed.
+    MalformedRecognized,
+    /// Message has a valid private header but unknown kind.
+    UnknownKind,
+    /// Message is not valid JSON or does not have a usable private header.
+    InvalidJson,
+}
+
+/// Summary of a persisted private stream batch.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrivateStreamIntakeReport {
+    /// Receive batch id assigned by storage.
+    pub receive_batch_id: u64,
+    /// Stored stream item ids in input order.
+    pub stream_item_ids: Vec<u64>,
+    /// Event ID conflicts found while updating dedupe records.
+    pub event_conflicts: Vec<EventIdConflict>,
+}
+
+/// Summary for receiving private messages from one counterparty.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrivateStreamCounterpartyIntakeReport {
+    /// Counterparty whose private stream was received.
+    pub counterparty: PubkyPublicKey,
+    /// Successful intake report, when receive completed.
+    pub report: Option<PrivateStreamIntakeReport>,
+    /// Error text, when receive failed for this counterparty.
+    pub error: Option<String>,
+}
+
+/// Reused Event ID with a different payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventIdConflict {
+    /// Conflicting Event ID.
+    pub event_id: String,
+    /// First stream item that used this Event ID.
+    pub first_stream_item_id: u64,
+    /// Stream item that reused this Event ID with a different payload.
+    pub conflicting_stream_item_id: u64,
+}
+
+/// Persist an ordered batch of Private Application Messages and a link checkpoint.
+#[cfg(test)]
+pub(crate) async fn persist_private_stream_batch<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    messages: Vec<PrivateApplicationMessage>,
+    link_state: Option<EncryptedLinkStateRecord>,
+    received_at: DateTime<Utc>,
+) -> Result<PrivateStreamIntakeReport>
+where
+    S: StorageAdapter,
+{
+    persist_private_stream_batch_with_link_lease(
+        storage,
+        counterparty,
+        messages,
+        link_state,
+        None,
+        received_at,
+    )
+    .await
+}
+
+/// Persist a batch and checkpoint only if the peer link lease is still active.
+pub(crate) async fn persist_private_stream_batch_with_link_lease<S>(
+    storage: &S,
+    counterparty: PubkyPublicKey,
+    messages: Vec<PrivateApplicationMessage>,
+    link_state: Option<EncryptedLinkStateRecord>,
+    link_lease: Option<PeerLinkOperationLease>,
+    received_at: DateTime<Utc>,
+) -> Result<PrivateStreamIntakeReport>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(move |tx| {
+            let receive_batch_id = tx.allocate_receive_batch_id();
+            let mut report = PrivateStreamIntakeReport {
+                receive_batch_id,
+                stream_item_ids: Vec::with_capacity(messages.len()),
+                event_conflicts: Vec::new(),
+            };
+
+            for message in messages {
+                let PrivateStreamMessageClassification {
+                    status,
+                    parse_error,
+                    event,
+                    receipt_access,
+                } = classify_private_application_message(&message);
+                let stream_item_id = tx.insert_private_stream_item(NewPrivateStreamItem::new(
+                    NewPrivateStreamItemDetails {
+                        counterparty: counterparty.clone(),
+                        receive_batch_id,
+                        raw_json: message.raw_json.clone(),
+                        parsed_version: message.version.map(u32::from),
+                        parsed_kind: message.kind.clone(),
+                        known_paykit_kind: message
+                            .known_kind()
+                            .map(|kind| kind.as_str().to_owned()),
+                        parse_status: status,
+                        parse_error,
+                        received_at,
+                    },
+                ));
+
+                let dedupe_outcome = event.map(|event| {
+                    update_event_dedupe(
+                        tx,
+                        &counterparty,
+                        event.event_id,
+                        event.event_kind,
+                        payload_hash(&message.raw_json),
+                        stream_item_id,
+                        &mut report,
+                    )
+                });
+
+                if matches!(dedupe_outcome, Some(EventDedupeOutcome::First)) {
+                    if let Some(access) = receipt_access.as_ref() {
+                        tx.save_receipt_access_record(ReceiptAccessRecord::from_access(
+                            counterparty.clone(),
+                            stream_item_id,
+                            receive_batch_id,
+                            received_at,
+                            access,
+                        ));
+                    }
+                }
+
+                report.stream_item_ids.push(stream_item_id);
+            }
+
+            let checkpointed_link = link_state.is_some();
+            if let Some(link_state) = link_state {
+                if let Some(lease) = link_lease.as_ref() {
+                    require_peer_link_operation_lease(tx, lease)?;
+                }
+                tx.save_encrypted_link_state(link_state);
+            }
+            if let Some(mut peer) = tx.linked_peer(&counterparty) {
+                if !report.stream_item_ids.is_empty() {
+                    peer.last_private_receive_at = Some(received_at);
+                }
+                if checkpointed_link || !report.stream_item_ids.is_empty() {
+                    peer.last_sync_at = Some(received_at);
+                }
+                tx.save_linked_peer(peer);
+            }
+
+            Ok(report)
+        })
+        .await
+}
+
+pub(crate) struct PrivateStreamMessageClassification {
+    pub(crate) status: PrivateStreamParseStatus,
+    pub(crate) parse_error: Option<String>,
+    pub(crate) event: Option<PrivateStreamEventHeader>,
+    pub(crate) receipt_access: Option<ReceiptAccess>,
+}
+
+pub(crate) struct PrivateStreamEventHeader {
+    pub(crate) event_id: String,
+    pub(crate) event_kind: String,
+}
+
+pub(crate) fn classify_private_application_message(
+    message: &PrivateApplicationMessage,
+) -> PrivateStreamMessageClassification {
+    let Some(kind) = message.known_kind() else {
+        return PrivateStreamMessageClassification {
+            status: if message.version.is_some() && message.kind.is_some() {
+                PrivateStreamParseStatus::UnknownKind
+            } else {
+                PrivateStreamParseStatus::InvalidJson
+            },
+            parse_error: message.invalid_utf8_error().map(str::to_owned),
+            event: None,
+            receipt_access: None,
+        };
+    };
+
+    match kind {
+        PrivateMessageKind::PrivatePaymentList => {
+            match parse_private_payment_list_json(&message.raw_json) {
+                Ok(_) => PrivateStreamMessageClassification {
+                    status: PrivateStreamParseStatus::Valid,
+                    parse_error: None,
+                    event: None,
+                    receipt_access: None,
+                },
+                Err(err) => PrivateStreamMessageClassification {
+                    status: PrivateStreamParseStatus::MalformedRecognized,
+                    parse_error: Some(err.to_string()),
+                    event: None,
+                    receipt_access: None,
+                },
+            }
+        }
+        PrivateMessageKind::ReceiptAccess => {
+            let parsed = parse_receipt_access_event_message(message);
+            let event = parsed
+                .as_ref()
+                .and_then(|parsed| parsed.event_id())
+                .map(|event_id| PrivateStreamEventHeader {
+                    event_id: event_id.as_str().to_owned(),
+                    event_kind: kind.as_str().to_owned(),
+                });
+            PrivateStreamMessageClassification {
+                status: status_from_event_validity(
+                    parsed.as_ref().is_some_and(|parsed| parsed.is_valid()),
+                ),
+                parse_error: parsed
+                    .as_ref()
+                    .and_then(|parsed| parsed.validation_error())
+                    .map(str::to_owned),
+                event,
+                receipt_access: parsed.and_then(|parsed| parsed.parsed_access().cloned()),
+            }
+        }
+        PrivateMessageKind::PaymentRequest
+        | PrivateMessageKind::PaymentRequestAcceptance
+        | PrivateMessageKind::PaymentRequestRejection
+        | PrivateMessageKind::PaymentRequestCancellation
+        | PrivateMessageKind::PaymentProof => {
+            let parsed = parse_payment_request_event_message(message);
+            let event = parsed
+                .as_ref()
+                .and_then(|parsed| parsed.event_id())
+                .map(|event_id| PrivateStreamEventHeader {
+                    event_id: event_id.as_str().to_owned(),
+                    event_kind: kind.as_str().to_owned(),
+                });
+            PrivateStreamMessageClassification {
+                status: status_from_event_validity(
+                    parsed.as_ref().is_some_and(|parsed| parsed.is_valid()),
+                ),
+                parse_error: parsed
+                    .as_ref()
+                    .and_then(|parsed| parsed.validation_error())
+                    .map(str::to_owned),
+                event,
+                receipt_access: None,
+            }
+        }
+    }
+}
+
+fn status_from_event_validity(is_valid: bool) -> PrivateStreamParseStatus {
+    if is_valid {
+        PrivateStreamParseStatus::Valid
+    } else {
+        PrivateStreamParseStatus::MalformedRecognized
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EventDedupeOutcome {
+    First,
+    Duplicate,
+    Conflict,
+}
+
+fn update_event_dedupe(
+    tx: &mut dyn crate::storage::StorageTransaction,
+    counterparty: &PubkyPublicKey,
+    event_id: String,
+    event_kind: String,
+    payload_hash: String,
+    stream_item_id: u64,
+    report: &mut PrivateStreamIntakeReport,
+) -> EventDedupeOutcome {
+    let Some(mut record) = tx.event_dedup_record(counterparty, &event_id) else {
+        tx.save_event_dedup_record(EventDedupRecord {
+            counterparty: counterparty.clone(),
+            event_id,
+            event_kind,
+            payload_hash,
+            first_stream_item_id: stream_item_id,
+            duplicate_stream_item_ids: Vec::new(),
+            conflicting_stream_item_ids: Vec::new(),
+        });
+        return EventDedupeOutcome::First;
+    };
+
+    let outcome = if record.payload_hash == payload_hash {
+        record.duplicate_stream_item_ids.push(stream_item_id);
+        EventDedupeOutcome::Duplicate
+    } else {
+        record.conflicting_stream_item_ids.push(stream_item_id);
+        report.event_conflicts.push(EventIdConflict {
+            event_id: record.event_id.clone(),
+            first_stream_item_id: record.first_stream_item_id,
+            conflicting_stream_item_id: stream_item_id,
+        });
+        EventDedupeOutcome::Conflict
+    };
+
+    tx.save_event_dedup_record(record);
+    outcome
+}
+
+pub(crate) fn payload_hash(raw_json: &str) -> String {
+    let digest = Sha256::digest(raw_json.as_bytes());
+    format!("sha256:{digest:x}")
+}

--- a/paykit-sdk/src/publication.rs
+++ b/paykit-sdk/src/publication.rs
@@ -1,0 +1,35 @@
+//! Shared publication status values.
+
+use serde::{Deserialize, Serialize};
+
+/// Local publication state for SDK-managed public data.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PublicationStatus {
+    /// No publication is known to exist.
+    #[default]
+    NotPublished,
+    /// Publication was recorded locally before the remote write.
+    #[serde(alias = "Desired")]
+    PendingPublication,
+    /// Publication is known to exist.
+    Published,
+    /// Removal was recorded locally before the remote delete.
+    PendingRemoval,
+    /// Publication is known to be removed.
+    Removed,
+    /// Last publication or removal attempt failed.
+    Failed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_publication_status_accepts_desired_alias() {
+        let status: PublicationStatus = serde_json::from_str("\"Desired\"").unwrap();
+
+        assert_eq!(status, PublicationStatus::PendingPublication);
+    }
+}

--- a/paykit-sdk/src/receipts.rs
+++ b/paykit-sdk/src/receipts.rs
@@ -1,0 +1,939 @@
+//! Receipt Access indexing helpers.
+//!
+//! Indexed Receipt Access and receipt issuance records include Receipt
+//! Decryption Keys or exact Receipt Access JSON. Store them as private SDK
+//! state and avoid logging field values directly.
+
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use paykit_lib::{
+    serialize_receipt_access_json, BillingPeriod, PaymentAmount, PaymentEndpointIdentifier,
+    PaymentReference, PaymentRequestId, PreparedReceipt, Receipt, ReceiptAccess,
+    ReceiptDecryptionKey, ReceiptDraft, ReceiptId,
+};
+use pubky::{errors::RequestError, Error as PubkyError, StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    outbound_private::validate_outbound_private_message,
+    records::{AmountRecord, BillingPeriodRecord},
+    storage::{NewOutboundPrivateMessage, StorageAdapter},
+    PaykitSdkError, PubkyPublicKey, Result,
+};
+
+/// Builder for caller-provided receipt fields.
+#[derive(Clone)]
+pub struct ReceiptDraftBuilder {
+    receipt_id: Option<ReceiptId>,
+    payment_reference: PaymentReference,
+    payment_request_id: Option<PaymentRequestId>,
+    billing_period: Option<BillingPeriod>,
+    payment_endpoint_identifier: Option<PaymentEndpointIdentifier>,
+    amount: Option<PaymentAmount>,
+    metadata: JsonMap<String, JsonValue>,
+}
+
+impl fmt::Debug for ReceiptDraftBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiptDraftBuilder")
+            .field("receipt_id", &self.receipt_id)
+            .field("payment_reference", &"<redacted>")
+            .field("payment_request_id", &self.payment_request_id)
+            .field("billing_period", &self.billing_period)
+            .field(
+                "payment_endpoint_identifier",
+                &self.payment_endpoint_identifier,
+            )
+            .field("amount", &self.amount.as_ref().map(|_| "<redacted>"))
+            .field(
+                "metadata",
+                &format_args!("<redacted:{} fields>", self.metadata.len()),
+            )
+            .finish()
+    }
+}
+
+impl ReceiptDraftBuilder {
+    /// Start a draft from a Payment Reference string.
+    pub fn new(payment_reference: impl Into<String>) -> Result<Self> {
+        Ok(Self::from_payment_reference(PaymentReference::new(
+            payment_reference,
+        )?))
+    }
+
+    /// Start a draft from an already validated Payment Reference.
+    pub fn from_payment_reference(payment_reference: PaymentReference) -> Self {
+        Self {
+            receipt_id: None,
+            payment_reference,
+            payment_request_id: None,
+            billing_period: None,
+            payment_endpoint_identifier: None,
+            amount: None,
+            metadata: JsonMap::new(),
+        }
+    }
+
+    /// Set a caller-provided Receipt ID.
+    pub fn with_receipt_id(mut self, receipt_id: ReceiptId) -> Self {
+        self.receipt_id = Some(receipt_id);
+        self
+    }
+
+    /// Generate and set a Receipt ID before issuing.
+    pub fn with_new_receipt_id(self) -> Self {
+        self.with_receipt_id(ReceiptId::new_v4())
+    }
+
+    /// Set the Payment Request ID this receipt corresponds to.
+    pub fn with_payment_request_id(mut self, payment_request_id: PaymentRequestId) -> Self {
+        self.payment_request_id = Some(payment_request_id);
+        self
+    }
+
+    /// Set the Billing Period for a recurring Payment Request receipt.
+    pub fn with_billing_period(mut self, billing_period: BillingPeriod) -> Self {
+        self.billing_period = Some(billing_period);
+        self
+    }
+
+    /// Set the Payment Endpoint Identifier used for the payment.
+    pub fn with_payment_endpoint_identifier(
+        mut self,
+        payment_endpoint_identifier: PaymentEndpointIdentifier,
+    ) -> Self {
+        self.payment_endpoint_identifier = Some(payment_endpoint_identifier);
+        self
+    }
+
+    /// Validate and set the Payment Endpoint Identifier used for the payment.
+    pub fn with_payment_endpoint_identifier_text(
+        self,
+        payment_endpoint_identifier: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(
+            self.with_payment_endpoint_identifier(PaymentEndpointIdentifier::new(
+                payment_endpoint_identifier,
+            )?),
+        )
+    }
+
+    /// Set the Payment Amount being receipted.
+    pub fn with_amount(mut self, amount: PaymentAmount) -> Self {
+        self.amount = Some(amount);
+        self
+    }
+
+    /// Validate and set the Payment Amount being receipted.
+    pub fn with_amount_text(
+        self,
+        value: impl Into<String>,
+        asset: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(self.with_amount(PaymentAmount::new(value, asset)?))
+    }
+
+    /// Set caller-defined Receipt Metadata.
+    pub fn with_metadata(mut self, metadata: JsonMap<String, JsonValue>) -> Self {
+        self.metadata = metadata;
+        self
+    }
+
+    /// Build the Receipt Draft.
+    pub fn build(self) -> Result<ReceiptDraft> {
+        if self.billing_period.is_some() && self.payment_request_id.is_none() {
+            return Err(PaykitSdkError::Protocol(
+                "Receipt Draft billing_period requires payment_request_id".into(),
+            ));
+        }
+        Ok(ReceiptDraft {
+            receipt_id: self.receipt_id,
+            payment_reference: self.payment_reference,
+            payment_request_id: self.payment_request_id,
+            billing_period: self.billing_period,
+            payment_endpoint_identifier: self.payment_endpoint_identifier,
+            amount: self.amount,
+            metadata: self.metadata,
+        })
+    }
+}
+
+/// Receipt retrieval state for an indexed Receipt Access event.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ReceiptRetrievalStatus {
+    /// Receipt Access has been indexed, but retrieval has not succeeded yet.
+    #[default]
+    Pending,
+    /// Encrypted Receipt was fetched and decrypted.
+    Retrieved,
+    /// Receipt Location was missing on the issuer homeserver.
+    NotFound,
+    /// Retrieval or decryption failed.
+    Failed,
+}
+
+/// Local receipt issuance state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ReceiptIssuanceStatus {
+    /// Receipt was prepared locally, but the Encrypted Receipt has not been
+    /// stored on the issuer homeserver yet.
+    #[default]
+    PendingStorage,
+    /// Encrypted Receipt was stored, but Receipt Access has not been queued yet.
+    Stored,
+    /// Receipt Access was queued for private delivery.
+    AccessQueued,
+    /// Last storage or queueing attempt failed.
+    Failed,
+}
+
+/// Durable local state for issuing one receipt.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiptIssuanceRecord {
+    /// Counterparty that should receive Receipt Access.
+    pub counterparty: PubkyPublicKey,
+    /// Receipt ID.
+    pub receipt_id: String,
+    /// Receipt Access Event ID.
+    pub receipt_access_event_id: String,
+    /// Payment Reference copied from the Receipt.
+    pub payment_reference: String,
+    /// Optional Payment Request ID copied from the Receipt.
+    pub payment_request_id: Option<String>,
+    /// Optional Billing Period copied from the Receipt.
+    pub billing_period: Option<BillingPeriodRecord>,
+    /// Optional Payment Endpoint Identifier copied from the Receipt.
+    pub payment_endpoint_identifier: Option<String>,
+    /// Optional Payment Amount copied from the Receipt.
+    pub amount: Option<AmountRecord>,
+    /// Receipt Location path on the issuer homeserver.
+    pub location: String,
+    /// Encrypted Receipt JSON to store at the Receipt Location.
+    pub encrypted_receipt: String,
+    /// Exact Receipt Access JSON to queue for private delivery.
+    pub access_json: String,
+    /// Current issuance status.
+    pub status: ReceiptIssuanceStatus,
+    /// Outbound private message id that carries Receipt Access, once queued.
+    pub outbound_message_id: Option<u64>,
+    /// Creation time.
+    pub created_at: DateTime<Utc>,
+    /// Last status update time.
+    pub updated_at: DateTime<Utc>,
+    /// Time the Encrypted Receipt was stored.
+    pub stored_at: Option<DateTime<Utc>>,
+    /// Time Receipt Access was queued for private delivery.
+    pub access_queued_at: Option<DateTime<Utc>>,
+    /// Last storage or queueing error, when available.
+    pub last_error: Option<String>,
+}
+
+impl ReceiptIssuanceRecord {
+    pub(crate) fn from_prepared(
+        counterparty: PubkyPublicKey,
+        prepared: PreparedReceipt,
+        now: DateTime<Utc>,
+    ) -> Result<Self> {
+        let access_json = serialize_receipt_access_json(&prepared.access)?;
+        Ok(Self {
+            counterparty,
+            receipt_id: prepared.receipt.receipt_id.as_str().to_owned(),
+            receipt_access_event_id: prepared.access.event_id.as_str().to_owned(),
+            payment_reference: prepared.receipt.payment_reference.as_str().to_owned(),
+            payment_request_id: prepared
+                .receipt
+                .payment_request_id
+                .as_ref()
+                .map(|id| id.as_str().to_owned()),
+            billing_period: prepared
+                .receipt
+                .billing_period
+                .as_ref()
+                .map(BillingPeriodRecord::from),
+            payment_endpoint_identifier: prepared
+                .receipt
+                .payment_endpoint_identifier
+                .as_ref()
+                .map(|identifier| identifier.as_str().to_owned()),
+            amount: prepared.receipt.amount.as_ref().map(AmountRecord::from),
+            location: prepared.access.location.clone(),
+            encrypted_receipt: prepared.encrypted_receipt,
+            access_json,
+            status: ReceiptIssuanceStatus::PendingStorage,
+            outbound_message_id: None,
+            created_at: now,
+            updated_at: now,
+            stored_at: None,
+            access_queued_at: None,
+            last_error: None,
+        })
+    }
+
+    pub(crate) fn mark_stored(&self, stored_at: DateTime<Utc>) -> Self {
+        let mut record = self.clone();
+        record.status = ReceiptIssuanceStatus::Stored;
+        record.updated_at = stored_at;
+        record.stored_at = Some(stored_at);
+        record.last_error = None;
+        record
+    }
+
+    pub(crate) fn mark_access_queued(
+        &self,
+        outbound_message_id: u64,
+        queued_at: DateTime<Utc>,
+    ) -> Self {
+        let mut record = self.clone();
+        record.status = ReceiptIssuanceStatus::AccessQueued;
+        record.updated_at = queued_at;
+        record.outbound_message_id = Some(outbound_message_id);
+        record.access_queued_at = Some(queued_at);
+        record.last_error = None;
+        record
+    }
+
+    pub(crate) fn mark_failed(&self, failed_at: DateTime<Utc>, error: String) -> Self {
+        let mut record = self.clone();
+        record.status = ReceiptIssuanceStatus::Failed;
+        record.updated_at = failed_at;
+        record.last_error = Some(error);
+        record
+    }
+}
+
+impl fmt::Debug for ReceiptIssuanceRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiptIssuanceRecord")
+            .field("counterparty", &self.counterparty)
+            .field("receipt_id", &self.receipt_id)
+            .field("receipt_access_event_id", &self.receipt_access_event_id)
+            .field("payment_reference", &"<redacted>")
+            .field("payment_request_id", &self.payment_request_id)
+            .field("billing_period", &self.billing_period)
+            .field(
+                "payment_endpoint_identifier",
+                &self.payment_endpoint_identifier,
+            )
+            .field("amount", &self.amount.as_ref().map(|_| "<redacted>"))
+            .field("location", &"<redacted>")
+            .field(
+                "encrypted_receipt",
+                &format_args!("<redacted:{} bytes>", self.encrypted_receipt.len()),
+            )
+            .field(
+                "access_json",
+                &format_args!("<redacted:{} bytes>", self.access_json.len()),
+            )
+            .field("status", &self.status)
+            .field("outbound_message_id", &self.outbound_message_id)
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .field("stored_at", &self.stored_at)
+            .field("access_queued_at", &self.access_queued_at)
+            .field(
+                "last_error",
+                &self.last_error.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+/// App-facing view of local receipt issuance progress.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiptIssuanceView {
+    /// Counterparty that should receive Receipt Access.
+    pub counterparty: PubkyPublicKey,
+    /// Receipt ID.
+    pub receipt_id: String,
+    /// Receipt Access Event ID.
+    pub receipt_access_event_id: String,
+    /// Payment Reference copied from the Receipt.
+    pub payment_reference: String,
+    /// Optional Payment Request ID copied from the Receipt.
+    pub payment_request_id: Option<String>,
+    /// Optional Billing Period copied from the Receipt.
+    pub billing_period: Option<BillingPeriodRecord>,
+    /// Optional Payment Endpoint Identifier copied from the Receipt.
+    pub payment_endpoint_identifier: Option<String>,
+    /// Optional Payment Amount copied from the Receipt.
+    pub amount: Option<AmountRecord>,
+    /// Current issuance status.
+    pub status: ReceiptIssuanceStatus,
+    /// Outbound private message id that carries Receipt Access, once queued.
+    pub outbound_message_id: Option<u64>,
+    /// Creation time.
+    pub created_at: DateTime<Utc>,
+    /// Last status update time.
+    pub updated_at: DateTime<Utc>,
+    /// Time the Encrypted Receipt was stored.
+    pub stored_at: Option<DateTime<Utc>>,
+    /// Time Receipt Access was queued for private delivery.
+    pub access_queued_at: Option<DateTime<Utc>>,
+}
+
+impl fmt::Debug for ReceiptIssuanceView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiptIssuanceView")
+            .field("counterparty", &self.counterparty)
+            .field("receipt_id", &self.receipt_id)
+            .field("receipt_access_event_id", &self.receipt_access_event_id)
+            .field("payment_reference", &"<redacted>")
+            .field("payment_request_id", &self.payment_request_id)
+            .field("billing_period", &self.billing_period)
+            .field(
+                "payment_endpoint_identifier",
+                &self.payment_endpoint_identifier,
+            )
+            .field("amount", &self.amount.as_ref().map(|_| "<redacted>"))
+            .field("status", &self.status)
+            .field("outbound_message_id", &self.outbound_message_id)
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .field("stored_at", &self.stored_at)
+            .field("access_queued_at", &self.access_queued_at)
+            .finish()
+    }
+}
+
+impl From<&ReceiptIssuanceRecord> for ReceiptIssuanceView {
+    fn from(record: &ReceiptIssuanceRecord) -> Self {
+        Self {
+            counterparty: record.counterparty.clone(),
+            receipt_id: record.receipt_id.clone(),
+            receipt_access_event_id: record.receipt_access_event_id.clone(),
+            payment_reference: record.payment_reference.clone(),
+            payment_request_id: record.payment_request_id.clone(),
+            billing_period: record.billing_period.clone(),
+            payment_endpoint_identifier: record.payment_endpoint_identifier.clone(),
+            amount: record.amount.clone(),
+            status: record.status,
+            outbound_message_id: record.outbound_message_id,
+            created_at: record.created_at,
+            updated_at: record.updated_at,
+            stored_at: record.stored_at,
+            access_queued_at: record.access_queued_at,
+        }
+    }
+}
+
+/// Indexed Receipt Access event.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiptAccessRecord {
+    /// Counterparty that sent the Receipt Access event.
+    pub counterparty: PubkyPublicKey,
+    /// Stream item id that first carried this Event ID.
+    pub stream_item_id: u64,
+    /// Receive batch id that contained the stream item.
+    pub receive_batch_id: u64,
+    /// Receipt Access Event ID.
+    pub event_id: String,
+    /// Receipt ID.
+    pub receipt_id: String,
+    /// Payment Reference copied from Receipt Access.
+    pub payment_reference: String,
+    /// Optional Payment Request ID copied from Receipt Access.
+    pub payment_request_id: Option<String>,
+    /// Optional Billing Period copied from Receipt Access.
+    pub billing_period: Option<BillingPeriodRecord>,
+    /// Receipt Location path on the issuer homeserver.
+    pub location: String,
+    /// Receipt Decryption Key material. Treat as secret storage data.
+    pub key: String,
+    /// Current retrieval state for the referenced receipt.
+    #[serde(default)]
+    pub retrieval_status: ReceiptRetrievalStatus,
+    /// Last retrieval attempt time.
+    #[serde(default)]
+    pub retrieval_attempted_at: Option<DateTime<Utc>>,
+    /// Successful retrieval/decryption time.
+    #[serde(default)]
+    pub retrieved_at: Option<DateTime<Utc>>,
+    /// Last retrieval/decryption error, when available.
+    #[serde(default)]
+    pub last_retrieval_error: Option<String>,
+    /// Receive time of the indexed stream item.
+    pub received_at: DateTime<Utc>,
+}
+
+/// App-facing view of an indexed Receipt Access event.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiptAccessView {
+    /// Counterparty that sent the Receipt Access event.
+    pub counterparty: PubkyPublicKey,
+    /// Receipt Access Event ID.
+    pub event_id: String,
+    /// Receipt ID.
+    pub receipt_id: String,
+    /// Payment Reference copied from Receipt Access.
+    pub payment_reference: String,
+    /// Optional Payment Request ID copied from Receipt Access.
+    pub payment_request_id: Option<String>,
+    /// Optional Billing Period copied from Receipt Access.
+    pub billing_period: Option<BillingPeriodRecord>,
+    /// Current retrieval state for the referenced receipt.
+    pub retrieval_status: ReceiptRetrievalStatus,
+    /// Last retrieval attempt time.
+    pub retrieval_attempted_at: Option<DateTime<Utc>>,
+    /// Successful retrieval/decryption time.
+    pub retrieved_at: Option<DateTime<Utc>>,
+    /// Receive time of the indexed stream item.
+    pub received_at: DateTime<Utc>,
+}
+
+impl fmt::Debug for ReceiptAccessView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiptAccessView")
+            .field("counterparty", &self.counterparty)
+            .field("event_id", &self.event_id)
+            .field("receipt_id", &self.receipt_id)
+            .field("payment_reference", &"<redacted>")
+            .field("payment_request_id", &self.payment_request_id)
+            .field("billing_period", &self.billing_period)
+            .field("retrieval_status", &self.retrieval_status)
+            .field("retrieval_attempted_at", &self.retrieval_attempted_at)
+            .field("retrieved_at", &self.retrieved_at)
+            .field("received_at", &self.received_at)
+            .finish()
+    }
+}
+
+impl From<&ReceiptAccessRecord> for ReceiptAccessView {
+    fn from(record: &ReceiptAccessRecord) -> Self {
+        Self {
+            counterparty: record.counterparty.clone(),
+            event_id: record.event_id.clone(),
+            receipt_id: record.receipt_id.clone(),
+            payment_reference: record.payment_reference.clone(),
+            payment_request_id: record.payment_request_id.clone(),
+            billing_period: record.billing_period.clone(),
+            retrieval_status: record.retrieval_status,
+            retrieval_attempted_at: record.retrieval_attempted_at,
+            retrieved_at: record.retrieved_at,
+            received_at: record.received_at,
+        }
+    }
+}
+
+impl ReceiptAccessRecord {
+    pub(crate) fn from_access(
+        counterparty: PubkyPublicKey,
+        stream_item_id: u64,
+        receive_batch_id: u64,
+        received_at: DateTime<Utc>,
+        access: &ReceiptAccess,
+    ) -> Self {
+        Self {
+            counterparty,
+            stream_item_id,
+            receive_batch_id,
+            event_id: access.event_id.as_str().to_owned(),
+            receipt_id: access.receipt_id.as_str().to_owned(),
+            payment_reference: access.payment_reference.as_str().to_owned(),
+            payment_request_id: access
+                .payment_request_id
+                .as_ref()
+                .map(|id| id.as_str().to_owned()),
+            billing_period: access
+                .billing_period
+                .as_ref()
+                .map(BillingPeriodRecord::from),
+            location: access.location.clone(),
+            key: access.key.as_str().to_owned(),
+            retrieval_status: ReceiptRetrievalStatus::Pending,
+            retrieval_attempted_at: None,
+            retrieved_at: None,
+            last_retrieval_error: None,
+            received_at,
+        }
+    }
+
+    pub(crate) fn mark_retrieved(&self, retrieved_at: DateTime<Utc>) -> Self {
+        let mut record = self.clone();
+        record.retrieval_status = ReceiptRetrievalStatus::Retrieved;
+        record.retrieval_attempted_at = Some(retrieved_at);
+        record.retrieved_at = Some(retrieved_at);
+        record.last_retrieval_error = None;
+        record
+    }
+
+    pub(crate) fn mark_retrieval_error(
+        &self,
+        status: ReceiptRetrievalStatus,
+        attempted_at: DateTime<Utc>,
+        error: String,
+    ) -> Self {
+        let mut record = self.clone();
+        record.retrieval_status = status;
+        record.retrieval_attempted_at = Some(attempted_at);
+        record.retrieved_at = None;
+        record.last_retrieval_error = Some(error);
+        record
+    }
+}
+
+impl fmt::Debug for ReceiptAccessRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiptAccessRecord")
+            .field("counterparty", &self.counterparty)
+            .field("stream_item_id", &self.stream_item_id)
+            .field("receive_batch_id", &self.receive_batch_id)
+            .field("event_id", &self.event_id)
+            .field("receipt_id", &self.receipt_id)
+            .field("payment_reference", &"<redacted>")
+            .field("payment_request_id", &self.payment_request_id)
+            .field("billing_period", &self.billing_period)
+            .field("location", &"<redacted>")
+            .field("key", &"<redacted>")
+            .field("retrieval_status", &self.retrieval_status)
+            .field("retrieval_attempted_at", &self.retrieval_attempted_at)
+            .field("retrieved_at", &self.retrieved_at)
+            .field(
+                "last_retrieval_error",
+                &self.last_retrieval_error.as_ref().map(|_| "<redacted>"),
+            )
+            .field("received_at", &self.received_at)
+            .finish()
+    }
+}
+
+/// Decrypted Receipt record stored by the SDK.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiptRecord {
+    /// Counterparty that issued the Receipt Access event.
+    pub issuer: PubkyPublicKey,
+    /// Receipt Access Event ID used for retrieval.
+    pub receipt_access_event_id: String,
+    /// Hash of the Receipt Access key that decrypted the Receipt.
+    #[serde(default)]
+    pub receipt_access_key_hash: String,
+    /// Receipt ID.
+    pub receipt_id: String,
+    /// Payment Reference copied from the decrypted Receipt.
+    pub payment_reference: String,
+    /// Optional Payment Request ID copied from the decrypted Receipt.
+    pub payment_request_id: Option<String>,
+    /// Optional Billing Period copied from the decrypted Receipt.
+    pub billing_period: Option<BillingPeriodRecord>,
+    /// Recipient public key from the decrypted Receipt.
+    pub recipient_public_key: PubkyPublicKey,
+    /// Optional Payment Endpoint Identifier copied from the decrypted Receipt.
+    pub payment_endpoint_identifier: Option<String>,
+    /// Optional Payment Amount copied from the decrypted Receipt.
+    pub amount: Option<AmountRecord>,
+    /// Caller-defined Receipt Metadata.
+    pub metadata: JsonMap<String, JsonValue>,
+    /// Receipt Location path used for retrieval.
+    pub location: String,
+    /// Successful retrieval/decryption time.
+    pub retrieved_at: DateTime<Utc>,
+}
+
+impl ReceiptRecord {
+    fn from_receipt(
+        issuer: PubkyPublicKey,
+        access: &ReceiptAccessRecord,
+        receipt: Receipt,
+        retrieved_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            issuer,
+            receipt_access_event_id: access.event_id.clone(),
+            receipt_access_key_hash: receipt_access_key_hash(&access.key),
+            receipt_id: receipt.receipt_id.as_str().to_owned(),
+            payment_reference: receipt.payment_reference.as_str().to_owned(),
+            payment_request_id: receipt
+                .payment_request_id
+                .as_ref()
+                .map(|id| id.as_str().to_owned()),
+            billing_period: receipt
+                .billing_period
+                .as_ref()
+                .map(BillingPeriodRecord::from),
+            recipient_public_key: PubkyPublicKey::from_public_key(&receipt.recipient_public_key),
+            payment_endpoint_identifier: receipt
+                .payment_endpoint_identifier
+                .as_ref()
+                .map(|identifier| identifier.as_str().to_owned()),
+            amount: receipt.amount.as_ref().map(AmountRecord::from),
+            metadata: receipt.metadata,
+            location: access.location.clone(),
+            retrieved_at,
+        }
+    }
+}
+
+impl fmt::Debug for ReceiptRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiptRecord")
+            .field("issuer", &self.issuer)
+            .field("receipt_access_event_id", &self.receipt_access_event_id)
+            .field("receipt_access_key_hash", &self.receipt_access_key_hash)
+            .field("receipt_id", &self.receipt_id)
+            .field("payment_reference", &"<redacted>")
+            .field("payment_request_id", &self.payment_request_id)
+            .field("billing_period", &self.billing_period)
+            .field("recipient_public_key", &self.recipient_public_key)
+            .field(
+                "payment_endpoint_identifier",
+                &self.payment_endpoint_identifier,
+            )
+            .field("amount", &self.amount.as_ref().map(|_| "<redacted>"))
+            .field(
+                "metadata",
+                &format_args!("<redacted:{} fields>", self.metadata.len()),
+            )
+            .field("location", &"<redacted>")
+            .field("retrieved_at", &self.retrieved_at)
+            .finish()
+    }
+}
+
+/// List indexed Receipt Access records for one counterparty.
+#[cfg(test)]
+pub(crate) async fn receipt_access_records<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Vec<ReceiptAccessRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.receipt_access_records(counterparty)))
+        .await
+}
+
+/// Load the latest indexed Receipt Access record for a receipt.
+#[cfg(test)]
+pub(crate) async fn receipt_access_record_by_receipt_id<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    receipt_id: &str,
+) -> Result<Option<ReceiptAccessRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.receipt_access_record_by_receipt_id(counterparty, receipt_id)))
+        .await
+}
+
+pub(crate) async fn fetch_encrypted_receipt_json(
+    public_storage: &pubky::PublicStorage,
+    issuer: &PubkyPublicKey,
+    location: &str,
+) -> Result<Option<String>> {
+    let addr = format!("{}{}", issuer.to_public_key()?, location);
+    match public_storage.get(addr).await {
+        Ok(response) => {
+            let bytes = response
+                .bytes()
+                .await
+                .map_err(|err| PaykitSdkError::Transport {
+                    context: "read encrypted receipt bytes".into(),
+                    source: Some(err.into()),
+                })?;
+            let json = String::from_utf8(bytes.to_vec()).map_err(|err| {
+                PaykitSdkError::Protocol(format!("encrypted receipt is not UTF-8: {err}"))
+            })?;
+            Ok(Some(json))
+        }
+        Err(err) if is_not_found(&err) => Ok(None),
+        Err(err) => Err(PaykitSdkError::Transport {
+            context: "fetch encrypted receipt".into(),
+            source: Some(err.into()),
+        }),
+    }
+}
+
+pub(crate) async fn store_encrypted_receipt_json(
+    session: &pubky::PubkySession,
+    record: &ReceiptIssuanceRecord,
+) -> Result<()> {
+    session
+        .storage()
+        .put(record.location.clone(), record.encrypted_receipt.clone())
+        .await
+        .map(|_| ())
+        .map_err(|err| PaykitSdkError::Transport {
+            context: format!("failed to store encrypted receipt at {}", record.location),
+            source: Some(err.into()),
+        })
+}
+
+pub(crate) fn receipt_issuance_record_matches_draft(
+    record: &ReceiptIssuanceRecord,
+    draft: &ReceiptDraft,
+) -> Result<bool> {
+    let access = paykit_lib::parse_receipt_access_json(&record.access_json)?;
+    let receipt =
+        paykit_lib::decrypt_receipt(&record.encrypted_receipt, &access.key, &access.location)?;
+    let expected_receipt_id = draft.receipt_id.as_ref().map(|id| id.as_str());
+    let expected_recipient = record.counterparty.to_public_key()?;
+    Ok(Some(receipt.receipt_id.as_str()) == expected_receipt_id
+        && receipt.payment_reference == draft.payment_reference
+        && receipt.payment_request_id == draft.payment_request_id
+        && receipt.billing_period == draft.billing_period
+        && receipt.recipient_public_key == expected_recipient
+        && receipt.payment_endpoint_identifier == draft.payment_endpoint_identifier
+        && receipt.amount == draft.amount
+        && receipt.metadata == draft.metadata)
+}
+
+pub(crate) async fn receipt_issuance_records<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Vec<ReceiptIssuanceRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.receipt_issuance_records(counterparty)))
+        .await
+}
+
+pub(crate) async fn receipt_issuance_record<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+    receipt_id: &str,
+) -> Result<Option<ReceiptIssuanceRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.receipt_issuance_record(counterparty, receipt_id)))
+        .await
+}
+
+pub(crate) async fn receipt_issuance_record_by_receipt_id<S>(
+    storage: &S,
+    receipt_id: &str,
+) -> Result<Option<ReceiptIssuanceRecord>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| Ok(tx.receipt_issuance_record_by_receipt_id(receipt_id)))
+        .await
+}
+
+pub(crate) async fn enqueue_receipt_access_for_issuance<S>(
+    storage: &S,
+    record: ReceiptIssuanceRecord,
+    now: DateTime<Utc>,
+) -> Result<ReceiptIssuanceRecord>
+where
+    S: StorageAdapter,
+{
+    if record.outbound_message_id.is_some() {
+        return Ok(record);
+    }
+    let kind = validate_outbound_private_message(&record.access_json)?;
+    if kind != paykit_lib::PrivateMessageKind::ReceiptAccess.as_str() {
+        return Err(PaykitSdkError::Protocol(
+            "receipt issuance access JSON is not Receipt Access".into(),
+        ));
+    }
+    storage
+        .transaction(move |tx| {
+            let outbound = tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                record.counterparty.clone(),
+                kind,
+                record.access_json.clone(),
+                now,
+            ));
+            let queued = record.mark_access_queued(outbound.outbound_message_id, now);
+            tx.save_receipt_issuance_record(queued.clone());
+            Ok(queued)
+        })
+        .await
+}
+
+pub(crate) fn decrypt_receipt_record_from_access(
+    access: &ReceiptAccessRecord,
+    encrypted_json: &str,
+    retrieved_at: DateTime<Utc>,
+    expected_recipient: &PubkyPublicKey,
+) -> Result<ReceiptRecord> {
+    let key = ReceiptDecryptionKey::new(access.key.clone())?;
+    let receipt = paykit_lib::decrypt_receipt(encrypted_json, &key, &access.location)?;
+    validate_receipt_matches_access(access, &receipt, expected_recipient)?;
+    Ok(ReceiptRecord::from_receipt(
+        access.counterparty.clone(),
+        access,
+        receipt,
+        retrieved_at,
+    ))
+}
+
+pub(crate) fn receipt_record_matches_access(
+    record: &ReceiptRecord,
+    access: &ReceiptAccessRecord,
+) -> bool {
+    record.issuer == access.counterparty
+        && record.receipt_access_key_hash == receipt_access_key_hash(&access.key)
+        && record.receipt_id == access.receipt_id
+        && record.payment_reference == access.payment_reference
+        && record.payment_request_id == access.payment_request_id
+        && record.billing_period == access.billing_period
+        && record.location == access.location
+}
+
+pub(crate) fn receipt_access_key_hash(key: &str) -> String {
+    let digest = Sha256::digest(key.as_bytes());
+    format!("sha256:{digest:x}")
+}
+
+fn validate_receipt_matches_access(
+    access: &ReceiptAccessRecord,
+    receipt: &Receipt,
+    expected_recipient: &PubkyPublicKey,
+) -> Result<()> {
+    if receipt.receipt_id.as_str() != access.receipt_id {
+        return Err(PaykitSdkError::Protocol(
+            "decrypted Receipt ID does not match Receipt Access".into(),
+        ));
+    }
+    let recipient = PubkyPublicKey::from_public_key(&receipt.recipient_public_key);
+    if &recipient != expected_recipient {
+        return Err(PaykitSdkError::Protocol(
+            "decrypted Receipt recipient does not match local identity".into(),
+        ));
+    }
+    if receipt.payment_reference.as_str() != access.payment_reference {
+        return Err(PaykitSdkError::Protocol(
+            "decrypted Receipt Payment Reference does not match Receipt Access".into(),
+        ));
+    }
+    let receipt_payment_request_id = receipt
+        .payment_request_id
+        .as_ref()
+        .map(|id| id.as_str().to_owned());
+    if receipt_payment_request_id != access.payment_request_id {
+        return Err(PaykitSdkError::Protocol(
+            "decrypted Receipt Payment Request ID does not match Receipt Access".into(),
+        ));
+    }
+    let receipt_billing_period = receipt
+        .billing_period
+        .as_ref()
+        .map(BillingPeriodRecord::from);
+    if receipt_billing_period != access.billing_period {
+        return Err(PaykitSdkError::Protocol(
+            "decrypted Receipt Billing Period does not match Receipt Access".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_not_found(err: &PubkyError) -> bool {
+    matches!(
+        err,
+        PubkyError::Request(RequestError::Server { status, .. })
+            if *status == StatusCode::NOT_FOUND || *status == StatusCode::GONE
+    )
+}

--- a/paykit-sdk/src/records.rs
+++ b/paykit-sdk/src/records.rs
@@ -1,0 +1,39 @@
+//! Shared SDK record field types.
+
+use serde::{Deserialize, Serialize};
+
+/// Durable Payment Amount fields copied into SDK records.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AmountRecord {
+    /// Decimal amount text.
+    pub value: String,
+    /// Asset code or unit.
+    pub asset: String,
+}
+
+impl From<&paykit_lib::PaymentAmount> for AmountRecord {
+    fn from(amount: &paykit_lib::PaymentAmount) -> Self {
+        Self {
+            value: amount.value.clone(),
+            asset: amount.asset.clone(),
+        }
+    }
+}
+
+/// Billing Period fields copied into SDK records.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BillingPeriodRecord {
+    /// RFC3339 UTC timestamp using `Z`.
+    pub starts_at: String,
+    /// RFC3339 UTC timestamp using `Z`.
+    pub ends_at: String,
+}
+
+impl From<&paykit_lib::BillingPeriod> for BillingPeriodRecord {
+    fn from(period: &paykit_lib::BillingPeriod) -> Self {
+        Self {
+            starts_at: period.starts_at.clone(),
+            ends_at: period.ends_at.clone(),
+        }
+    }
+}

--- a/paykit-sdk/src/recovery.rs
+++ b/paykit-sdk/src/recovery.rs
@@ -1,0 +1,63 @@
+//! Encrypted Link recovery marker state.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    linked_peers::LinkedPeerState,
+    storage::{LinkedPeerRecord, StorageAdapter},
+    PubkyPublicKey, Result,
+};
+
+/// Public recovery marker state tracked for one Linked Peer.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EncryptedLinkRecoveryMarkerReport {
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Current Linked Peer state.
+    pub state: LinkedPeerState,
+    /// Locally published recovery attempt id.
+    pub local_attempt_id: Option<String>,
+    /// Creation time for the local marker payload.
+    pub local_marker_created_at: Option<DateTime<Utc>>,
+    /// Last local marker publish/remove error, when available.
+    pub local_marker_last_error: Option<String>,
+    /// Latest observed counterparty recovery attempt id.
+    pub remote_attempt_id: Option<String>,
+    /// Time the counterparty marker was observed.
+    pub remote_marker_observed_at: Option<DateTime<Utc>>,
+    /// Whether this operation observed a new counterparty marker.
+    pub remote_marker_changed: bool,
+}
+
+impl EncryptedLinkRecoveryMarkerReport {
+    pub(crate) fn from_peer(peer: &LinkedPeerRecord, remote_marker_changed: bool) -> Self {
+        Self {
+            counterparty: peer.counterparty.clone(),
+            state: peer.state.clone(),
+            local_attempt_id: peer.local_recovery_attempt_id.clone(),
+            local_marker_created_at: peer.local_recovery_marker_created_at,
+            local_marker_last_error: peer.local_recovery_marker_last_error.clone(),
+            remote_attempt_id: peer.remote_recovery_attempt_id.clone(),
+            remote_marker_observed_at: peer.remote_recovery_marker_observed_at,
+            remote_marker_changed,
+        }
+    }
+}
+
+pub(crate) async fn recovery_marker_report<S>(
+    storage: &S,
+    counterparty: &PubkyPublicKey,
+) -> Result<Option<EncryptedLinkRecoveryMarkerReport>>
+where
+    S: StorageAdapter,
+{
+    storage
+        .transaction(|tx| {
+            Ok(tx
+                .linked_peer(counterparty)
+                .as_ref()
+                .map(|peer| EncryptedLinkRecoveryMarkerReport::from_peer(peer, false)))
+        })
+        .await
+}

--- a/paykit-sdk/src/runtime.rs
+++ b/paykit-sdk/src/runtime.rs
@@ -1,0 +1,108 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    IdentityStatus, PaykitSdkConfig, PaymentAdapter, PubkySessionProvider, Result, StorageAdapter,
+};
+
+/// Clock abstraction used by SDK workflows and tests.
+pub trait Clock: Clone + Send + Sync + 'static {
+    /// Return the current UTC time.
+    fn now(&self) -> DateTime<Utc>;
+}
+
+/// System UTC clock.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+/// Initialization report returned after SDK startup.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InitializationReport {
+    /// Last persisted identity status.
+    pub identity: IdentityStatus,
+    /// Whether the provider returned live Pubky session access during startup.
+    pub live_session_available: bool,
+}
+
+/// Stateful Paykit SDK runtime for one local Pubky identity.
+pub struct PaykitSdk<S, K, P, C = SystemClock> {
+    storage: S,
+    pubky: K,
+    payment: P,
+    config: PaykitSdkConfig,
+    clock: C,
+}
+
+impl<S, K, P> PaykitSdk<S, K, P, SystemClock>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+{
+    /// Create an SDK runtime with the system clock.
+    pub fn new(storage: S, pubky: K, payment: P, config: PaykitSdkConfig) -> Result<Self> {
+        Self::try_with_clock(storage, pubky, payment, config, SystemClock)
+    }
+
+    /// Fallible alias for [`Self::new`].
+    pub fn try_new(storage: S, pubky: K, payment: P, config: PaykitSdkConfig) -> Result<Self> {
+        Self::new(storage, pubky, payment, config)
+    }
+}
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Create an SDK runtime with an explicit clock.
+    pub fn try_with_clock(
+        storage: S,
+        pubky: K,
+        payment: P,
+        config: PaykitSdkConfig,
+        clock: C,
+    ) -> Result<Self> {
+        config.validate()?;
+        Ok(Self {
+            storage,
+            pubky,
+            payment,
+            config,
+            clock,
+        })
+    }
+
+    /// Access the storage adapter used by this SDK instance.
+    pub fn storage(&self) -> &S {
+        &self.storage
+    }
+
+    /// Access the Pubky session provider used by this SDK instance.
+    pub fn pubky_session_provider(&self) -> &K {
+        &self.pubky
+    }
+
+    /// Access the payment adapter used by this SDK instance.
+    pub fn payment_adapter(&self) -> &P {
+        &self.payment
+    }
+
+    /// Access the SDK configuration.
+    pub fn config(&self) -> &PaykitSdkConfig {
+        &self.config
+    }
+
+    /// Access the SDK clock.
+    pub fn clock(&self) -> &C {
+        &self.clock
+    }
+}

--- a/paykit-sdk/src/storage.rs
+++ b/paykit-sdk/src/storage.rs
@@ -1,0 +1,324 @@
+use std::{any::Any, sync::Arc};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+mod in_memory;
+mod queue;
+mod records;
+
+pub use in_memory::InMemoryStorage;
+pub use records::{
+    EncryptedLinkStateRecord, EventDedupRecord, LinkedPeerRecord, NewOutboundPrivateMessage,
+    NewPrivateStreamItem, OutboundPrivateMessageRecord, PaymentEndpointReservationRecord,
+    PeerLinkOperationLease, PrivateStreamItemRecord, PublicEndpointRecord, StorageState,
+};
+
+pub(crate) use queue::outbound_private_queue_head_is_claimable;
+pub(crate) use records::NewPrivateStreamItemDetails;
+
+use crate::{
+    backup::ValidatedStorageState,
+    contacts::ContactRecord,
+    identity::{IdentityState, PubkyPublicKey},
+    receipts::{ReceiptAccessRecord, ReceiptIssuanceRecord, ReceiptRecord},
+    PaykitSdkError, Result,
+};
+
+/// Erased storage transaction callback for boxed storage adapters.
+pub type StorageTransactionCallback<'a> =
+    Box<dyn FnOnce(&mut dyn StorageTransaction) -> Result<Box<dyn Any + Send>> + Send + 'a>;
+
+/// Durable storage boundary for Paykit SDK.
+///
+/// Production adapters must provide atomic transactions with monotonic id
+/// allocation, stable FIFO ordering for outbound/private-stream records, and
+/// lease-aware writes. The SDK assumes all mutation methods called inside one
+/// transaction either commit together or roll back together.
+#[async_trait]
+pub trait StorageAdapter: Send + Sync {
+    /// Run an atomic storage transaction through an object-safe erased callback.
+    async fn transaction_erased<'a>(
+        &self,
+        f: StorageTransactionCallback<'a>,
+    ) -> Result<Box<dyn Any + Send>>;
+
+    /// Run an atomic storage transaction.
+    async fn transaction<T, F>(&self, f: F) -> Result<T>
+    where
+        Self: Sized,
+        T: Send + 'static,
+        F: FnOnce(&mut dyn StorageTransaction) -> Result<T> + Send,
+    {
+        let result = self
+            .transaction_erased(Box::new(move |tx| {
+                Ok(Box::new(f(tx)?) as Box<dyn Any + Send>)
+            }))
+            .await?;
+        result
+            .downcast::<T>()
+            .map(|value| *value)
+            .map_err(|_| PaykitSdkError::Storage {
+                context: "storage transaction result type mismatch".into(),
+                source: None,
+            })
+    }
+
+    /// Load the current identity state.
+    async fn load_identity_state(&self) -> Result<Option<IdentityState>> {
+        let result = self
+            .transaction_erased(Box::new(|tx| {
+                Ok(Box::new(tx.load_identity_state()) as Box<dyn Any + Send>)
+            }))
+            .await?;
+        result
+            .downcast::<Option<IdentityState>>()
+            .map(|value| *value)
+            .map_err(|_| PaykitSdkError::Storage {
+                context: "storage transaction result type mismatch".into(),
+                source: None,
+            })
+    }
+
+    /// Save the current identity state atomically.
+    async fn save_identity_state(&self, state: IdentityState) -> Result<()> {
+        self.transaction_erased(Box::new(move |tx| {
+            tx.save_identity_state(state);
+            Ok(Box::new(()) as Box<dyn Any + Send>)
+        }))
+        .await
+        .map(|_| ())
+    }
+}
+
+#[async_trait]
+impl<T> StorageAdapter for Box<T>
+where
+    T: StorageAdapter + ?Sized,
+{
+    async fn transaction_erased<'a>(
+        &self,
+        f: StorageTransactionCallback<'a>,
+    ) -> Result<Box<dyn Any + Send>> {
+        (**self).transaction_erased(f).await
+    }
+}
+
+#[async_trait]
+impl<T> StorageAdapter for Arc<T>
+where
+    T: StorageAdapter + ?Sized,
+{
+    async fn transaction_erased<'a>(
+        &self,
+        f: StorageTransactionCallback<'a>,
+    ) -> Result<Box<dyn Any + Send>> {
+        (**self).transaction_erased(f).await
+    }
+}
+
+/// Mutable operations available inside one storage transaction.
+pub trait StorageTransaction {
+    /// Export the full logical SDK storage state.
+    fn export_storage_state(&self) -> StorageState;
+
+    /// Replace the full logical SDK storage state after backup validation.
+    fn replace_storage_state(&mut self, state: ValidatedStorageState);
+
+    /// Load the current identity state.
+    fn load_identity_state(&self) -> Option<IdentityState>;
+
+    /// Save the current identity state.
+    fn save_identity_state(&mut self, state: IdentityState);
+
+    /// Clear SDK-managed state that belongs to one local identity.
+    fn clear_identity_scoped_state(&mut self);
+
+    /// Clear private SDK-managed state that depends on local secret-key access.
+    fn clear_private_identity_scoped_state(&mut self);
+
+    /// Load one Linked Peer record.
+    fn linked_peer(&self, counterparty: &PubkyPublicKey) -> Option<LinkedPeerRecord>;
+
+    /// Save one Linked Peer record.
+    fn save_linked_peer(&mut self, record: LinkedPeerRecord);
+
+    /// List local contact records.
+    fn contact_records(&self) -> Vec<ContactRecord>;
+
+    /// Load one local contact record.
+    fn contact_record(&self, public_key: &PubkyPublicKey) -> Option<ContactRecord>;
+
+    /// Save one local contact record.
+    fn save_contact_record(&mut self, record: ContactRecord);
+
+    /// Remove one local contact record.
+    fn remove_contact_record(&mut self, public_key: &PubkyPublicKey) -> Option<ContactRecord>;
+
+    /// List SDK-managed public Payment Endpoint records.
+    fn public_endpoint_records(&self) -> Vec<PublicEndpointRecord>;
+
+    /// Save one SDK-managed public Payment Endpoint record.
+    fn save_public_endpoint_record(&mut self, record: PublicEndpointRecord);
+
+    /// List Payment Endpoint Reservation records for one counterparty.
+    fn payment_endpoint_reservations(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Vec<PaymentEndpointReservationRecord>;
+
+    /// Load one Payment Endpoint Reservation record.
+    fn payment_endpoint_reservation(
+        &self,
+        counterparty: &PubkyPublicKey,
+        reservation_id: &str,
+    ) -> Option<PaymentEndpointReservationRecord>;
+
+    /// Save one Payment Endpoint Reservation record.
+    fn save_payment_endpoint_reservation(&mut self, record: PaymentEndpointReservationRecord);
+
+    /// Remove one Payment Endpoint Reservation record.
+    fn remove_payment_endpoint_reservation(
+        &mut self,
+        counterparty: &PubkyPublicKey,
+        reservation_id: &str,
+    ) -> Option<PaymentEndpointReservationRecord>;
+
+    /// Load one Encrypted Link state record.
+    fn encrypted_link_state(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Option<EncryptedLinkStateRecord>;
+
+    /// Save one Encrypted Link state record.
+    fn save_encrypted_link_state(&mut self, record: EncryptedLinkStateRecord);
+
+    /// Claim exclusive local work on one peer's Encrypted Link.
+    fn claim_peer_link_operation(
+        &mut self,
+        counterparty: &PubkyPublicKey,
+        now: DateTime<Utc>,
+        expires_at: DateTime<Utc>,
+    ) -> Option<PeerLinkOperationLease>;
+
+    /// Load the active peer link operation lease.
+    fn peer_link_operation_lease(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Option<PeerLinkOperationLease>;
+
+    /// Release a previously claimed peer link operation.
+    fn release_peer_link_operation(&mut self, counterparty: &PubkyPublicKey, lease_id: u64);
+
+    /// Insert one outbound private message and return its assigned record.
+    fn insert_outbound_private_message(
+        &mut self,
+        message: NewOutboundPrivateMessage,
+    ) -> OutboundPrivateMessageRecord;
+
+    /// List outbound private messages that should be attempted.
+    fn queued_outbound_private_messages(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Vec<OutboundPrivateMessageRecord>;
+
+    /// List all outbound private messages for one counterparty.
+    fn outbound_private_messages(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Vec<OutboundPrivateMessageRecord>;
+
+    /// Claim the next retryable outbound private message for sending.
+    ///
+    /// Event Messages are claimed FIFO. Private Payment Lists are Latest-State
+    /// Messages, so older claimable unsent lists should be marked
+    /// [`crate::OutboundPrivateMessageStatus::Superseded`] before claiming.
+    /// Stale [`crate::OutboundPrivateMessageStatus::Sending`] records can be
+    /// reclaimed only at the queue head so the same message is retried before
+    /// later private messages advance the Encrypted Link.
+    fn claim_next_outbound_private_message(
+        &mut self,
+        counterparty: &PubkyPublicKey,
+        now: DateTime<Utc>,
+        stale_before: DateTime<Utc>,
+        failed_retry_after: DateTime<Utc>,
+    ) -> Option<OutboundPrivateMessageRecord>;
+
+    /// Save updates for one existing outbound private message record.
+    fn save_outbound_private_message(&mut self, record: OutboundPrivateMessageRecord)
+        -> Result<()>;
+
+    /// Allocate a receive batch id.
+    fn allocate_receive_batch_id(&mut self) -> u64;
+
+    /// Insert one private stream item and return its assigned id.
+    fn insert_private_stream_item(&mut self, item: NewPrivateStreamItem) -> u64;
+
+    /// List private stream items for a counterparty.
+    fn private_stream_items(&self, counterparty: &PubkyPublicKey) -> Vec<PrivateStreamItemRecord>;
+
+    /// Load an Event Message dedupe record.
+    fn event_dedup_record(
+        &self,
+        counterparty: &PubkyPublicKey,
+        event_id: &str,
+    ) -> Option<EventDedupRecord>;
+
+    /// Save an Event Message dedupe record.
+    fn save_event_dedup_record(&mut self, record: EventDedupRecord);
+
+    /// Save one indexed Receipt Access record.
+    fn save_receipt_access_record(&mut self, record: ReceiptAccessRecord);
+
+    /// List indexed Receipt Access records for one counterparty.
+    fn receipt_access_records(&self, counterparty: &PubkyPublicKey) -> Vec<ReceiptAccessRecord>;
+
+    /// Load the latest indexed Receipt Access record for a receipt.
+    fn receipt_access_record_by_receipt_id(
+        &self,
+        counterparty: &PubkyPublicKey,
+        receipt_id: &str,
+    ) -> Option<ReceiptAccessRecord>;
+
+    /// Save one decrypted Receipt record.
+    fn save_receipt_record(&mut self, record: ReceiptRecord);
+
+    /// Load one decrypted Receipt record.
+    fn receipt_record(&self, issuer: &PubkyPublicKey, receipt_id: &str) -> Option<ReceiptRecord>;
+
+    /// Save one local receipt issuance record.
+    fn save_receipt_issuance_record(&mut self, record: ReceiptIssuanceRecord);
+
+    /// List receipt issuance records for one counterparty.
+    fn receipt_issuance_records(&self, counterparty: &PubkyPublicKey)
+        -> Vec<ReceiptIssuanceRecord>;
+
+    /// Load one receipt issuance record.
+    fn receipt_issuance_record(
+        &self,
+        counterparty: &PubkyPublicKey,
+        receipt_id: &str,
+    ) -> Option<ReceiptIssuanceRecord>;
+
+    /// Load one receipt issuance record by Receipt ID across counterparties.
+    fn receipt_issuance_record_by_receipt_id(
+        &self,
+        receipt_id: &str,
+    ) -> Option<ReceiptIssuanceRecord>;
+}
+
+pub(crate) fn require_peer_link_operation_lease(
+    tx: &dyn StorageTransaction,
+    lease: &PeerLinkOperationLease,
+) -> Result<()> {
+    match tx.peer_link_operation_lease(&lease.counterparty) {
+        Some(active) if active.lease_id == lease.lease_id => Ok(()),
+        _ => Err(PaykitSdkError::Policy(format!(
+            "peer link operation lease {} is no longer active for counterparty {}",
+            lease.lease_id, lease.counterparty
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/storage/in_memory.rs
+++ b/paykit-sdk/src/storage/in_memory.rs
@@ -1,0 +1,502 @@
+use std::sync::{Arc, Mutex};
+
+use super::queue::{
+    is_claimable_outbound_private_message, supersede_outdated_private_payment_lists,
+};
+use super::*;
+use crate::OutboundPrivateMessageStatus;
+
+/// In-memory SDK storage implementation for tests and examples.
+///
+/// This storage is not durable and must not be used for production SDK state.
+#[derive(Clone, Debug, Default)]
+pub struct InMemoryStorage {
+    state: Arc<Mutex<StorageState>>,
+}
+
+impl InMemoryStorage {
+    /// Create empty in-memory storage.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return a copy of the current storage state.
+    pub fn snapshot(&self) -> Result<StorageState> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|err| PaykitSdkError::Storage {
+                context: "in-memory storage lock poisoned".into(),
+                source: Some(anyhow::anyhow!(err.to_string())),
+            })?
+            .clone())
+    }
+}
+
+#[async_trait]
+impl StorageAdapter for InMemoryStorage {
+    async fn transaction_erased<'a>(
+        &self,
+        f: StorageTransactionCallback<'a>,
+    ) -> Result<Box<dyn std::any::Any + Send>> {
+        let mut guard = self.state.lock().map_err(|err| PaykitSdkError::Storage {
+            context: "in-memory storage lock poisoned".into(),
+            source: Some(anyhow::anyhow!(err.to_string())),
+        })?;
+        let mut transaction = InMemoryStorageTransaction {
+            state: guard.clone(),
+        };
+
+        let value = f(&mut transaction)?;
+        *guard = transaction.state;
+        Ok(value)
+    }
+}
+
+struct InMemoryStorageTransaction {
+    state: StorageState,
+}
+
+impl StorageTransaction for InMemoryStorageTransaction {
+    fn export_storage_state(&self) -> StorageState {
+        self.state.clone()
+    }
+
+    fn replace_storage_state(&mut self, state: ValidatedStorageState) {
+        self.state = state.into_storage_state();
+    }
+
+    fn load_identity_state(&self) -> Option<IdentityState> {
+        self.state.identity_state.clone()
+    }
+
+    fn save_identity_state(&mut self, state: IdentityState) {
+        self.state.identity_state = Some(state);
+    }
+
+    fn clear_identity_scoped_state(&mut self) {
+        self.clear_private_identity_scoped_state();
+        self.state.contact_records.clear();
+        self.state.public_endpoint_records.clear();
+    }
+
+    fn clear_private_identity_scoped_state(&mut self) {
+        self.state.linked_peers.clear();
+        self.state.encrypted_link_states.clear();
+        self.state.peer_link_operation_leases.clear();
+        self.state.payment_endpoint_reservations.clear();
+        self.state.outbound_private_messages.clear();
+        self.state.private_stream_items.clear();
+        self.state.event_dedup_records.clear();
+        self.state.receipt_access_records.clear();
+        self.state.receipt_records.clear();
+        self.state.receipt_issuance_records.clear();
+    }
+
+    fn linked_peer(&self, counterparty: &PubkyPublicKey) -> Option<LinkedPeerRecord> {
+        self.state.linked_peers.get(counterparty).cloned()
+    }
+
+    fn save_linked_peer(&mut self, record: LinkedPeerRecord) {
+        self.state
+            .linked_peers
+            .insert(record.counterparty.clone(), record);
+    }
+
+    fn contact_records(&self) -> Vec<ContactRecord> {
+        let mut records = self
+            .state
+            .contact_records
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by(|left, right| left.public_key.as_str().cmp(right.public_key.as_str()));
+        records
+    }
+
+    fn contact_record(&self, public_key: &PubkyPublicKey) -> Option<ContactRecord> {
+        self.state.contact_records.get(public_key).cloned()
+    }
+
+    fn save_contact_record(&mut self, record: ContactRecord) {
+        self.state
+            .contact_records
+            .insert(record.public_key.clone(), record);
+    }
+
+    fn remove_contact_record(&mut self, public_key: &PubkyPublicKey) -> Option<ContactRecord> {
+        self.state.contact_records.remove(public_key)
+    }
+
+    fn public_endpoint_records(&self) -> Vec<PublicEndpointRecord> {
+        let mut records = self
+            .state
+            .public_endpoint_records
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by(|left, right| left.identifier.cmp(&right.identifier));
+        records
+    }
+
+    fn save_public_endpoint_record(&mut self, record: PublicEndpointRecord) {
+        self.state
+            .public_endpoint_records
+            .insert(record.identifier.clone(), record);
+    }
+
+    fn payment_endpoint_reservations(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Vec<PaymentEndpointReservationRecord> {
+        let mut records = self
+            .state
+            .payment_endpoint_reservations
+            .values()
+            .filter(|record| &record.counterparty == counterparty)
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by_key(|record| record.created_at);
+        records
+    }
+
+    fn payment_endpoint_reservation(
+        &self,
+        counterparty: &PubkyPublicKey,
+        reservation_id: &str,
+    ) -> Option<PaymentEndpointReservationRecord> {
+        self.state
+            .payment_endpoint_reservations
+            .get(&(counterparty.clone(), reservation_id.to_owned()))
+            .cloned()
+    }
+
+    fn save_payment_endpoint_reservation(&mut self, record: PaymentEndpointReservationRecord) {
+        self.state.payment_endpoint_reservations.insert(
+            (record.counterparty.clone(), record.reservation_id.clone()),
+            record,
+        );
+    }
+
+    fn remove_payment_endpoint_reservation(
+        &mut self,
+        counterparty: &PubkyPublicKey,
+        reservation_id: &str,
+    ) -> Option<PaymentEndpointReservationRecord> {
+        self.state
+            .payment_endpoint_reservations
+            .remove(&(counterparty.clone(), reservation_id.to_owned()))
+    }
+
+    fn encrypted_link_state(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Option<EncryptedLinkStateRecord> {
+        self.state.encrypted_link_states.get(counterparty).cloned()
+    }
+
+    fn save_encrypted_link_state(&mut self, record: EncryptedLinkStateRecord) {
+        self.state
+            .encrypted_link_states
+            .insert(record.counterparty.clone(), record);
+    }
+
+    fn claim_peer_link_operation(
+        &mut self,
+        counterparty: &PubkyPublicKey,
+        now: DateTime<Utc>,
+        expires_at: DateTime<Utc>,
+    ) -> Option<PeerLinkOperationLease> {
+        if let Some(existing) = self.state.peer_link_operation_leases.get(counterparty) {
+            if existing.expires_at > now {
+                return None;
+            }
+        }
+
+        let lease = PeerLinkOperationLease {
+            counterparty: counterparty.clone(),
+            lease_id: self.state.next_peer_link_operation_lease_id,
+            claimed_at: now,
+            expires_at,
+        };
+        self.state.next_peer_link_operation_lease_id += 1;
+        self.state
+            .peer_link_operation_leases
+            .insert(counterparty.clone(), lease.clone());
+        Some(lease)
+    }
+
+    fn peer_link_operation_lease(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Option<PeerLinkOperationLease> {
+        self.state
+            .peer_link_operation_leases
+            .get(counterparty)
+            .cloned()
+    }
+
+    fn release_peer_link_operation(&mut self, counterparty: &PubkyPublicKey, lease_id: u64) {
+        if self
+            .state
+            .peer_link_operation_leases
+            .get(counterparty)
+            .is_some_and(|lease| lease.lease_id == lease_id)
+        {
+            self.state.peer_link_operation_leases.remove(counterparty);
+        }
+    }
+
+    fn insert_outbound_private_message(
+        &mut self,
+        message: NewOutboundPrivateMessage,
+    ) -> OutboundPrivateMessageRecord {
+        let outbound_message_id = self.state.next_outbound_private_message_id;
+        self.state.next_outbound_private_message_id += 1;
+        let record = OutboundPrivateMessageRecord::from_new(outbound_message_id, message);
+        self.state.outbound_private_messages.push(record.clone());
+        record
+    }
+
+    fn queued_outbound_private_messages(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Vec<OutboundPrivateMessageRecord> {
+        let mut messages = self
+            .state
+            .outbound_private_messages
+            .iter()
+            .filter(|message| {
+                &message.counterparty == counterparty
+                    && matches!(
+                        message.status,
+                        OutboundPrivateMessageStatus::Pending
+                            | OutboundPrivateMessageStatus::Sending
+                            | OutboundPrivateMessageStatus::Failed
+                    )
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        messages.sort_by_key(|message| message.outbound_message_id);
+        messages
+    }
+
+    fn outbound_private_messages(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Vec<OutboundPrivateMessageRecord> {
+        let mut messages = self
+            .state
+            .outbound_private_messages
+            .iter()
+            .filter(|message| &message.counterparty == counterparty)
+            .cloned()
+            .collect::<Vec<_>>();
+        messages.sort_by_key(|message| message.outbound_message_id);
+        messages
+    }
+
+    fn claim_next_outbound_private_message(
+        &mut self,
+        counterparty: &PubkyPublicKey,
+        now: DateTime<Utc>,
+        stale_before: DateTime<Utc>,
+        failed_retry_after: DateTime<Utc>,
+    ) -> Option<OutboundPrivateMessageRecord> {
+        supersede_outdated_private_payment_lists(
+            &mut self.state,
+            counterparty,
+            now,
+            stale_before,
+            failed_retry_after,
+        );
+
+        let mut indexes = self
+            .state
+            .outbound_private_messages
+            .iter()
+            .enumerate()
+            .filter(|(_, message)| {
+                &message.counterparty == counterparty
+                    && !matches!(
+                        message.status,
+                        OutboundPrivateMessageStatus::Sent
+                            | OutboundPrivateMessageStatus::Invalid
+                            | OutboundPrivateMessageStatus::RecoveryRequired
+                            | OutboundPrivateMessageStatus::Superseded
+                    )
+            })
+            .map(|(index, message)| (index, message.outbound_message_id))
+            .collect::<Vec<_>>();
+        indexes.sort_by_key(|(_, outbound_message_id)| *outbound_message_id);
+
+        let (index, _) = indexes.first().copied()?;
+        let message = &mut self.state.outbound_private_messages[index];
+        if !is_claimable_outbound_private_message(message, stale_before, failed_retry_after) {
+            return None;
+        }
+
+        message.status = OutboundPrivateMessageStatus::Sending;
+        message.attempt_count = message.attempt_count.saturating_add(1);
+        message.last_attempt_at = Some(now);
+        message.updated_at = now;
+        message.last_error = None;
+        Some(message.clone())
+    }
+
+    fn save_outbound_private_message(
+        &mut self,
+        record: OutboundPrivateMessageRecord,
+    ) -> Result<()> {
+        if let Some(existing) = self
+            .state
+            .outbound_private_messages
+            .iter_mut()
+            .find(|message| message.outbound_message_id == record.outbound_message_id)
+        {
+            *existing = record;
+            Ok(())
+        } else {
+            Err(PaykitSdkError::Storage {
+                context: format!(
+                    "outbound private message {} does not exist",
+                    record.outbound_message_id
+                ),
+                source: None,
+            })
+        }
+    }
+
+    fn allocate_receive_batch_id(&mut self) -> u64 {
+        let receive_batch_id = self.state.next_receive_batch_id;
+        self.state.next_receive_batch_id += 1;
+        receive_batch_id
+    }
+
+    fn insert_private_stream_item(&mut self, item: NewPrivateStreamItem) -> u64 {
+        let stream_item_id = self.state.next_private_stream_item_id;
+        self.state.next_private_stream_item_id += 1;
+        self.state
+            .private_stream_items
+            .push(PrivateStreamItemRecord::from_new(stream_item_id, item));
+        stream_item_id
+    }
+
+    fn private_stream_items(&self, counterparty: &PubkyPublicKey) -> Vec<PrivateStreamItemRecord> {
+        self.state
+            .private_stream_items
+            .iter()
+            .filter(|item| &item.counterparty == counterparty)
+            .cloned()
+            .collect()
+    }
+
+    fn event_dedup_record(
+        &self,
+        counterparty: &PubkyPublicKey,
+        event_id: &str,
+    ) -> Option<EventDedupRecord> {
+        self.state
+            .event_dedup_records
+            .get(&(counterparty.clone(), event_id.to_owned()))
+            .cloned()
+    }
+
+    fn save_event_dedup_record(&mut self, record: EventDedupRecord) {
+        self.state.event_dedup_records.insert(
+            (record.counterparty.clone(), record.event_id.clone()),
+            record,
+        );
+    }
+
+    fn save_receipt_access_record(&mut self, record: ReceiptAccessRecord) {
+        self.state.receipt_access_records.insert(
+            (record.counterparty.clone(), record.event_id.clone()),
+            record,
+        );
+    }
+
+    fn receipt_access_records(&self, counterparty: &PubkyPublicKey) -> Vec<ReceiptAccessRecord> {
+        let mut records = self
+            .state
+            .receipt_access_records
+            .values()
+            .filter(|record| &record.counterparty == counterparty)
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by_key(|record| record.stream_item_id);
+        records
+    }
+
+    fn receipt_access_record_by_receipt_id(
+        &self,
+        counterparty: &PubkyPublicKey,
+        receipt_id: &str,
+    ) -> Option<ReceiptAccessRecord> {
+        self.state
+            .receipt_access_records
+            .values()
+            .filter(|record| {
+                &record.counterparty == counterparty && record.receipt_id == receipt_id
+            })
+            .max_by_key(|record| record.stream_item_id)
+            .cloned()
+    }
+
+    fn save_receipt_record(&mut self, record: ReceiptRecord) {
+        self.state
+            .receipt_records
+            .insert((record.issuer.clone(), record.receipt_id.clone()), record);
+    }
+
+    fn receipt_record(&self, issuer: &PubkyPublicKey, receipt_id: &str) -> Option<ReceiptRecord> {
+        self.state
+            .receipt_records
+            .get(&(issuer.clone(), receipt_id.to_owned()))
+            .cloned()
+    }
+
+    fn save_receipt_issuance_record(&mut self, record: ReceiptIssuanceRecord) {
+        self.state.receipt_issuance_records.insert(
+            (record.counterparty.clone(), record.receipt_id.clone()),
+            record,
+        );
+    }
+
+    fn receipt_issuance_records(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Vec<ReceiptIssuanceRecord> {
+        let mut records = self
+            .state
+            .receipt_issuance_records
+            .values()
+            .filter(|record| &record.counterparty == counterparty)
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by_key(|record| record.created_at);
+        records
+    }
+
+    fn receipt_issuance_record(
+        &self,
+        counterparty: &PubkyPublicKey,
+        receipt_id: &str,
+    ) -> Option<ReceiptIssuanceRecord> {
+        self.state
+            .receipt_issuance_records
+            .get(&(counterparty.clone(), receipt_id.to_owned()))
+            .cloned()
+    }
+
+    fn receipt_issuance_record_by_receipt_id(
+        &self,
+        receipt_id: &str,
+    ) -> Option<ReceiptIssuanceRecord> {
+        self.state
+            .receipt_issuance_records
+            .values()
+            .find(|record| record.receipt_id == receipt_id)
+            .cloned()
+    }
+}

--- a/paykit-sdk/src/storage/queue.rs
+++ b/paykit-sdk/src/storage/queue.rs
@@ -1,0 +1,125 @@
+use chrono::{DateTime, Utc};
+use paykit_lib::PrivateMessageKind;
+
+use crate::{
+    identity::PubkyPublicKey,
+    outbound_private::OutboundPrivateMessageStatus,
+    storage::{OutboundPrivateMessageRecord, StorageState},
+};
+
+pub(super) fn is_claimable_outbound_private_message(
+    message: &OutboundPrivateMessageRecord,
+    stale_before: DateTime<Utc>,
+    failed_retry_after: DateTime<Utc>,
+) -> bool {
+    match message.status {
+        OutboundPrivateMessageStatus::Pending => true,
+        OutboundPrivateMessageStatus::Failed => message
+            .last_attempt_at
+            .is_none_or(|last_attempt_at| last_attempt_at <= failed_retry_after),
+        OutboundPrivateMessageStatus::Sending => {
+            is_stale_sending_outbound_private_message(message, stale_before)
+        }
+        OutboundPrivateMessageStatus::Sent
+        | OutboundPrivateMessageStatus::Invalid
+        | OutboundPrivateMessageStatus::RecoveryRequired
+        | OutboundPrivateMessageStatus::Superseded => false,
+    }
+}
+
+pub(super) fn is_stale_sending_outbound_private_message(
+    message: &OutboundPrivateMessageRecord,
+    stale_before: DateTime<Utc>,
+) -> bool {
+    message.status == OutboundPrivateMessageStatus::Sending
+        && message
+            .last_attempt_at
+            .is_none_or(|last_attempt_at| last_attempt_at <= stale_before)
+}
+
+pub(crate) fn outbound_private_queue_head_is_claimable(
+    messages: &[OutboundPrivateMessageRecord],
+    stale_before: DateTime<Utc>,
+    failed_retry_after: DateTime<Utc>,
+) -> bool {
+    let latest_private_list_id = messages
+        .iter()
+        .filter(|message| {
+            message.kind == PrivateMessageKind::PrivatePaymentList.as_str()
+                && !matches!(
+                    message.status,
+                    OutboundPrivateMessageStatus::Invalid
+                        | OutboundPrivateMessageStatus::RecoveryRequired
+                        | OutboundPrivateMessageStatus::Superseded
+                )
+        })
+        .map(|message| message.outbound_message_id)
+        .max();
+    let mut ordered = messages.iter().collect::<Vec<_>>();
+    ordered.sort_by_key(|message| message.outbound_message_id);
+
+    for message in ordered {
+        if matches!(
+            message.status,
+            OutboundPrivateMessageStatus::Sent
+                | OutboundPrivateMessageStatus::Invalid
+                | OutboundPrivateMessageStatus::RecoveryRequired
+                | OutboundPrivateMessageStatus::Superseded
+        ) {
+            continue;
+        }
+        let is_supersedable_private_list = latest_private_list_id.is_some_and(|latest| {
+            message.kind == PrivateMessageKind::PrivatePaymentList.as_str()
+                && message.outbound_message_id < latest
+                && message.status != OutboundPrivateMessageStatus::Sending
+                && is_claimable_outbound_private_message(message, stale_before, failed_retry_after)
+        });
+        if is_supersedable_private_list {
+            continue;
+        }
+        return is_claimable_outbound_private_message(message, stale_before, failed_retry_after)
+            || is_stale_sending_outbound_private_message(message, stale_before);
+    }
+
+    false
+}
+
+pub(super) fn supersede_outdated_private_payment_lists(
+    state: &mut StorageState,
+    counterparty: &PubkyPublicKey,
+    now: DateTime<Utc>,
+    stale_before: DateTime<Utc>,
+    failed_retry_after: DateTime<Utc>,
+) {
+    let latest_private_list_id = state
+        .outbound_private_messages
+        .iter()
+        .filter(|message| {
+            &message.counterparty == counterparty
+                && message.kind == PrivateMessageKind::PrivatePaymentList.as_str()
+                && !matches!(
+                    message.status,
+                    OutboundPrivateMessageStatus::Invalid
+                        | OutboundPrivateMessageStatus::RecoveryRequired
+                        | OutboundPrivateMessageStatus::Superseded
+                )
+        })
+        .map(|message| message.outbound_message_id)
+        .max();
+    let Some(latest_private_list_id) = latest_private_list_id else {
+        return;
+    };
+
+    for message in state.outbound_private_messages.iter_mut() {
+        if &message.counterparty == counterparty
+            && message.kind == PrivateMessageKind::PrivatePaymentList.as_str()
+            && message.outbound_message_id < latest_private_list_id
+            && message.status != OutboundPrivateMessageStatus::Sending
+            && is_claimable_outbound_private_message(message, stale_before, failed_retry_after)
+        {
+            message.status = OutboundPrivateMessageStatus::Superseded;
+            message.updated_at = now;
+            message.last_error = None;
+        }
+    }
+}

--- a/paykit-sdk/src/storage/records.rs
+++ b/paykit-sdk/src/storage/records.rs
@@ -1,0 +1,589 @@
+use std::{collections::HashMap, fmt};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    contacts::ContactRecord,
+    identity::{IdentityState, PubkyPublicKey},
+    linked_peers::LinkedPeerState,
+    outbound_private::OutboundPrivateMessageStatus,
+    private_stream::PrivateStreamParseStatus,
+    publication::PublicationStatus,
+    receipts::{ReceiptAccessRecord, ReceiptIssuanceRecord, ReceiptRecord},
+};
+
+/// Durable Linked Peer state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinkedPeerRecord {
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Current local relationship/link state.
+    pub state: LinkedPeerState,
+    /// Last successful sync time.
+    pub last_sync_at: Option<DateTime<Utc>>,
+    /// Last private receive time.
+    pub last_private_receive_at: Option<DateTime<Utc>>,
+    /// Consecutive failure count for recovery/retry policy.
+    pub failure_count: u32,
+    /// Locally published Encrypted Link recovery attempt id.
+    pub local_recovery_attempt_id: Option<String>,
+    /// Creation time for the local recovery marker payload.
+    pub local_recovery_marker_created_at: Option<DateTime<Utc>>,
+    /// Last local recovery marker publish/remove error, when available.
+    #[serde(default)]
+    pub local_recovery_marker_last_error: Option<String>,
+    /// Latest counterparty recovery attempt id already observed.
+    pub remote_recovery_attempt_id: Option<String>,
+    /// Time the counterparty recovery marker was observed.
+    pub remote_recovery_marker_observed_at: Option<DateTime<Utc>>,
+}
+
+/// Durable SDK-managed public Payment Endpoint publication record.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PublicEndpointRecord {
+    /// Payment Endpoint Identifier.
+    pub identifier: String,
+    /// Last payload the SDK tried to publish.
+    pub payload: Option<String>,
+    /// Current publication status.
+    pub status: PublicationStatus,
+    /// Last status update time.
+    pub updated_at: DateTime<Utc>,
+    /// Last sync error, when available.
+    pub last_error: Option<String>,
+}
+
+impl fmt::Debug for PublicEndpointRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PublicEndpointRecord")
+            .field("identifier", &self.identifier)
+            .field(
+                "payload",
+                &self
+                    .payload
+                    .as_ref()
+                    .map(|payload| format!("<redacted:{} bytes>", payload.len())),
+            )
+            .field("status", &self.status)
+            .field("updated_at", &self.updated_at)
+            .field("last_error", &self.last_error)
+            .finish()
+    }
+}
+
+/// Durable SDK-managed Payment Endpoint Reservation record.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaymentEndpointReservationRecord {
+    /// Adapter-stable reservation id.
+    pub reservation_id: String,
+    /// Counterparty the reserved endpoint is intended for.
+    pub counterparty: PubkyPublicKey,
+    /// Payment Endpoint Identifier.
+    pub identifier: String,
+    /// Hash of the reserved endpoint payload.
+    pub payload_hash: String,
+    /// Latest outbound message id that queued this reservation for sharing.
+    pub outbound_message_id: u64,
+    /// Adapter-provided attribution metadata.
+    pub attribution: HashMap<String, String>,
+    /// Optional reservation expiry.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Time at which adapter cancellation was claimed for this reservation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancellation_started_at: Option<DateTime<Utc>>,
+    /// Creation time.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Durable Encrypted Link snapshot state.
+///
+/// Snapshot bytes contain Noise key and counter material. Store them encrypted
+/// at rest and avoid logging them.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EncryptedLinkStateRecord {
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Serialized active link snapshot.
+    pub link_snapshot: Option<Vec<u8>>,
+    /// Serialized in-progress handshake snapshot.
+    pub handshake_snapshot: Option<Vec<u8>>,
+    /// Local role for the in-progress handshake.
+    pub handshake_role: Option<crate::EncryptedLinkHandshakeRole>,
+    /// Local snapshot generation.
+    pub generation: u64,
+    /// Last checkpoint time.
+    pub checkpointed_at: DateTime<Utc>,
+}
+
+impl fmt::Debug for EncryptedLinkStateRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EncryptedLinkStateRecord")
+            .field("counterparty", &self.counterparty)
+            .field(
+                "link_snapshot",
+                &self
+                    .link_snapshot
+                    .as_ref()
+                    .map(|snapshot| format!("<redacted:{} bytes>", snapshot.len())),
+            )
+            .field(
+                "handshake_snapshot",
+                &self
+                    .handshake_snapshot
+                    .as_ref()
+                    .map(|snapshot| format!("<redacted:{} bytes>", snapshot.len())),
+            )
+            .field("handshake_role", &self.handshake_role)
+            .field("generation", &self.generation)
+            .field("checkpointed_at", &self.checkpointed_at)
+            .finish()
+    }
+}
+
+/// Storage-backed lease for one peer link operation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerLinkOperationLease {
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Assigned lease id.
+    pub lease_id: u64,
+    /// Claim time.
+    pub claimed_at: DateTime<Utc>,
+    /// Expiry time after which another worker may retry.
+    pub expires_at: DateTime<Utc>,
+}
+
+/// New outbound private message before storage assigns an id.
+///
+/// The payload may contain private Paykit secrets. `Debug` redacts it.
+#[derive(Clone, PartialEq, Eq)]
+pub struct NewOutboundPrivateMessage {
+    counterparty: PubkyPublicKey,
+    kind: String,
+    raw_json: String,
+    created_at: DateTime<Utc>,
+}
+
+impl NewOutboundPrivateMessage {
+    pub(crate) fn new(
+        counterparty: PubkyPublicKey,
+        kind: String,
+        raw_json: String,
+        created_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            counterparty,
+            kind,
+            raw_json,
+            created_at,
+        }
+    }
+
+    /// Counterparty public key.
+    pub fn counterparty(&self) -> &PubkyPublicKey {
+        &self.counterparty
+    }
+
+    /// Private Message Kind string.
+    pub fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    /// Exact outbound JSON payload to send.
+    pub fn raw_json(&self) -> &str {
+        &self.raw_json
+    }
+
+    /// Queue time.
+    pub fn created_at(&self) -> DateTime<Utc> {
+        self.created_at
+    }
+}
+
+impl fmt::Debug for NewOutboundPrivateMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NewOutboundPrivateMessage")
+            .field("counterparty", &self.counterparty)
+            .field("kind", &self.kind)
+            .field(
+                "raw_json",
+                &format!("<redacted:{} bytes>", self.raw_json.len()),
+            )
+            .field("created_at", &self.created_at)
+            .finish()
+    }
+}
+
+/// Durable outbound private message.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboundPrivateMessageRecord {
+    /// Assigned outbound message id.
+    pub outbound_message_id: u64,
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Private Message Kind string.
+    pub kind: String,
+    /// Exact outbound JSON payload to send.
+    pub raw_json: String,
+    /// Delivery status.
+    pub status: OutboundPrivateMessageStatus,
+    /// Number of send attempts.
+    pub attempt_count: u32,
+    /// Queue time.
+    pub created_at: DateTime<Utc>,
+    /// Last status update time.
+    pub updated_at: DateTime<Utc>,
+    /// Last send attempt time.
+    pub last_attempt_at: Option<DateTime<Utc>>,
+    /// Successful send time.
+    pub sent_at: Option<DateTime<Utc>>,
+    /// Last send error, when available.
+    pub last_error: Option<String>,
+}
+
+impl fmt::Debug for OutboundPrivateMessageRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let last_error = self
+            .last_error
+            .as_ref()
+            .map(|error| format!("<redacted:{} bytes>", error.len()));
+        f.debug_struct("OutboundPrivateMessageRecord")
+            .field("outbound_message_id", &self.outbound_message_id)
+            .field("counterparty", &self.counterparty)
+            .field("kind", &self.kind)
+            .field(
+                "raw_json",
+                &format!("<redacted:{} bytes>", self.raw_json.len()),
+            )
+            .field("status", &self.status)
+            .field("attempt_count", &self.attempt_count)
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .field("last_attempt_at", &self.last_attempt_at)
+            .field("sent_at", &self.sent_at)
+            .field("last_error", &last_error)
+            .finish()
+    }
+}
+
+impl OutboundPrivateMessageRecord {
+    pub(super) fn from_new(outbound_message_id: u64, message: NewOutboundPrivateMessage) -> Self {
+        Self {
+            outbound_message_id,
+            counterparty: message.counterparty,
+            kind: message.kind,
+            raw_json: message.raw_json,
+            status: OutboundPrivateMessageStatus::Pending,
+            attempt_count: 0,
+            created_at: message.created_at,
+            updated_at: message.created_at,
+            last_attempt_at: None,
+            sent_at: None,
+            last_error: None,
+        }
+    }
+}
+
+/// New private stream item before storage assigns an id.
+///
+/// The payload may contain private Paykit secrets. `Debug` redacts it.
+#[derive(Clone, PartialEq, Eq)]
+pub struct NewPrivateStreamItem {
+    counterparty: PubkyPublicKey,
+    receive_batch_id: u64,
+    raw_json: String,
+    parsed_version: Option<u32>,
+    parsed_kind: Option<String>,
+    known_paykit_kind: Option<String>,
+    parse_status: PrivateStreamParseStatus,
+    parse_error: Option<String>,
+    received_at: DateTime<Utc>,
+}
+
+impl NewPrivateStreamItem {
+    pub(crate) fn new(details: NewPrivateStreamItemDetails) -> Self {
+        Self {
+            counterparty: details.counterparty,
+            receive_batch_id: details.receive_batch_id,
+            raw_json: details.raw_json,
+            parsed_version: details.parsed_version,
+            parsed_kind: details.parsed_kind,
+            known_paykit_kind: details.known_paykit_kind,
+            parse_status: details.parse_status,
+            parse_error: details.parse_error,
+            received_at: details.received_at,
+        }
+    }
+
+    /// Counterparty public key.
+    pub fn counterparty(&self) -> &PubkyPublicKey {
+        &self.counterparty
+    }
+
+    /// Receive batch id assigned by the SDK runtime.
+    pub fn receive_batch_id(&self) -> u64 {
+        self.receive_batch_id
+    }
+
+    /// Raw plaintext payload.
+    pub fn raw_json(&self) -> &str {
+        &self.raw_json
+    }
+
+    /// Parsed Private Application Message version.
+    pub fn parsed_version(&self) -> Option<u32> {
+        self.parsed_version
+    }
+
+    /// Parsed Private Application Message kind.
+    pub fn parsed_kind(&self) -> Option<&str> {
+        self.parsed_kind.as_deref()
+    }
+
+    /// Whether the kind is a known Paykit kind.
+    pub fn known_paykit_kind(&self) -> Option<&str> {
+        self.known_paykit_kind.as_deref()
+    }
+
+    /// Parse status.
+    pub fn parse_status(&self) -> PrivateStreamParseStatus {
+        self.parse_status.clone()
+    }
+
+    /// Parse error, when available.
+    pub fn parse_error(&self) -> Option<&str> {
+        self.parse_error.as_deref()
+    }
+
+    /// Receive time.
+    pub fn received_at(&self) -> DateTime<Utc> {
+        self.received_at
+    }
+}
+
+pub(crate) struct NewPrivateStreamItemDetails {
+    pub(crate) counterparty: PubkyPublicKey,
+    pub(crate) receive_batch_id: u64,
+    pub(crate) raw_json: String,
+    pub(crate) parsed_version: Option<u32>,
+    pub(crate) parsed_kind: Option<String>,
+    pub(crate) known_paykit_kind: Option<String>,
+    pub(crate) parse_status: PrivateStreamParseStatus,
+    pub(crate) parse_error: Option<String>,
+    pub(crate) received_at: DateTime<Utc>,
+}
+
+impl fmt::Debug for NewPrivateStreamItem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NewPrivateStreamItem")
+            .field("counterparty", &self.counterparty)
+            .field("receive_batch_id", &self.receive_batch_id)
+            .field(
+                "raw_json",
+                &format!("<redacted:{} bytes>", self.raw_json.len()),
+            )
+            .field("parsed_version", &self.parsed_version)
+            .field("parsed_kind", &self.parsed_kind)
+            .field("known_paykit_kind", &self.known_paykit_kind)
+            .field("parse_status", &self.parse_status)
+            .field("parse_error", &self.parse_error)
+            .field("received_at", &self.received_at)
+            .finish()
+    }
+}
+
+/// Durable private stream item.
+///
+/// The payload may contain private Paykit secrets. `Debug` redacts it.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrivateStreamItemRecord {
+    /// Assigned stream item id.
+    pub stream_item_id: u64,
+    /// Counterparty public key.
+    pub counterparty: PubkyPublicKey,
+    /// Receive batch id assigned by the SDK runtime.
+    pub receive_batch_id: u64,
+    /// Raw plaintext payload.
+    pub raw_json: String,
+    /// Parsed Private Application Message version.
+    pub parsed_version: Option<u32>,
+    /// Parsed Private Application Message kind.
+    pub parsed_kind: Option<String>,
+    /// Whether the kind is a known Paykit kind.
+    pub known_paykit_kind: Option<String>,
+    /// Parse status.
+    pub parse_status: PrivateStreamParseStatus,
+    /// Parse error, when available.
+    pub parse_error: Option<String>,
+    /// Receive time.
+    pub received_at: DateTime<Utc>,
+}
+
+impl fmt::Debug for PrivateStreamItemRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PrivateStreamItemRecord")
+            .field("stream_item_id", &self.stream_item_id)
+            .field("counterparty", &self.counterparty)
+            .field("receive_batch_id", &self.receive_batch_id)
+            .field(
+                "raw_json",
+                &format!("<redacted:{} bytes>", self.raw_json.len()),
+            )
+            .field("parsed_version", &self.parsed_version)
+            .field("parsed_kind", &self.parsed_kind)
+            .field("known_paykit_kind", &self.known_paykit_kind)
+            .field("parse_status", &self.parse_status)
+            .field("parse_error", &self.parse_error)
+            .field("received_at", &self.received_at)
+            .finish()
+    }
+}
+
+impl PrivateStreamItemRecord {
+    pub(super) fn from_new(stream_item_id: u64, item: NewPrivateStreamItem) -> Self {
+        Self {
+            stream_item_id,
+            counterparty: item.counterparty,
+            receive_batch_id: item.receive_batch_id,
+            raw_json: item.raw_json,
+            parsed_version: item.parsed_version,
+            parsed_kind: item.parsed_kind,
+            known_paykit_kind: item.known_paykit_kind,
+            parse_status: item.parse_status,
+            parse_error: item.parse_error,
+            received_at: item.received_at,
+        }
+    }
+}
+
+/// Event Message dedupe/conflict record.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventDedupRecord {
+    /// Counterparty that sent the event.
+    pub counterparty: PubkyPublicKey,
+    /// Event ID.
+    pub event_id: String,
+    /// Event kind.
+    pub event_kind: String,
+    /// Hash of the exact payload bytes.
+    pub payload_hash: String,
+    /// First stream item that carried the event.
+    pub first_stream_item_id: u64,
+    /// Duplicate stream items with the same payload.
+    pub duplicate_stream_item_ids: Vec<u64>,
+    /// Conflicting stream items that reused the Event ID with a different payload.
+    pub conflicting_stream_item_ids: Vec<u64>,
+}
+
+/// Logical SDK storage state used by snapshots, tests, and backup/restore.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct StorageState {
+    /// Current identity state.
+    pub identity_state: Option<IdentityState>,
+    /// Linked Peer records by counterparty.
+    pub linked_peers: HashMap<PubkyPublicKey, LinkedPeerRecord>,
+    /// Local contact records by public key.
+    pub contact_records: HashMap<PubkyPublicKey, ContactRecord>,
+    /// SDK-managed public endpoint records by identifier.
+    pub public_endpoint_records: HashMap<String, PublicEndpointRecord>,
+    /// SDK-managed Payment Endpoint Reservation records by counterparty and reservation id.
+    pub payment_endpoint_reservations:
+        HashMap<(PubkyPublicKey, String), PaymentEndpointReservationRecord>,
+    /// Encrypted Link state records by counterparty.
+    pub encrypted_link_states: HashMap<PubkyPublicKey, EncryptedLinkStateRecord>,
+    /// Active peer link operation leases by counterparty.
+    pub peer_link_operation_leases: HashMap<PubkyPublicKey, PeerLinkOperationLease>,
+    /// Next peer link operation lease id.
+    pub next_peer_link_operation_lease_id: u64,
+    /// Append-only outbound private message records.
+    pub outbound_private_messages: Vec<OutboundPrivateMessageRecord>,
+    /// Next outbound private message id.
+    pub next_outbound_private_message_id: u64,
+    /// Append-only private stream items.
+    pub private_stream_items: Vec<PrivateStreamItemRecord>,
+    /// Next receive batch id.
+    pub next_receive_batch_id: u64,
+    /// Next private stream item id.
+    pub next_private_stream_item_id: u64,
+    /// Event dedupe records by counterparty and Event ID.
+    pub event_dedup_records: HashMap<(PubkyPublicKey, String), EventDedupRecord>,
+    /// Receipt Access records by counterparty and Event ID.
+    pub receipt_access_records: HashMap<(PubkyPublicKey, String), ReceiptAccessRecord>,
+    /// Decrypted Receipt records by issuer and Receipt ID.
+    pub receipt_records: HashMap<(PubkyPublicKey, String), ReceiptRecord>,
+    /// Local receipt issuance records by counterparty and Receipt ID.
+    pub receipt_issuance_records: HashMap<(PubkyPublicKey, String), ReceiptIssuanceRecord>,
+}
+
+impl fmt::Debug for StorageState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StorageState")
+            .field(
+                "identity_state",
+                &self.identity_state.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "linked_peers",
+                &format_args!("{} records", self.linked_peers.len()),
+            )
+            .field(
+                "contact_records",
+                &format_args!("{} records", self.contact_records.len()),
+            )
+            .field(
+                "public_endpoint_records",
+                &format_args!("{} records", self.public_endpoint_records.len()),
+            )
+            .field(
+                "payment_endpoint_reservations",
+                &format_args!("{} records", self.payment_endpoint_reservations.len()),
+            )
+            .field(
+                "encrypted_link_states",
+                &format_args!("{} records", self.encrypted_link_states.len()),
+            )
+            .field(
+                "peer_link_operation_leases",
+                &format_args!("{} records", self.peer_link_operation_leases.len()),
+            )
+            .field(
+                "next_peer_link_operation_lease_id",
+                &self.next_peer_link_operation_lease_id,
+            )
+            .field(
+                "outbound_private_messages",
+                &format_args!("{} records", self.outbound_private_messages.len()),
+            )
+            .field(
+                "next_outbound_private_message_id",
+                &self.next_outbound_private_message_id,
+            )
+            .field(
+                "private_stream_items",
+                &format_args!("{} records", self.private_stream_items.len()),
+            )
+            .field("next_receive_batch_id", &self.next_receive_batch_id)
+            .field(
+                "next_private_stream_item_id",
+                &self.next_private_stream_item_id,
+            )
+            .field(
+                "event_dedup_records",
+                &format_args!("{} records", self.event_dedup_records.len()),
+            )
+            .field(
+                "receipt_access_records",
+                &format_args!("{} records", self.receipt_access_records.len()),
+            )
+            .field(
+                "receipt_records",
+                &format_args!("{} records", self.receipt_records.len()),
+            )
+            .field(
+                "receipt_issuance_records",
+                &format_args!("{} records", self.receipt_issuance_records.len()),
+            )
+            .finish()
+    }
+}

--- a/paykit-sdk/src/storage/tests.rs
+++ b/paykit-sdk/src/storage/tests.rs
@@ -1,0 +1,934 @@
+use std::collections::HashMap;
+
+use chrono::{TimeZone, Utc};
+
+use super::*;
+use crate::outbound_private::{
+    claim_next_outbound_private_message, mark_outbound_failed, mark_outbound_invalid,
+    mark_outbound_sent, queued_outbound_private_messages,
+};
+use crate::{
+    LinkedPeerState, OutboundPrivateMessageStatus, PrivateStreamParseStatus, PublicationStatus,
+};
+
+fn timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+}
+
+fn counterparty() -> PubkyPublicKey {
+    PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+}
+
+fn public_endpoint_record(identifier: &str) -> PublicEndpointRecord {
+    PublicEndpointRecord {
+        identifier: identifier.into(),
+        payload: Some("public-endpoint-secret".into()),
+        status: PublicationStatus::Published,
+        updated_at: timestamp(),
+        last_error: None,
+    }
+}
+
+fn outbound_private_message(counterparty: PubkyPublicKey) -> NewOutboundPrivateMessage {
+    NewOutboundPrivateMessage::new(
+        counterparty,
+        "paykit.private_payment_list".into(),
+        r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#.into(),
+        timestamp(),
+    )
+}
+
+fn outbound_payment_request_message(counterparty: PubkyPublicKey) -> NewOutboundPrivateMessage {
+    NewOutboundPrivateMessage::new(
+            counterparty,
+            "paykit.payment_request".into(),
+            r#"{"version":1,"kind":"paykit.payment_request","event_id":"650e8400-e29b-41d4-a716-446655440000","payment_request_id":"550e8400-e29b-41d4-a716-446655440000","request":{"payment_request_id":"550e8400-e29b-41d4-a716-446655440000","terms":{"amount":{"value":"1","asset":"btc"},"payment_reference":"invoice-2026-0001","proposal_expires_at":null,"recurrence":null,"accepted_payment_endpoint_identifiers":["btc-lightning-bolt11"],"metadata":{}}}}"#.into(),
+            timestamp(),
+        )
+}
+
+fn receipt_access_record(counterparty: PubkyPublicKey) -> ReceiptAccessRecord {
+    ReceiptAccessRecord {
+        counterparty,
+        stream_item_id: 0,
+        receive_batch_id: 0,
+        event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+        receipt_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+        payment_reference: "invoice-2026-0001".into(),
+        payment_request_id: None,
+        billing_period: None,
+        location: "/pub/paykit/v0/private/receipts/550e8400-e29b-41d4-a716-446655440000".into(),
+        key: "receipt-secret".into(),
+        retrieval_status: crate::ReceiptRetrievalStatus::Pending,
+        retrieval_attempted_at: None,
+        retrieved_at: None,
+        last_retrieval_error: None,
+        received_at: timestamp(),
+    }
+}
+
+fn receipt_record(issuer: PubkyPublicKey) -> ReceiptRecord {
+    ReceiptRecord {
+        issuer,
+        receipt_access_event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+        receipt_access_key_hash: "sha256:test".into(),
+        receipt_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+        payment_reference: "invoice-2026-0001".into(),
+        payment_request_id: None,
+        billing_period: None,
+        recipient_public_key: PubkyPublicKey::from_public_key(
+            &pubky::Keypair::random().public_key(),
+        ),
+        payment_endpoint_identifier: None,
+        amount: None,
+        metadata: serde_json::Map::new(),
+        location: "/pub/paykit/v0/private/receipts/550e8400-e29b-41d4-a716-446655440000".into(),
+        retrieved_at: timestamp(),
+    }
+}
+
+fn payment_endpoint_reservation_record(
+    counterparty: PubkyPublicKey,
+) -> PaymentEndpointReservationRecord {
+    PaymentEndpointReservationRecord {
+        reservation_id: "reservation-1".into(),
+        counterparty,
+        identifier: "btc-lightning-bolt11".into(),
+        payload_hash: "reserved-payload-hash".into(),
+        outbound_message_id: 7,
+        attribution: HashMap::from([("contact".into(), "alice".into())]),
+        expires_at: None,
+        cancellation_started_at: None,
+        created_at: timestamp(),
+    }
+}
+
+#[tokio::test]
+async fn test_storage_adapter_supports_erased_transactions() {
+    let storage: std::sync::Arc<dyn StorageAdapter> = std::sync::Arc::new(InMemoryStorage::new());
+    let identity_public_key = counterparty();
+    let saved_identity = crate::IdentityState {
+        public_key: Some(identity_public_key.clone()),
+        capability: crate::PubkyIdentityCapability::PrivateLinkCapable,
+        local_secret_available: true,
+        initialized_at: timestamp(),
+        sign_out_generation: 0,
+    };
+    let value = storage
+        .transaction_erased(Box::new(move |tx| {
+            tx.save_identity_state(saved_identity);
+            Ok(Box::new(42_u32) as Box<dyn std::any::Any + Send>)
+        }))
+        .await
+        .unwrap();
+
+    assert_eq!(*value.downcast::<u32>().unwrap(), 42);
+    let loaded = storage
+        .transaction_erased(Box::new(|tx| {
+            Ok(Box::new(tx.load_identity_state()) as Box<dyn std::any::Any + Send>)
+        }))
+        .await
+        .unwrap();
+    let loaded = *loaded.downcast::<Option<crate::IdentityState>>().unwrap();
+    assert_eq!(loaded.unwrap().public_key, Some(identity_public_key));
+}
+
+#[test]
+fn test_sensitive_storage_debug_is_redacted() {
+    let stream_counterparty = counterparty();
+    let link_state = EncryptedLinkStateRecord {
+        counterparty: stream_counterparty.clone(),
+        link_snapshot: Some(vec![1, 2, 3]),
+        handshake_snapshot: Some(vec![4, 5, 6]),
+        handshake_role: None,
+        generation: 0,
+        checkpointed_at: timestamp(),
+    };
+    let mut outbound = OutboundPrivateMessageRecord::from_new(
+        0,
+        outbound_private_message(stream_counterparty.clone()),
+    );
+    outbound.last_error = Some("outbound-secret".into());
+    let stream = PrivateStreamItemRecord::from_new(
+        0,
+        NewPrivateStreamItem::new(NewPrivateStreamItemDetails {
+            counterparty: stream_counterparty,
+            receive_batch_id: 0,
+            raw_json: r#"{"key":"secret"}"#.into(),
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.receipt_access".into()),
+            known_paykit_kind: Some("paykit.receipt_access".into()),
+            parse_status: PrivateStreamParseStatus::Valid,
+            parse_error: None,
+            received_at: timestamp(),
+        }),
+    );
+    let receipt_access = receipt_access_record(stream.counterparty.clone());
+    let receipt = receipt_record(receipt_access.counterparty.clone());
+    let reservation = payment_endpoint_reservation_record(receipt_access.counterparty.clone());
+    let public_endpoint = public_endpoint_record("btc-lightning-bolt11");
+    let contact_public_key = counterparty();
+    let contact = ContactRecord {
+        public_key: contact_public_key.clone(),
+        label: Some("contact-secret".into()),
+        profile: Some(crate::PaykitProfile {
+            display_name: Some("profile-secret".into()),
+            image_uri: None,
+            extra: None,
+        }),
+        profile_fetched_at: Some(timestamp()),
+        created_at: timestamp(),
+        updated_at: timestamp(),
+        public_contact_marker_status: crate::PublicationStatus::Published,
+        public_contact_published_at: Some(timestamp()),
+        public_contact_removed_at: None,
+        public_contact_last_error: Some("marker-secret".into()),
+    };
+    let storage_state = StorageState {
+        contact_records: HashMap::from([(contact_public_key.clone(), contact.clone())]),
+        public_endpoint_records: HashMap::from([(
+            public_endpoint.identifier.clone(),
+            public_endpoint.clone(),
+        )]),
+        ..StorageState::default()
+    };
+
+    let debug = format!(
+            "{link_state:?} {outbound:?} {stream:?} {receipt_access:?} {receipt:?} {reservation:?} {public_endpoint:?} {contact:?} {storage_state:?}"
+        );
+    assert!(debug.contains("<redacted:"));
+    assert!(!debug.contains("secret"));
+    assert!(!debug.contains("outbound-secret"));
+    assert!(!debug.contains("receipt-secret"));
+    assert!(!debug.contains("alice"));
+    assert!(!debug.contains(contact_public_key.as_str()));
+    assert!(!debug.contains("[1, 2, 3]"));
+}
+
+#[tokio::test]
+async fn test_transaction_commits_records() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let stream_item_id = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(timestamp()),
+                    last_private_receive_at: Some(timestamp()),
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_public_endpoint_record(public_endpoint_record("btc-lightning-bolt11"));
+                tx.save_payment_endpoint_reservation(payment_endpoint_reservation_record(
+                    counterparty.clone(),
+                ));
+                tx.insert_outbound_private_message(outbound_private_message(counterparty.clone()));
+
+                let stream_item_id = tx.insert_private_stream_item(NewPrivateStreamItem::new(
+                    NewPrivateStreamItemDetails {
+                        counterparty: counterparty.clone(),
+                        receive_batch_id: 7,
+                        raw_json: r#"{"version":1,"kind":"paykit.test"}"#.into(),
+                        parsed_version: Some(1),
+                        parsed_kind: Some("paykit.test".into()),
+                        known_paykit_kind: None,
+                        parse_status: PrivateStreamParseStatus::UnknownKind,
+                        parse_error: None,
+                        received_at: timestamp(),
+                    },
+                ));
+
+                tx.save_event_dedup_record(EventDedupRecord {
+                    counterparty: counterparty.clone(),
+                    event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+                    event_kind: "paykit.test".into(),
+                    payload_hash: "hash".into(),
+                    first_stream_item_id: stream_item_id,
+                    duplicate_stream_item_ids: Vec::new(),
+                    conflicting_stream_item_ids: Vec::new(),
+                });
+
+                tx.save_receipt_access_record(receipt_access_record(counterparty.clone()));
+                tx.save_receipt_record(receipt_record(counterparty));
+
+                Ok(stream_item_id)
+            }
+        })
+        .await
+        .unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    assert_eq!(stream_item_id, 0);
+    assert_eq!(
+        snapshot.linked_peers[&counterparty].state,
+        LinkedPeerState::Linked
+    );
+    assert_eq!(snapshot.public_endpoint_records.len(), 1);
+    assert_eq!(snapshot.payment_endpoint_reservations.len(), 1);
+    assert_eq!(snapshot.outbound_private_messages.len(), 1);
+    assert_eq!(snapshot.private_stream_items.len(), 1);
+    assert_eq!(snapshot.event_dedup_records.len(), 1);
+    assert_eq!(snapshot.receipt_access_records.len(), 1);
+    assert_eq!(snapshot.receipt_records.len(), 1);
+    assert_eq!(snapshot.next_private_stream_item_id, 1);
+    assert_eq!(snapshot.next_outbound_private_message_id, 1);
+}
+
+#[tokio::test]
+async fn test_save_outbound_private_message_rejects_missing_record() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let result: Result<()> = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_outbound_private_message(OutboundPrivateMessageRecord {
+                    outbound_message_id: 99,
+                    counterparty,
+                    kind: "paykit.private_payment_list".into(),
+                    raw_json:
+                        r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#
+                            .into(),
+                    status: OutboundPrivateMessageStatus::Pending,
+                    attempt_count: 0,
+                    created_at: timestamp(),
+                    updated_at: timestamp(),
+                    last_attempt_at: None,
+                    sent_at: None,
+                    last_error: None,
+                })
+            }
+        })
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Storage { .. })));
+    assert!(storage
+        .snapshot()
+        .unwrap()
+        .outbound_private_messages
+        .is_empty());
+}
+
+#[tokio::test]
+async fn test_invalid_outbound_private_message_does_not_block_later_records() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let (first, second) = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let first = tx.insert_outbound_private_message(outbound_private_message(
+                    counterparty.clone(),
+                ));
+                let second =
+                    tx.insert_outbound_private_message(outbound_private_message(counterparty));
+                Ok((first, second))
+            }
+        })
+        .await
+        .unwrap();
+    storage
+        .transaction({
+            let invalid =
+                mark_outbound_invalid(first, "invalid private message JSON".into(), timestamp());
+            move |tx| {
+                tx.save_outbound_private_message(invalid)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let claimed = claim_next_outbound_private_message(
+        &storage,
+        &counterparty,
+        timestamp(),
+        timestamp() - chrono::Duration::seconds(60),
+        timestamp() - chrono::Duration::seconds(60),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(claimed.outbound_message_id, second.outbound_message_id);
+    assert_eq!(claimed.status, OutboundPrivateMessageStatus::Sending);
+    let queued = queued_outbound_private_messages(&storage, &counterparty)
+        .await
+        .unwrap();
+    assert_eq!(queued.len(), 1);
+    assert_eq!(queued[0].outbound_message_id, second.outbound_message_id);
+}
+
+#[tokio::test]
+async fn test_private_payment_list_queue_sends_only_latest_state() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let (first, second) = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let first = tx.insert_outbound_private_message(outbound_private_message(
+                    counterparty.clone(),
+                ));
+                let second =
+                    tx.insert_outbound_private_message(outbound_private_message(counterparty));
+                Ok((first, second))
+            }
+        })
+        .await
+        .unwrap();
+
+    let claimed = claim_next_outbound_private_message(
+        &storage,
+        &counterparty,
+        timestamp(),
+        timestamp() - chrono::Duration::seconds(60),
+        timestamp() - chrono::Duration::seconds(60),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(claimed.outbound_message_id, second.outbound_message_id);
+    assert_eq!(claimed.status, OutboundPrivateMessageStatus::Sending);
+    let snapshot = storage.snapshot().unwrap();
+    let first = snapshot
+        .outbound_private_messages
+        .iter()
+        .find(|message| message.outbound_message_id == first.outbound_message_id)
+        .unwrap();
+    assert_eq!(first.status, OutboundPrivateMessageStatus::Superseded);
+}
+
+#[tokio::test]
+async fn test_private_payment_list_queue_reclaims_stale_sending_before_newer_list() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let (first, second) = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut first = tx.insert_outbound_private_message(outbound_private_message(
+                    counterparty.clone(),
+                ));
+                first.status = OutboundPrivateMessageStatus::Sending;
+                first.last_attempt_at = Some(timestamp() - chrono::Duration::seconds(120));
+                tx.save_outbound_private_message(first.clone())?;
+                let second =
+                    tx.insert_outbound_private_message(outbound_private_message(counterparty));
+                Ok((first, second))
+            }
+        })
+        .await
+        .unwrap();
+
+    let claimed = claim_next_outbound_private_message(
+        &storage,
+        &counterparty,
+        timestamp(),
+        timestamp() - chrono::Duration::seconds(60),
+        timestamp() - chrono::Duration::seconds(60),
+    )
+    .await
+    .unwrap();
+
+    let claimed = claimed.unwrap();
+    assert_eq!(claimed.outbound_message_id, first.outbound_message_id);
+    assert_eq!(claimed.status, OutboundPrivateMessageStatus::Sending);
+    assert_eq!(claimed.attempt_count, 1);
+    let snapshot = storage.snapshot().unwrap();
+    let first = snapshot
+        .outbound_private_messages
+        .iter()
+        .find(|message| message.outbound_message_id == first.outbound_message_id)
+        .unwrap();
+    assert_eq!(first.status, OutboundPrivateMessageStatus::Sending);
+    let second = snapshot
+        .outbound_private_messages
+        .iter()
+        .find(|message| message.outbound_message_id == second.outbound_message_id)
+        .unwrap();
+    assert_eq!(second.status, OutboundPrivateMessageStatus::Pending);
+}
+
+#[tokio::test]
+async fn test_event_message_queue_preserves_fifo() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let (first, second) = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let first = tx.insert_outbound_private_message(outbound_payment_request_message(
+                    counterparty.clone(),
+                ));
+                let second = tx.insert_outbound_private_message(outbound_payment_request_message(
+                    counterparty,
+                ));
+                Ok((first, second))
+            }
+        })
+        .await
+        .unwrap();
+
+    let claimed = claim_next_outbound_private_message(
+        &storage,
+        &counterparty,
+        timestamp(),
+        timestamp() - chrono::Duration::seconds(60),
+        timestamp() - chrono::Duration::seconds(60),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(claimed.outbound_message_id, first.outbound_message_id);
+    assert_eq!(claimed.status, OutboundPrivateMessageStatus::Sending);
+    let queued = queued_outbound_private_messages(&storage, &counterparty)
+        .await
+        .unwrap();
+    assert!(queued
+        .iter()
+        .any(|message| message.outbound_message_id == second.outbound_message_id));
+}
+
+#[tokio::test]
+async fn test_peer_link_operation_lease_blocks_until_released() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let first = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp(),
+                    timestamp() + chrono::Duration::seconds(60),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let blocked = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp(),
+                    timestamp() + chrono::Duration::seconds(60),
+                ))
+            }
+        })
+        .await
+        .unwrap();
+    assert!(blocked.is_none());
+
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.release_peer_link_operation(&counterparty, first.lease_id);
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let second = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp(),
+                    timestamp() + chrono::Duration::seconds(60),
+                ))
+            }
+        })
+        .await
+        .unwrap();
+
+    assert!(second.is_some());
+}
+
+#[tokio::test]
+async fn test_clear_identity_scoped_state_preserves_identity_only() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let identity = IdentityState {
+        public_key: Some(counterparty.clone()),
+        capability: crate::PubkyIdentityCapability::PrivateLinkCapable,
+        local_secret_available: true,
+        initialized_at: timestamp(),
+        sign_out_generation: 1,
+    };
+
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let identity = identity.clone();
+            move |tx| {
+                tx.save_identity_state(identity);
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(timestamp()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_public_endpoint_record(public_endpoint_record("btc-lightning-bolt11"));
+                tx.save_payment_endpoint_reservation(payment_endpoint_reservation_record(
+                    counterparty.clone(),
+                ));
+                tx.insert_outbound_private_message(outbound_private_message(counterparty.clone()));
+                tx.insert_private_stream_item(NewPrivateStreamItem::new(
+                    NewPrivateStreamItemDetails {
+                        counterparty: counterparty.clone(),
+                        receive_batch_id: 0,
+                        raw_json: r#"{"version":1,"kind":"paykit.test"}"#.into(),
+                        parsed_version: Some(1),
+                        parsed_kind: Some("paykit.test".into()),
+                        known_paykit_kind: None,
+                        parse_status: PrivateStreamParseStatus::UnknownKind,
+                        parse_error: None,
+                        received_at: timestamp(),
+                    },
+                ));
+                tx.save_receipt_access_record(receipt_access_record(counterparty.clone()));
+                tx.save_receipt_record(receipt_record(counterparty));
+                tx.clear_identity_scoped_state();
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    assert_eq!(snapshot.identity_state, Some(identity));
+    assert!(snapshot.linked_peers.is_empty());
+    assert!(snapshot.public_endpoint_records.is_empty());
+    assert!(snapshot.payment_endpoint_reservations.is_empty());
+    assert!(snapshot.encrypted_link_states.is_empty());
+    assert!(snapshot.outbound_private_messages.is_empty());
+    assert!(snapshot.private_stream_items.is_empty());
+    assert!(snapshot.event_dedup_records.is_empty());
+    assert!(snapshot.receipt_access_records.is_empty());
+    assert!(snapshot.receipt_records.is_empty());
+}
+
+#[tokio::test]
+async fn test_clear_private_identity_scoped_state_preserves_public_endpoints() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let identity = IdentityState {
+        public_key: Some(counterparty.clone()),
+        capability: crate::PubkyIdentityCapability::PrivateLinkCapable,
+        local_secret_available: true,
+        initialized_at: timestamp(),
+        sign_out_generation: 1,
+    };
+
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let identity = identity.clone();
+            move |tx| {
+                tx.save_identity_state(identity);
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(timestamp()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_public_endpoint_record(public_endpoint_record("btc-lightning-bolt11"));
+                tx.save_payment_endpoint_reservation(payment_endpoint_reservation_record(
+                    counterparty.clone(),
+                ));
+                tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp(),
+                    timestamp() + chrono::Duration::seconds(60),
+                );
+                tx.allocate_receive_batch_id();
+                tx.insert_outbound_private_message(outbound_private_message(counterparty.clone()));
+                tx.insert_private_stream_item(NewPrivateStreamItem::new(
+                    NewPrivateStreamItemDetails {
+                        counterparty: counterparty.clone(),
+                        receive_batch_id: 0,
+                        raw_json: r#"{"version":1,"kind":"paykit.test"}"#.into(),
+                        parsed_version: Some(1),
+                        parsed_kind: Some("paykit.test".into()),
+                        known_paykit_kind: None,
+                        parse_status: PrivateStreamParseStatus::UnknownKind,
+                        parse_error: None,
+                        received_at: timestamp(),
+                    },
+                ));
+                tx.save_receipt_access_record(receipt_access_record(counterparty.clone()));
+                tx.save_receipt_record(receipt_record(counterparty));
+                tx.clear_private_identity_scoped_state();
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    assert_eq!(snapshot.identity_state, Some(identity));
+    assert_eq!(snapshot.public_endpoint_records.len(), 1);
+    assert!(snapshot.payment_endpoint_reservations.is_empty());
+    assert!(snapshot.linked_peers.is_empty());
+    assert!(snapshot.encrypted_link_states.is_empty());
+    assert!(snapshot.outbound_private_messages.is_empty());
+    assert!(snapshot.private_stream_items.is_empty());
+    assert!(snapshot.event_dedup_records.is_empty());
+    assert!(snapshot.receipt_access_records.is_empty());
+    assert!(snapshot.receipt_records.is_empty());
+    assert_eq!(snapshot.next_peer_link_operation_lease_id, 1);
+    assert_eq!(snapshot.next_outbound_private_message_id, 1);
+    assert_eq!(snapshot.next_receive_batch_id, 1);
+    assert_eq!(snapshot.next_private_stream_item_id, 1);
+}
+
+#[tokio::test]
+async fn test_peer_link_operation_lease_can_be_reclaimed_after_expiry() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let first = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp(),
+                    timestamp() + chrono::Duration::seconds(10),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let second = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp() + chrono::Duration::seconds(11),
+                    timestamp() + chrono::Duration::seconds(71),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_ne!(first.lease_id, second.lease_id);
+    assert_eq!(
+        storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+            })
+            .await
+            .unwrap(),
+        Some(second)
+    );
+}
+
+#[tokio::test]
+async fn test_peer_link_operation_stale_release_keeps_newer_lease() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let first = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp(),
+                    timestamp() + chrono::Duration::seconds(10),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let second = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp() + chrono::Duration::seconds(11),
+                    timestamp() + chrono::Duration::seconds(71),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.release_peer_link_operation(&counterparty, first.lease_id);
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+            })
+            .await
+            .unwrap(),
+        Some(second)
+    );
+}
+
+#[tokio::test]
+async fn test_stale_peer_link_lease_cannot_overwrite_outbound_status() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let (record, first_lease) = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let record = tx.insert_outbound_private_message(outbound_private_message(
+                    counterparty.clone(),
+                ));
+                let lease = tx
+                    .claim_peer_link_operation(
+                        &counterparty,
+                        timestamp(),
+                        timestamp() + chrono::Duration::seconds(10),
+                    )
+                    .unwrap();
+                Ok((record, lease))
+            }
+        })
+        .await
+        .unwrap();
+    let active_lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx
+                    .claim_peer_link_operation(
+                        &counterparty,
+                        timestamp() + chrono::Duration::seconds(11),
+                        timestamp() + chrono::Duration::seconds(71),
+                    )
+                    .unwrap())
+            }
+        })
+        .await
+        .unwrap();
+    let sent = mark_outbound_sent(record.clone(), timestamp() + chrono::Duration::seconds(12));
+    storage
+        .transaction({
+            let sent = sent.clone();
+            let active_lease = active_lease.clone();
+            move |tx| {
+                require_peer_link_operation_lease(tx, &active_lease)?;
+                tx.save_outbound_private_message(sent)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let failed = mark_outbound_failed(
+        record,
+        "late failed send".into(),
+        timestamp() + chrono::Duration::seconds(13),
+    );
+    let stale_result: Result<()> = storage
+        .transaction({
+            let failed = failed.clone();
+            move |tx| {
+                require_peer_link_operation_lease(tx, &first_lease)?;
+                tx.save_outbound_private_message(failed)?;
+                Ok(())
+            }
+        })
+        .await;
+
+    assert!(matches!(stale_result, Err(PaykitSdkError::Policy(_))));
+    let snapshot = storage.snapshot().unwrap();
+    assert_eq!(
+        snapshot.outbound_private_messages[0].status,
+        OutboundPrivateMessageStatus::Sent
+    );
+    assert!(snapshot.outbound_private_messages[0].last_error.is_none());
+}
+
+#[tokio::test]
+async fn test_transaction_rolls_back_on_error() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let result: Result<()> = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(timestamp()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+
+                Err(PaykitSdkError::Storage {
+                    context: "forced rollback".into(),
+                    source: None,
+                })
+            }
+        })
+        .await;
+
+    assert!(result.is_err());
+    let snapshot = storage.snapshot().unwrap();
+    assert!(snapshot.linked_peers.is_empty());
+}


### PR DESCRIPTION
## Summary

Replacement stack PR 1/5 for the Paykit SDK split.

Adds the SDK domain/storage foundation in the final module layout:

- `paykit-sdk` crate and public root facade
- adapter traits, config, identity, errors, publication status
- storage adapter contract, in-memory storage, queue helpers, and storage records
- SDK domain records/helpers for contacts, endpoints, linked peers, outbound private messages, private stream items, Payment Requests, receipts, endpoint reservations, backup state, and recovery state
- low-level `paykit-lib` support needed by the SDK, including recovery markers, private receive classification, and paginated public endpoint listing

The runtime workflow methods and full test suite are added in later stacked PRs.

## Stack

1. This PR: SDK domain/storage foundation
2. Runtime workflows
3. Domain/storage tests
4. Runtime workflow tests
5. Docs and bindings plan

The final stack branch was verified to match draft reference PR #55 exactly.

## Verification

- `cargo fmt --check`
- `cargo check -p paykit-sdk`
