### PR TITLE
Add SDK runtime workflows

### DIFF
--- a/paykit-sdk/src/runtime.rs
+++ b/paykit-sdk/src/runtime.rs
@@ -1,9 +1,119 @@
-use chrono::{DateTime, Utc};
+use std::{
+    cmp::Reverse,
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex},
+};
+
+use chrono::{DateTime, Duration as ChronoDuration, SecondsFormat, Utc};
+use paykit_lib::{
+    BillingPeriod, EncryptedLinkRecoveryMarker, EventId, PaymentEndpointIdentifier, PaymentProof,
+    PaymentRequest, PaymentRequestAcceptance, PaymentRequestCancellation, PaymentRequestId,
+    PaymentRequestRejection, PaymentRequestTerms, PrivateMessageKind, ReceiptDraft,
+};
+use pubky::{errors::RequestError, Error as PubkyError, StatusCode};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+#[cfg(test)]
+use paykit_lib::PaymentRequestEvent;
 
 use crate::{
-    IdentityStatus, PaykitSdkConfig, PaymentAdapter, PubkySessionProvider, Result, StorageAdapter,
+    backup::{
+        export_backup_state as export_sdk_backup_state,
+        restore_backup_state_with_identity as restore_sdk_backup_state, RestoreReport,
+        SdkBackupState,
+    },
+    config::{
+        EncryptedLinkRecoveryMarkerPolicy, EndpointManagementScope, PaykitSdkConfig,
+        PublicContactSharingPolicy,
+    },
+    contacts::{
+        parse_profile_json, parse_pubky_profile_json, paykit_blob_path,
+        paykit_blob_path_from_uri_or_path, paykit_blob_uri, profile_json,
+        pubky_follow_keys_from_follow_entries, public_contact_json, ContactPaymentResolution,
+        ContactPaymentResolutionPrivateState, ContactPaymentResolutionRequest,
+        ContactPaymentResolutionStatus, ContactProfileResolution, ContactRecord, ContactUpdate,
+        PaykitBlobRecord, PaykitProfile, PaykitProfileRecord, PubkyProfileRecord,
+        ResolvedPaymentEndpoint, PUBKY_FOLLOWS_PATH_PREFIX, PUBKY_PROFILE_PATH,
+    },
+    endpoint_reservations::{
+        expired_outbound_reservation_cancellations, invalid_private_list_reservation_cancellations,
+        queue_private_payment_list_with_reservations_with_link_lease, reservation_payload_hash,
+        unattempted_superseded_reservation_cancellations,
+        PaymentEndpointReservationCancellationRecord,
+    },
+    endpoints::{
+        failed_record, normalize_receiving_details, pending_publication_record,
+        pending_removal_record, published_record, removed_record, EndpointSyncChange,
+        EndpointSyncReport,
+    },
+    identity::{IdentityState, IdentityStatus, PubkyIdentityCapability},
+    linked_peers::{
+        mark_recovery_required_for_marker_in_transaction, mark_recovery_required_in_transaction,
+        mark_recovery_required_with_lease, save_link_handshake_state_if_generation_with_lease,
+        save_link_handshake_state_with_lease, save_linked_peer_link_state_if_generation_with_lease,
+        save_linked_peer_state_with_lease, EncryptedLinkHandshakeRole, LinkedPeerHandshakeReport,
+        LinkedPeerState,
+    },
+    outbound_private::{
+        claim_next_outbound_private_message_with_peer_lease, mark_outbound_failed,
+        mark_outbound_invalid, mark_outbound_recovery_required, mark_outbound_sent,
+        queued_outbound_private_messages, validate_queued_outbound_private_message,
+        OutboundPrivateCounterpartySendReport, OutboundPrivateSendFailure,
+        OutboundPrivateSendReport, RecoveryMarkerPublishFailure, ReservationCleanupFailure,
+    },
+    payment_requests::{
+        enqueue_payment_proof as enqueue_payment_proof_message,
+        enqueue_payment_request as enqueue_payment_request_message,
+        enqueue_payment_request_acceptance as enqueue_payment_request_acceptance_message,
+        enqueue_payment_request_cancellation as enqueue_payment_request_cancellation_message,
+        enqueue_payment_request_rejection as enqueue_payment_request_rejection_message,
+        payment_request_records as derive_payment_request_records,
+        received_payment_request_records as derive_received_payment_request_records,
+        request_from_record, PaymentRequestFilter, PaymentRequestLifecycleState,
+        PaymentRequestLocalRole, PaymentRequestRecord,
+    },
+    private_lists::{
+        current_private_payment_list as load_current_private_payment_list,
+        enqueue_private_payment_list_with_link_lease as enqueue_private_payment_list_message_with_link_lease,
+    },
+    private_stream::{
+        persist_private_stream_batch_with_link_lease, PrivateStreamCounterpartyIntakeReport,
+        PrivateStreamIntakeReport,
+    },
+    publication::PublicationStatus,
+    receipts::{
+        decrypt_receipt_record_from_access, enqueue_receipt_access_for_issuance,
+        fetch_encrypted_receipt_json, receipt_issuance_record as load_receipt_issuance_record,
+        receipt_issuance_record_by_receipt_id as load_receipt_issuance_record_by_receipt_id,
+        receipt_issuance_record_matches_draft,
+        receipt_issuance_records as load_receipt_issuance_records, receipt_record_matches_access,
+        store_encrypted_receipt_json, ReceiptAccessRecord, ReceiptAccessView,
+        ReceiptIssuanceRecord, ReceiptIssuanceStatus, ReceiptIssuanceView, ReceiptRecord,
+        ReceiptRetrievalStatus,
+    },
+    recovery::{recovery_marker_report, EncryptedLinkRecoveryMarkerReport},
+    storage::{
+        outbound_private_queue_head_is_claimable, EncryptedLinkStateRecord, LinkedPeerRecord,
+        OutboundPrivateMessageRecord, PeerLinkOperationLease, StorageAdapter,
+    },
+    PaykitSdkError, PaymentAdapter, PaymentEndpointCandidate, PaymentEndpointReservation,
+    PaymentEndpointReservationCancellation, PaymentEndpointSelectionRequest, PaymentEndpointSource,
+    PrivatePaymentListView, PubkyPublicKey, PubkySessionAccess, PubkySessionProvider,
+    ReceivingDetail, ReceivingDetailScope, Result,
 };
+
+mod backup;
+mod contacts;
+mod encrypted_links;
+mod outbound_private;
+mod payment_requests;
+mod payment_resolution;
+mod private_lists;
+mod private_stream;
+mod public_endpoints;
+mod receipts;
+mod recovery;
 
 /// Clock abstraction used by SDK workflows and tests.
 pub trait Clock: Clone + Send + Sync + 'static {
@@ -37,6 +147,19 @@ pub struct PaykitSdk<S, K, P, C = SystemClock> {
     payment: P,
     config: PaykitSdkConfig,
     clock: C,
+    identity_operation_in_progress: Arc<Mutex<bool>>,
+}
+
+struct RuntimeOperationGuard {
+    in_progress: Arc<Mutex<bool>>,
+}
+
+impl Drop for RuntimeOperationGuard {
+    fn drop(&mut self) {
+        if let Ok(mut in_progress) = self.in_progress.lock() {
+            *in_progress = false;
+        }
+    }
 }
 
 impl<S, K, P> PaykitSdk<S, K, P, SystemClock>
@@ -78,31 +201,355 @@ where
             payment,
             config,
             clock,
+            identity_operation_in_progress: Arc::new(Mutex::new(false)),
         })
     }
 
-    /// Access the storage adapter used by this SDK instance.
-    pub fn storage(&self) -> &S {
-        &self.storage
+    fn claim_identity_operation(&self, context: &str) -> Result<RuntimeOperationGuard> {
+        let mut in_progress = self
+            .identity_operation_in_progress
+            .lock()
+            .map_err(|_| PaykitSdkError::Policy("identity operation lock poisoned".into()))?;
+        if *in_progress {
+            return Err(PaykitSdkError::Policy(format!(
+                "cannot {context} while another identity-scoped operation is in progress"
+            )));
+        }
+        *in_progress = true;
+        Ok(RuntimeOperationGuard {
+            in_progress: Arc::clone(&self.identity_operation_in_progress),
+        })
     }
 
-    /// Access the Pubky session provider used by this SDK instance.
-    pub fn pubky_session_provider(&self) -> &K {
-        &self.pubky
+    #[cfg(test)]
+    fn with_clock(storage: S, pubky: K, payment: P, config: PaykitSdkConfig, clock: C) -> Self {
+        Self::try_with_clock(storage, pubky, payment, config, clock)
+            .expect("test PaykitSdkConfig must be valid")
     }
 
-    /// Access the payment adapter used by this SDK instance.
-    pub fn payment_adapter(&self) -> &P {
-        &self.payment
+    /// Initialize durable SDK identity state.
+    pub async fn initialize(&self) -> Result<InitializationReport> {
+        let _identity_guard = self.claim_identity_operation("initialize")?;
+        let (session, state) = self.load_session_access_and_refresh_identity().await?;
+        let live_session_available = session.is_some();
+        let private_link_capable = session
+            .as_ref()
+            .is_some_and(PubkySessionAccess::private_link_capable);
+
+        Ok(InitializationReport {
+            identity: IdentityStatus::from_state(
+                &state,
+                live_session_available,
+                private_link_capable,
+            ),
+            live_session_available,
+        })
     }
 
-    /// Access the SDK configuration.
+    /// Clear live Pubky session access and SDK-managed identity-scoped state.
+    ///
+    /// This is an explicit destructive sign-out. Apps that want to restore the
+    /// same user's private Paykit state later should export and persist an SDK
+    /// backup before calling this method.
+    ///
+    /// Temporary session unavailability should be represented by
+    /// [`PubkySessionProvider::load_session_access`] returning `None`; that
+    /// preserves stored SDK state and only blocks Pubky-backed workflows.
+    pub async fn sign_out(&self) -> Result<IdentityStatus> {
+        let _identity_guard = self.claim_identity_operation("sign out")?;
+        self.pubky.clear_session_access().await?;
+
+        let now = self.clock.now();
+        let state = self
+            .storage
+            .transaction(move |tx| {
+                let previous = tx.load_identity_state();
+                let previous_generation = previous
+                    .as_ref()
+                    .map(|state| state.sign_out_generation)
+                    .unwrap_or_default();
+                let was_signed_in = previous.as_ref().is_some_and(|state| {
+                    state.public_key.is_some()
+                        || state.capability != PubkyIdentityCapability::SignedOut
+                });
+                let generation = if was_signed_in {
+                    previous_generation.saturating_add(1)
+                } else {
+                    previous_generation
+                };
+
+                tx.clear_identity_scoped_state();
+                let state = IdentityState {
+                    public_key: None,
+                    local_secret_available: false,
+                    capability: PubkyIdentityCapability::SignedOut,
+                    initialized_at: now,
+                    sign_out_generation: generation,
+                };
+                tx.save_identity_state(state.clone());
+                Ok(state)
+            })
+            .await?;
+
+        Ok(IdentityStatus::from_state(&state, false, false))
+    }
+
+    async fn load_session_access_and_refresh_identity(
+        &self,
+    ) -> Result<(Option<PubkySessionAccess>, IdentityState)> {
+        let session = self.pubky.load_session_access().await?;
+        let now = self.clock.now();
+
+        let Some(session_access) = session.as_ref() else {
+            let state = self
+                .storage
+                .transaction(move |tx| {
+                    if let Some(previous) = tx.load_identity_state() {
+                        return Ok(previous);
+                    }
+
+                    let state = IdentityState {
+                        public_key: None,
+                        local_secret_available: false,
+                        capability: PubkyIdentityCapability::SignedOut,
+                        initialized_at: now,
+                        sign_out_generation: 0,
+                    };
+                    tx.save_identity_state(state.clone());
+                    Ok(state)
+                })
+                .await?;
+
+            return Ok((session, state));
+        };
+
+        let public_key = Some(session_access.public_key()?);
+        let capability = session_access.capability();
+        let state = self
+            .storage
+            .transaction(move |tx| {
+                let previous = tx.load_identity_state();
+                let identity_missing = previous.is_none();
+                let previous_generation = previous
+                    .as_ref()
+                    .map(|state| state.sign_out_generation)
+                    .unwrap_or_default();
+                let identity_changed = previous
+                    .as_ref()
+                    .is_some_and(|state| state.public_key != public_key);
+                let generation = if identity_changed {
+                    previous_generation.saturating_add(1)
+                } else {
+                    previous_generation
+                };
+
+                if identity_missing || identity_changed {
+                    tx.clear_identity_scoped_state();
+                }
+
+                let state = IdentityState {
+                    public_key,
+                    local_secret_available: capability
+                        == PubkyIdentityCapability::PrivateLinkCapable,
+                    capability,
+                    initialized_at: now,
+                    sign_out_generation: generation,
+                };
+                tx.save_identity_state(state.clone());
+                Ok(state)
+            })
+            .await?;
+
+        Ok((session, state))
+    }
+
+    async fn require_initialized_identity(&self, context: &str) -> Result<PubkyPublicKey> {
+        self.storage
+            .transaction(|tx| {
+                tx.load_identity_state()
+                    .and_then(|state| state.public_key)
+                    .ok_or_else(|| PaykitSdkError::Identity {
+                        context: format!("cannot {context} without an initialized Pubky identity"),
+                        source: None,
+                    })
+            })
+            .await
+    }
+
+    async fn load_session_access_for_initialized_identity(
+        &self,
+        context: &str,
+    ) -> Result<PubkySessionAccess> {
+        let expected_public_key = self.require_initialized_identity(context).await?;
+        let session_access =
+            self.pubky
+                .load_session_access()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: format!("cannot {context} without an active Pubky session"),
+                    source: None,
+                })?;
+        let actual_public_key = session_access.public_key()?;
+        if actual_public_key != expected_public_key {
+            return Err(PaykitSdkError::Identity {
+                context: format!(
+                    "cannot {context} because active Pubky session does not match initialized identity"
+                ),
+                source: None,
+            });
+        }
+        Ok(session_access)
+    }
+
+    /// Return the last persisted identity status, if initialized.
+    pub async fn identity_status(&self) -> Result<Option<IdentityStatus>> {
+        let session = self.pubky.load_session_access().await?;
+        let Some(state) = self.storage.load_identity_state().await? else {
+            return Ok(None);
+        };
+        let matching_session = session
+            .as_ref()
+            .filter(|session| session.public_key().ok().as_ref() == state.public_key.as_ref());
+        Ok(Some(IdentityStatus::from_state(
+            &state,
+            matching_session.is_some(),
+            matching_session.is_some_and(PubkySessionAccess::private_link_capable),
+        )))
+    }
+
+    /// Access SDK configuration.
     pub fn config(&self) -> &PaykitSdkConfig {
         &self.config
     }
 
-    /// Access the SDK clock.
-    pub fn clock(&self) -> &C {
-        &self.clock
+    /// List locally tracked Linked Peer records.
+    pub async fn linked_peers(&self) -> Result<Vec<LinkedPeerRecord>> {
+        self.storage
+            .transaction(|tx| {
+                let mut records = tx
+                    .export_storage_state()
+                    .linked_peers
+                    .into_values()
+                    .collect::<Vec<_>>();
+                records.sort_by(|left, right| {
+                    left.counterparty.as_str().cmp(right.counterparty.as_str())
+                });
+                Ok(records)
+            })
+            .await
     }
+
+    fn ensure_recovery_marker_publishing_enabled(&self) -> Result<()> {
+        if self.config.encrypted_link_recovery_markers
+            == EncryptedLinkRecoveryMarkerPolicy::Disabled
+        {
+            Err(PaykitSdkError::Policy(
+                "Encrypted Link recovery marker publishing is disabled".into(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+async fn fetch_public_text(
+    storage: &pubky::PublicStorage,
+    public_key: &PubkyPublicKey,
+    path: &str,
+    context: &'static str,
+) -> Result<Option<String>> {
+    let addr = format!("{public_key}{path}");
+    match storage.get(addr).await {
+        Ok(resp) => {
+            let bytes = resp
+                .bytes()
+                .await
+                .map_err(|err| PaykitSdkError::Transport {
+                    context: context.into(),
+                    source: Some(err.into()),
+                })?;
+            String::from_utf8(bytes.to_vec())
+                .map(Some)
+                .map_err(|err| PaykitSdkError::Protocol(format!("{context}: invalid UTF-8: {err}")))
+        }
+        Err(err) if is_pubky_not_found(&err) => Ok(None),
+        Err(err) => Err(map_pubky_transport_error(context, err)),
+    }
+}
+
+async fn fetch_public_file_uri(
+    storage: &pubky::PublicStorage,
+    uri: &str,
+    context: &'static str,
+) -> Result<Option<Vec<u8>>> {
+    let resource = uri
+        .parse::<pubky::PubkyResource>()
+        .map_err(|err| PaykitSdkError::Protocol(format!("{context}: invalid Pubky URI: {err}")))?;
+    match storage.get(resource).await {
+        Ok(resp) => resp
+            .bytes()
+            .await
+            .map(|bytes| Some(bytes.to_vec()))
+            .map_err(|err| PaykitSdkError::Transport {
+                context: context.into(),
+                source: Some(err.into()),
+            }),
+        Err(err) if is_pubky_not_found(&err) => Ok(None),
+        Err(err) => Err(map_pubky_transport_error(context, err)),
+    }
+}
+
+async fn list_public_resources(
+    storage: &pubky::PublicStorage,
+    public_key: &PubkyPublicKey,
+    path: &str,
+    context: &'static str,
+) -> Result<Vec<pubky::PubkyResource>> {
+    const LIST_PAGE_LIMIT: u16 = 100;
+
+    let addr = format!("{public_key}{path}");
+    let mut entries = Vec::new();
+    let mut cursor = None::<String>;
+    loop {
+        let mut builder = storage
+            .list(&addr)
+            .map_err(|err| map_pubky_transport_error(context, err))?
+            .shallow(true)
+            .limit(LIST_PAGE_LIMIT);
+        if let Some(cursor) = cursor.as_deref() {
+            builder = builder.cursor(cursor);
+        }
+        let page = match builder.send().await {
+            Ok(page) => page,
+            Err(err) if is_pubky_not_found(&err) => return Ok(entries),
+            Err(err) => return Err(map_pubky_transport_error(context, err)),
+        };
+        if page.is_empty() {
+            break;
+        }
+        let page_len = page.len();
+        cursor = page
+            .last()
+            .map(|entry| format!("{}{}", entry.owner.z32(), entry.path.as_str()));
+        entries.extend(page);
+        if page_len < LIST_PAGE_LIMIT as usize {
+            break;
+        }
+    }
+    Ok(entries)
+}
+
+fn map_pubky_transport_error(context: &'static str, err: PubkyError) -> PaykitSdkError {
+    PaykitSdkError::Transport {
+        context: context.into(),
+        source: Some(err.into()),
+    }
+}
+
+fn is_pubky_not_found(err: &PubkyError) -> bool {
+    matches!(
+        err,
+        PubkyError::Request(RequestError::Server { status, .. })
+            if *status == StatusCode::NOT_FOUND || *status == StatusCode::GONE
+    )
 }

--- a/paykit-sdk/src/runtime/backup.rs
+++ b/paykit-sdk/src/runtime/backup.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Export SDK-managed backup state.
+    pub async fn export_backup_state(&self) -> Result<SdkBackupState> {
+        export_sdk_backup_state(&self.storage).await
+    }
+
+    /// Restore SDK-managed backup state.
+    pub async fn restore_backup_state(&self, mut backup: SdkBackupState) -> Result<RestoreReport> {
+        let _identity_guard = self.claim_identity_operation("restore backup")?;
+        let mut trusted_identity = None;
+        if backup.identity_public_key().is_some() || backup.has_identity_scoped_state() {
+            let session_access = self.validate_backup_restore_session(&backup).await?;
+            if let Some(identity_state) = backup.identity_state.as_mut() {
+                identity_state.capability = session_access.capability();
+                identity_state.local_secret_available = session_access.private_link_capable();
+            }
+            trusted_identity = Some(self.restore_validation_identity(&session_access).await?);
+        }
+        restore_sdk_backup_state(&self.storage, backup, trusted_identity).await
+    }
+
+    async fn validate_backup_restore_session(
+        &self,
+        backup: &SdkBackupState,
+    ) -> Result<PubkySessionAccess> {
+        let session_access =
+            self.pubky
+                .load_session_access()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context:
+                        "cannot restore identity-scoped backup without an active Pubky identity"
+                            .into(),
+                    source: None,
+                })?;
+        let local_public_key = session_access.public_key()?;
+        if backup.identity_public_key() != Some(&local_public_key) {
+            return Err(PaykitSdkError::Identity {
+                context: "backup identity does not match active Pubky identity".into(),
+                source: None,
+            });
+        }
+        if backup.has_private_identity_scoped_state()
+            && session_access.capability() != PubkyIdentityCapability::PrivateLinkCapable
+        {
+            return Err(PaykitSdkError::Identity {
+                context: "cannot restore private Paykit state without private-link capability"
+                    .into(),
+                source: None,
+            });
+        }
+        Ok(session_access)
+    }
+
+    async fn restore_validation_identity(
+        &self,
+        session_access: &PubkySessionAccess,
+    ) -> Result<IdentityState> {
+        let public_key = session_access.public_key()?;
+        let capability = session_access.capability();
+        let local_secret_available = session_access.private_link_capable();
+        let initialized_at = self.clock.now();
+        self.storage
+            .transaction(move |tx| {
+                if let Some(identity) = tx.load_identity_state() {
+                    if identity.public_key.as_ref() == Some(&public_key) {
+                        return Ok(identity);
+                    }
+                }
+                Ok(IdentityState {
+                    public_key: Some(public_key),
+                    capability,
+                    local_secret_available,
+                    initialized_at,
+                    sign_out_generation: 0,
+                })
+            })
+            .await
+    }
+}

--- a/paykit-sdk/src/runtime/contacts.rs
+++ b/paykit-sdk/src/runtime/contacts.rs
@@ -1,0 +1,489 @@
+use super::*;
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Save or update a local contact record.
+    pub async fn save_contact(&self, update: ContactUpdate) -> Result<ContactRecord> {
+        update.validate()?;
+        self.require_initialized_identity("save contact").await?;
+        let now = self.clock.now();
+        self.storage
+            .transaction(move |tx| {
+                let existing = tx.contact_record(&update.public_key);
+                let record = ContactRecord::from_update(update, existing, now);
+                tx.save_contact_record(record.clone());
+                Ok(record)
+            })
+            .await
+    }
+
+    /// Load one local contact record.
+    pub async fn contact_record(
+        &self,
+        public_key: &PubkyPublicKey,
+    ) -> Result<Option<ContactRecord>> {
+        self.require_initialized_identity("load contact").await?;
+        self.storage
+            .transaction(|tx| Ok(tx.contact_record(public_key)))
+            .await
+    }
+
+    /// List local contact records.
+    pub async fn contact_records(&self) -> Result<Vec<ContactRecord>> {
+        self.require_initialized_identity("list contacts").await?;
+        self.storage
+            .transaction(|tx| Ok(tx.contact_records()))
+            .await
+    }
+
+    /// Remove one local contact record.
+    pub async fn remove_contact(
+        &self,
+        public_key: &PubkyPublicKey,
+    ) -> Result<Option<ContactRecord>> {
+        self.require_initialized_identity("remove contact").await?;
+        self.storage
+            .transaction(|tx| {
+                let Some(existing) = tx.contact_record(public_key) else {
+                    return Ok(None);
+                };
+                if !existing.can_remove_locally() {
+                    return Err(PaykitSdkError::Policy(format!(
+                        "remove public contact marker before deleting contact {public_key}"
+                    )));
+                }
+                Ok(tx.remove_contact_record(public_key))
+            })
+            .await
+    }
+
+    /// Publish the local public Paykit profile.
+    ///
+    /// This writes only the configured Paykit Profile path. Use Paykit Blob
+    /// helpers for profile files stored under the configured blob prefix.
+    pub async fn publish_paykit_profile(
+        &self,
+        profile: PaykitProfile,
+    ) -> Result<PaykitProfileRecord> {
+        let json = profile_json(&profile)?;
+        let (session_access, _) = self.load_session_access_and_refresh_identity().await?;
+        let session_access = session_access.ok_or_else(|| PaykitSdkError::Identity {
+            context: "no Pubky session available for profile publication".into(),
+            source: None,
+        })?;
+        let path = self.config.paykit_profile_path();
+        session_access
+            .session
+            .storage()
+            .put(path.as_str(), json)
+            .await
+            .map_err(|err| map_pubky_transport_error("publish Paykit profile", err))?;
+        Ok(PaykitProfileRecord {
+            public_key: session_access.public_key()?,
+            profile,
+            path,
+            updated_at: self.clock.now(),
+        })
+    }
+
+    /// Fetch a public Paykit profile.
+    pub async fn fetch_paykit_profile(
+        &self,
+        public_key: PubkyPublicKey,
+    ) -> Result<Option<PaykitProfileRecord>> {
+        let public_storage =
+            self.pubky
+                .load_public_storage()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: "no Pubky public storage available for profile lookup".into(),
+                    source: None,
+                })?;
+        let path = self.config.paykit_profile_path();
+        let Some(raw_json) =
+            fetch_public_text(&public_storage, &public_key, &path, "fetch profile").await?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(PaykitProfileRecord {
+            public_key,
+            profile: parse_profile_json(&raw_json)?,
+            path,
+            updated_at: self.clock.now(),
+        }))
+    }
+
+    /// Publish a public blob under the configured Paykit blob prefix.
+    pub async fn publish_paykit_blob(
+        &self,
+        blob_name: String,
+        bytes: Vec<u8>,
+    ) -> Result<PaykitBlobRecord> {
+        let path = paykit_blob_path(&self.config.paykit_profile_blob_path_prefix(), &blob_name)?;
+        let size_bytes = bytes.len() as u64;
+        let (session_access, _) = self.load_session_access_and_refresh_identity().await?;
+        let session_access = session_access.ok_or_else(|| PaykitSdkError::Identity {
+            context: "no Pubky session available for Paykit blob publication".into(),
+            source: None,
+        })?;
+        session_access
+            .session
+            .storage()
+            .put(path.as_str(), bytes)
+            .await
+            .map_err(|err| map_pubky_transport_error("publish Paykit blob", err))?;
+        let public_key = session_access.public_key()?;
+        let uri = paykit_blob_uri(&public_key, &path);
+        Ok(PaykitBlobRecord {
+            public_key,
+            path,
+            uri,
+            size_bytes,
+            updated_at: self.clock.now(),
+        })
+    }
+
+    /// Delete a public blob from the configured Paykit blob prefix.
+    pub async fn delete_paykit_blob(&self, uri_or_path: &str) -> Result<()> {
+        let session_access = self
+            .load_session_access_for_initialized_identity("delete Paykit blob")
+            .await?;
+        let public_key = session_access.public_key()?;
+        let path = paykit_blob_path_from_uri_or_path(
+            &public_key,
+            &self.config.paykit_profile_blob_path_prefix(),
+            uri_or_path,
+        )?;
+        session_access
+            .session
+            .storage()
+            .delete(path.as_str())
+            .await
+            .map(|_| ())
+            .or_else(|err| {
+                if is_pubky_not_found(&err) {
+                    Ok(())
+                } else {
+                    Err(map_pubky_transport_error("delete Paykit blob", err))
+                }
+            })
+    }
+
+    /// Fetch a public `pubky://` file referenced by profile metadata.
+    pub async fn fetch_pubky_file(&self, uri: &str) -> Result<Option<Vec<u8>>> {
+        let public_storage =
+            self.pubky
+                .load_public_storage()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: "no Pubky public storage available for Pubky file fetch".into(),
+                    source: None,
+                })?;
+        fetch_public_file_uri(&public_storage, uri, "fetch Pubky file").await
+    }
+
+    /// Fetch a public `pubky://` text file referenced by profile metadata.
+    pub async fn fetch_pubky_text(&self, uri: &str) -> Result<Option<String>> {
+        let Some(bytes) = self.fetch_pubky_file(uri).await? else {
+            return Ok(None);
+        };
+        String::from_utf8(bytes).map(Some).map_err(|err| {
+            PaykitSdkError::Protocol(format!("fetch Pubky text: invalid UTF-8: {err}"))
+        })
+    }
+
+    /// Fetch a public Pubky app profile.
+    pub async fn fetch_pubky_profile(
+        &self,
+        public_key: PubkyPublicKey,
+    ) -> Result<Option<PubkyProfileRecord>> {
+        let public_storage =
+            self.pubky
+                .load_public_storage()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: "no Pubky public storage available for Pubky profile lookup".into(),
+                    source: None,
+                })?;
+        let Some(raw_json) = fetch_public_text(
+            &public_storage,
+            &public_key,
+            PUBKY_PROFILE_PATH,
+            "fetch Pubky profile",
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(PubkyProfileRecord {
+            public_key,
+            profile: parse_pubky_profile_json(&raw_json)?,
+            path: PUBKY_PROFILE_PATH.into(),
+            fetched_at: self.clock.now(),
+        }))
+    }
+
+    /// Fetch public Pubky app follows.
+    pub async fn fetch_pubky_follows(
+        &self,
+        public_key: PubkyPublicKey,
+    ) -> Result<Vec<PubkyPublicKey>> {
+        let public_storage =
+            self.pubky
+                .load_public_storage()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: "no Pubky public storage available for Pubky follows lookup".into(),
+                    source: None,
+                })?;
+        let entries = list_public_resources(
+            &public_storage,
+            &public_key,
+            PUBKY_FOLLOWS_PATH_PREFIX,
+            "fetch Pubky follows",
+        )
+        .await?;
+        Ok(pubky_follow_keys_from_follow_entries(entries))
+    }
+
+    /// Resolve a contact display profile, preferring Paykit Profile.
+    pub async fn resolve_contact_profile(
+        &self,
+        public_key: PubkyPublicKey,
+        allow_pubky_profile_fallback: bool,
+    ) -> Result<Option<ContactProfileResolution>> {
+        if let Some(record) = self.fetch_paykit_profile(public_key.clone()).await? {
+            return Ok(Some(ContactProfileResolution::from_paykit(record)));
+        }
+        if allow_pubky_profile_fallback {
+            return self
+                .fetch_pubky_profile(public_key)
+                .await
+                .map(|record| record.map(ContactProfileResolution::from_pubky));
+        }
+        Ok(None)
+    }
+
+    /// Fetch a contact's public profile and cache it in the local contact record.
+    pub async fn refresh_contact_paykit_profile(
+        &self,
+        public_key: PubkyPublicKey,
+    ) -> Result<Option<ContactRecord>> {
+        self.require_initialized_identity("refresh contact Paykit profile")
+            .await?;
+        let fetched = self.fetch_paykit_profile(public_key.clone()).await?;
+        let now = self.clock.now();
+        self.storage
+            .transaction(move |tx| {
+                let Some(existing) = tx.contact_record(&public_key) else {
+                    return Ok(None);
+                };
+                let record = existing.with_profile(fetched.map(|record| record.profile), now);
+                tx.save_contact_record(record.clone());
+                Ok(Some(record))
+            })
+            .await
+    }
+
+    /// Publish a public contact marker for a saved local contact.
+    ///
+    /// This can reveal part of the local contact graph. It only runs when
+    /// `public_contact_sharing` is `ConfiguredPublicNamespace`.
+    pub async fn publish_public_contact(
+        &self,
+        public_key: PubkyPublicKey,
+    ) -> Result<ContactRecord> {
+        if self.config.public_contact_sharing
+            != PublicContactSharingPolicy::ConfiguredPublicNamespace
+        {
+            return Err(PaykitSdkError::Policy(
+                "public contact sharing is disabled".into(),
+            ));
+        }
+        let session_access = self
+            .load_session_access_for_initialized_identity("publish public contact")
+            .await?;
+        let pending_at = self.clock.now();
+        self.storage
+            .transaction(|tx| {
+                let Some(existing) = tx.contact_record(&public_key) else {
+                    return Err(PaykitSdkError::Protocol(format!(
+                        "cannot publish unsaved contact {public_key}"
+                    )));
+                };
+                tx.save_contact_record(
+                    existing.mark_public_contact_publication_pending(pending_at),
+                );
+                Ok(())
+            })
+            .await?;
+        let path = self.config.public_contact_path(&public_key);
+        let write_result = session_access
+            .session
+            .storage()
+            .put(path.as_str(), public_contact_json(&public_key)?)
+            .await
+            .map_err(|err| map_pubky_transport_error("publish public contact", err));
+        if let Err(err) = write_result {
+            self.mark_public_contact_failed(&public_key, err.to_string())
+                .await?;
+            return Err(err);
+        }
+        let now = self.clock.now();
+        self.storage
+            .transaction(move |tx| {
+                let Some(existing) = tx.contact_record(&public_key) else {
+                    return Err(PaykitSdkError::Protocol(format!(
+                        "contact {public_key} disappeared before public publication was recorded"
+                    )));
+                };
+                let record = existing.mark_public_contact_published(now);
+                tx.save_contact_record(record.clone());
+                Ok(record)
+            })
+            .await
+    }
+
+    /// Remove a public contact marker for a saved local contact.
+    ///
+    /// Cleanup is allowed even when public contact sharing is disabled, so an
+    /// app can stop publishing markers and still remove previously published
+    /// markers.
+    pub async fn remove_public_contact(
+        &self,
+        public_key: PubkyPublicKey,
+    ) -> Result<Option<ContactRecord>> {
+        let existing_record = self
+            .storage
+            .transaction(|tx| Ok(tx.contact_record(&public_key)))
+            .await?;
+        let session_access = self
+            .load_session_access_for_initialized_identity("remove public contact")
+            .await?;
+        let had_local_record = existing_record.is_some();
+        if existing_record
+            .as_ref()
+            .is_some_and(ContactRecord::may_have_public_marker)
+        {
+            let pending_at = self.clock.now();
+            self.storage
+                .transaction(|tx| {
+                    let Some(existing) = tx.contact_record(&public_key) else {
+                        return Ok(());
+                    };
+                    tx.save_contact_record(
+                        existing.mark_public_contact_removal_pending(pending_at),
+                    );
+                    Ok(())
+                })
+                .await?;
+        }
+        let path = self.config.public_contact_path(&public_key);
+        let delete_result = session_access.session.storage().delete(path.as_str()).await;
+        if let Err(err) = delete_result {
+            if !is_pubky_not_found(&err) {
+                let err = map_pubky_transport_error("remove public contact", err);
+                self.mark_public_contact_failed(&public_key, err.to_string())
+                    .await?;
+                return Err(err);
+            }
+        }
+        if !had_local_record {
+            return Ok(None);
+        }
+        let now = self.clock.now();
+        self.storage
+            .transaction(move |tx| {
+                let Some(existing) = tx.contact_record(&public_key) else {
+                    return Ok(None);
+                };
+                let record = existing.mark_public_contact_removed(now);
+                tx.save_contact_record(record.clone());
+                Ok(Some(record))
+            })
+            .await
+    }
+
+    /// Retry pending public contact marker publication/removal records.
+    pub async fn sync_public_contact_markers(&self) -> Result<Vec<ContactRecord>> {
+        let pending = self
+            .storage
+            .transaction(|tx| {
+                let mut records = tx
+                    .contact_records()
+                    .into_iter()
+                    .filter(|record| {
+                        matches!(
+                            record.public_contact_marker_status,
+                            PublicationStatus::PendingPublication
+                                | PublicationStatus::PendingRemoval
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                records.sort_by(|left, right| {
+                    let left_status = match left.public_contact_marker_status {
+                        PublicationStatus::PendingRemoval => 0,
+                        PublicationStatus::PendingPublication => 1,
+                        _ => 2,
+                    };
+                    let right_status = match right.public_contact_marker_status {
+                        PublicationStatus::PendingRemoval => 0,
+                        PublicationStatus::PendingPublication => 1,
+                        _ => 2,
+                    };
+                    left_status
+                        .cmp(&right_status)
+                        .then_with(|| left.public_key.as_str().cmp(right.public_key.as_str()))
+                });
+                Ok(records)
+            })
+            .await?;
+        let mut synced = Vec::new();
+        for record in pending {
+            match record.public_contact_marker_status {
+                PublicationStatus::PendingPublication => {
+                    if self.config.public_contact_sharing
+                        == PublicContactSharingPolicy::ConfiguredPublicNamespace
+                    {
+                        synced.push(self.publish_public_contact(record.public_key).await?);
+                    } else {
+                        self.mark_public_contact_failed(
+                            &record.public_key,
+                            "public contact sharing is disabled".into(),
+                        )
+                        .await?;
+                    }
+                }
+                PublicationStatus::PendingRemoval => {
+                    if let Some(record) = self.remove_public_contact(record.public_key).await? {
+                        synced.push(record);
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(synced)
+    }
+
+    async fn mark_public_contact_failed(
+        &self,
+        public_key: &PubkyPublicKey,
+        error: String,
+    ) -> Result<()> {
+        let failed_at = self.clock.now();
+        self.storage
+            .transaction(|tx| {
+                let Some(existing) = tx.contact_record(public_key) else {
+                    return Ok(());
+                };
+                tx.save_contact_record(existing.mark_public_contact_failed(error, failed_at));
+                Ok(())
+            })
+            .await
+    }
+}

--- a/paykit-sdk/src/runtime/encrypted_links.rs
+++ b/paykit-sdk/src/runtime/encrypted_links.rs
@@ -1,0 +1,445 @@
+use super::*;
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    pub(super) async fn ensure_peer_allows_private_automation(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<()> {
+        let (peer_state, has_active_link) = self
+            .storage
+            .transaction(|tx| {
+                let peer_state = tx.linked_peer(counterparty).map(|peer| peer.state);
+                let has_active_link = tx
+                    .encrypted_link_state(counterparty)
+                    .and_then(|state| state.link_snapshot)
+                    .is_some();
+                Ok((peer_state, has_active_link))
+            })
+            .await?;
+        match peer_state {
+            Some(LinkedPeerState::Linked) if has_active_link => Ok(()),
+            Some(LinkedPeerState::Linking) => Err(PaykitSdkError::RecoveryRequired(format!(
+                "Encrypted Link Handshake is still in progress for counterparty {counterparty}"
+            ))),
+            Some(LinkedPeerState::RecoveryRequired) => Err(PaykitSdkError::RecoveryRequired(
+                format!("Encrypted Link recovery is required for counterparty {counterparty}"),
+            )),
+            Some(LinkedPeerState::Blocked) => Err(PaykitSdkError::Policy(format!(
+                "counterparty {counterparty} is blocked"
+            ))),
+            _ => Err(PaykitSdkError::RecoveryRequired(format!(
+                "no active Encrypted Link snapshot for counterparty {counterparty}"
+            ))),
+        }
+    }
+
+    pub(super) async fn ensure_peer_not_blocked(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<()> {
+        let peer_state = self
+            .storage
+            .transaction(|tx| Ok(tx.linked_peer(counterparty).map(|peer| peer.state)))
+            .await?;
+        if matches!(peer_state, Some(LinkedPeerState::Blocked)) {
+            Err(PaykitSdkError::Policy(format!(
+                "counterparty {counterparty} is blocked"
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(super) async fn ensure_peer_not_recovery_required_or_blocked(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<()> {
+        let peer_state = self
+            .storage
+            .transaction(|tx| Ok(tx.linked_peer(counterparty).map(|peer| peer.state)))
+            .await?;
+        match peer_state {
+            Some(LinkedPeerState::RecoveryRequired) => Err(PaykitSdkError::RecoveryRequired(
+                format!("Encrypted Link recovery is required for counterparty {counterparty}"),
+            )),
+            Some(LinkedPeerState::Blocked) => Err(PaykitSdkError::Policy(format!(
+                "counterparty {counterparty} is blocked"
+            ))),
+            _ => Ok(()),
+        }
+    }
+
+    /// Start an Encrypted Link Handshake as the initiator.
+    pub async fn initiate_link_with_peer(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<LinkedPeerHandshakeReport> {
+        self.start_link_handshake(counterparty, EncryptedLinkHandshakeRole::Initiator)
+            .await
+    }
+
+    /// Start an Encrypted Link Handshake as the responder.
+    pub async fn accept_link_with_peer(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<LinkedPeerHandshakeReport> {
+        self.start_link_handshake(counterparty, EncryptedLinkHandshakeRole::Responder)
+            .await
+    }
+
+    /// Advance the stored Encrypted Link Handshake for one counterparty.
+    pub async fn advance_link_handshake(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<LinkedPeerHandshakeReport> {
+        self.ensure_peer_not_recovery_required_or_blocked(&counterparty)
+            .await?;
+        let _ = self.private_link_session_access().await?;
+        let lease = self.claim_peer_link_operation(&counterparty).await?;
+        let result = self
+            .advance_link_handshake_with_claim(counterparty, lease.clone())
+            .await;
+        self.finish_peer_link_operation(lease, result).await
+    }
+
+    async fn advance_link_handshake_with_claim(
+        &self,
+        counterparty: PubkyPublicKey,
+        lease: PeerLinkOperationLease,
+    ) -> Result<LinkedPeerHandshakeReport> {
+        self.ensure_peer_not_recovery_required_or_blocked(&counterparty)
+            .await?;
+        let Some(stored_link_state) = self
+            .storage
+            .transaction(|tx| Ok(tx.encrypted_link_state(&counterparty)))
+            .await?
+        else {
+            return Err(PaykitSdkError::RecoveryRequired(format!(
+                "no Encrypted Link state for counterparty {counterparty}"
+            )));
+        };
+        if stored_link_state.link_snapshot.is_some() {
+            save_linked_peer_state_with_lease(
+                &self.storage,
+                counterparty.clone(),
+                LinkedPeerState::Linked,
+                lease.clone(),
+                self.clock.now(),
+            )
+            .await?;
+            return Ok(LinkedPeerHandshakeReport {
+                counterparty: counterparty.clone(),
+                state: LinkedPeerState::Linked,
+                generation: stored_link_state.generation,
+                handshake_role: None,
+            });
+        }
+
+        let Some(handshake_role) = stored_link_state.handshake_role else {
+            self.mark_link_recovery_required(&counterparty, lease)
+                .await?;
+            return Err(PaykitSdkError::RecoveryRequired(format!(
+                "missing Encrypted Link Handshake role for counterparty {counterparty}"
+            )));
+        };
+        let Some(snapshot_bytes) = stored_link_state.handshake_snapshot.as_ref() else {
+            self.mark_link_recovery_required(&counterparty, lease)
+                .await?;
+            return Err(PaykitSdkError::RecoveryRequired(format!(
+                "no in-progress Encrypted Link Handshake snapshot for counterparty {counterparty}"
+            )));
+        };
+
+        let handshake = match self
+            .restore_link_handshake_from_snapshot(counterparty.clone(), snapshot_bytes)
+            .await
+        {
+            Ok(handshake) => handshake,
+            Err(err) => {
+                if Self::handshake_restore_error_requires_recovery(&err) {
+                    self.mark_link_recovery_required(&counterparty, lease)
+                        .await?;
+                }
+                return Err(err);
+            }
+        };
+
+        self.advance_restored_link_handshake(
+            counterparty,
+            handshake,
+            handshake_role,
+            stored_link_state.generation,
+            lease,
+        )
+        .await
+    }
+
+    async fn mark_link_recovery_required(
+        &self,
+        counterparty: &PubkyPublicKey,
+        lease: PeerLinkOperationLease,
+    ) -> Result<()> {
+        let mark = mark_recovery_required_with_lease(
+            &self.storage,
+            counterparty.clone(),
+            lease,
+            self.clock.now(),
+        )
+        .await?;
+        self.publish_local_recovery_marker_if_possible(counterparty, mark.new_episode)
+            .await;
+        Ok(())
+    }
+
+    async fn restore_link_handshake_from_snapshot(
+        &self,
+        counterparty: PubkyPublicKey,
+        snapshot_bytes: &[u8],
+    ) -> Result<paykit_lib::EncryptedLinkHandshake> {
+        let (session_access, secret_key) = self.private_link_session_access().await?;
+        let remote_public_key = counterparty.to_public_key()?;
+        let snapshot = paykit_lib::EncryptedLinkHandshakeSnapshot::deserialize(snapshot_bytes)?;
+        paykit_lib::restore_encrypted_link_handshake(
+            session_access.session,
+            secret_key,
+            &remote_public_key,
+            session_access.outbox_client,
+            snapshot,
+        )
+        .await
+        .map_err(Into::into)
+    }
+
+    fn handshake_restore_error_requires_recovery(err: &PaykitSdkError) -> bool {
+        matches!(
+            err,
+            PaykitSdkError::Transport { .. }
+                | PaykitSdkError::NotFound(_)
+                | PaykitSdkError::Protocol(_)
+                | PaykitSdkError::RecoveryRequired(_)
+        )
+    }
+
+    async fn advance_restored_link_handshake(
+        &self,
+        counterparty: PubkyPublicKey,
+        handshake: paykit_lib::EncryptedLinkHandshake,
+        handshake_role: EncryptedLinkHandshakeRole,
+        expected_generation: u64,
+        lease: PeerLinkOperationLease,
+    ) -> Result<LinkedPeerHandshakeReport> {
+        match paykit_lib::advance_handshake(handshake).await? {
+            paykit_lib::HandshakeProgress::Pending(handshake) => {
+                save_link_handshake_state_if_generation_with_lease(
+                    &self.storage,
+                    counterparty,
+                    handshake_role,
+                    handshake.serialize(),
+                    expected_generation,
+                    lease,
+                    self.clock.now(),
+                )
+                .await
+            }
+            paykit_lib::HandshakeProgress::Complete(link) => {
+                let report = save_linked_peer_link_state_if_generation_with_lease(
+                    &self.storage,
+                    counterparty.clone(),
+                    link.serialize(),
+                    expected_generation,
+                    lease,
+                    self.clock.now(),
+                )
+                .await?;
+                self.remove_local_recovery_marker_if_recorded(&counterparty)
+                    .await?;
+                Ok(report)
+            }
+        }
+    }
+
+    async fn start_link_handshake(
+        &self,
+        counterparty: PubkyPublicKey,
+        role: EncryptedLinkHandshakeRole,
+    ) -> Result<LinkedPeerHandshakeReport> {
+        let _ = self.private_link_session_access().await?;
+        let lease = self.claim_peer_link_operation(&counterparty).await?;
+        let result = self
+            .start_link_handshake_with_claim(counterparty, role, lease.clone())
+            .await;
+        self.finish_peer_link_operation(lease, result).await
+    }
+
+    pub(super) async fn start_link_handshake_with_claim(
+        &self,
+        counterparty: PubkyPublicKey,
+        role: EncryptedLinkHandshakeRole,
+        lease: PeerLinkOperationLease,
+    ) -> Result<LinkedPeerHandshakeReport> {
+        let peer_state = self
+            .storage
+            .transaction(|tx| Ok(tx.linked_peer(&counterparty).map(|peer| peer.state)))
+            .await?;
+        if matches!(peer_state, Some(LinkedPeerState::Blocked)) {
+            return Err(PaykitSdkError::Policy(format!(
+                "counterparty {counterparty} is blocked"
+            )));
+        }
+
+        if !matches!(peer_state, Some(LinkedPeerState::RecoveryRequired)) {
+            if let Some(existing) = self
+                .storage
+                .transaction(|tx| Ok(tx.encrypted_link_state(&counterparty)))
+                .await?
+            {
+                if existing.link_snapshot.is_some() {
+                    save_linked_peer_state_with_lease(
+                        &self.storage,
+                        counterparty.clone(),
+                        LinkedPeerState::Linked,
+                        lease.clone(),
+                        self.clock.now(),
+                    )
+                    .await?;
+                    return Ok(LinkedPeerHandshakeReport {
+                        counterparty,
+                        state: LinkedPeerState::Linked,
+                        generation: existing.generation,
+                        handshake_role: None,
+                    });
+                }
+                if existing.handshake_snapshot.is_some() {
+                    if existing.handshake_role.is_none() {
+                        let mark = mark_recovery_required_with_lease(
+                            &self.storage,
+                            counterparty.clone(),
+                            lease.clone(),
+                            self.clock.now(),
+                        )
+                        .await?;
+                        self.publish_local_recovery_marker_if_possible(
+                            &counterparty,
+                            mark.new_episode,
+                        )
+                        .await;
+                        return Err(PaykitSdkError::RecoveryRequired(format!(
+                            "missing Encrypted Link Handshake role for counterparty {counterparty}"
+                        )));
+                    }
+                    save_linked_peer_state_with_lease(
+                        &self.storage,
+                        counterparty.clone(),
+                        LinkedPeerState::Linking,
+                        lease.clone(),
+                        self.clock.now(),
+                    )
+                    .await?;
+                    return Ok(LinkedPeerHandshakeReport {
+                        counterparty,
+                        state: LinkedPeerState::Linking,
+                        generation: existing.generation,
+                        handshake_role: existing.handshake_role,
+                    });
+                }
+            }
+        }
+
+        let (session_access, secret_key) = self.private_link_session_access().await?;
+        let remote_public_key = counterparty.to_public_key()?;
+        let handshake = match role {
+            EncryptedLinkHandshakeRole::Initiator => paykit_lib::initiate_encrypted_link(
+                session_access.session,
+                secret_key,
+                &remote_public_key,
+                session_access.outbox_client,
+            )?,
+            EncryptedLinkHandshakeRole::Responder => paykit_lib::accept_encrypted_link(
+                session_access.session,
+                secret_key,
+                &remote_public_key,
+                session_access.outbox_client,
+            )?,
+        };
+
+        save_link_handshake_state_with_lease(
+            &self.storage,
+            counterparty,
+            role,
+            handshake.serialize(),
+            lease,
+            self.clock.now(),
+        )
+        .await
+    }
+
+    pub(super) async fn claim_peer_link_operation(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<PeerLinkOperationLease> {
+        let now = self.clock.now();
+        let lease_timeout = ChronoDuration::from_std(self.config.peer_link_operation_lease_timeout)
+            .map_err(|err| {
+                PaykitSdkError::Policy(format!("invalid peer link lease timeout: {err}"))
+            })?;
+        let expires_at = now + lease_timeout;
+        self.storage
+            .transaction(|tx| Ok(tx.claim_peer_link_operation(counterparty, now, expires_at)))
+            .await?
+            .ok_or_else(|| {
+                PaykitSdkError::Policy(format!(
+                    "peer link operation already in progress for counterparty {counterparty}"
+                ))
+            })
+    }
+
+    pub(super) async fn release_peer_link_operation(
+        &self,
+        lease: &PeerLinkOperationLease,
+    ) -> Result<()> {
+        self.storage
+            .transaction(|tx| {
+                tx.release_peer_link_operation(&lease.counterparty, lease.lease_id);
+                Ok(())
+            })
+            .await
+    }
+
+    pub(super) async fn finish_peer_link_operation<T>(
+        &self,
+        lease: PeerLinkOperationLease,
+        result: Result<T>,
+    ) -> Result<T> {
+        let release_result = self.release_peer_link_operation(&lease).await;
+        match (result, release_result) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(err), _) => Err(err),
+            (Ok(_), Err(err)) => Err(err),
+        }
+    }
+
+    pub(super) async fn private_link_session_access(
+        &self,
+    ) -> Result<(PubkySessionAccess, [u8; 32])> {
+        let (session_access, _) = self.load_session_access_and_refresh_identity().await?;
+        let session_access = session_access.ok_or_else(|| PaykitSdkError::Identity {
+            context: "no Pubky session available".into(),
+            source: None,
+        })?;
+        let secret_key = *session_access
+            .local_secret_key
+            .as_ref()
+            .ok_or_else(|| PaykitSdkError::Identity {
+                context: "local Pubky secret key is unavailable for Encrypted Links".into(),
+                source: None,
+            })?
+            .as_bytes();
+        Ok((session_access, secret_key))
+    }
+}

--- a/paykit-sdk/src/runtime/outbound_private.rs
+++ b/paykit-sdk/src/runtime/outbound_private.rs
@@ -1,0 +1,446 @@
+use super::*;
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Send queued outbound private messages for one counterparty in order.
+    pub async fn process_outbound_private_messages(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<OutboundPrivateSendReport> {
+        let mut report = OutboundPrivateSendReport::default();
+        self.ensure_peer_not_recovery_required_or_blocked(&counterparty)
+            .await?;
+        let (session_access, _) = self.private_link_session_access().await?;
+        self.ensure_peer_allows_private_automation(&counterparty)
+            .await?;
+        let queued = queued_outbound_private_messages(&self.storage, &counterparty).await?;
+        if queued.is_empty() {
+            let lease = self.claim_peer_link_operation(&counterparty).await?;
+            report.reservation_cleanup_failures.extend(
+                self.cancel_terminal_private_list_reservations(&counterparty, Some(&lease))
+                    .await,
+            );
+            return self.finish_peer_link_operation(lease, Ok(report)).await;
+        }
+
+        let lease = self.claim_peer_link_operation(&counterparty).await?;
+        let result = self
+            .process_outbound_private_messages_with_claim(
+                counterparty,
+                report,
+                lease.clone(),
+                session_access,
+            )
+            .await;
+        self.finish_peer_link_operation(lease, result).await
+    }
+
+    /// List counterparties with queued private messages ready for retry.
+    pub async fn pending_outbound_private_counterparties(&self) -> Result<Vec<PubkyPublicKey>> {
+        let now = self.clock.now();
+        let lease_timeout = ChronoDuration::from_std(
+            self.config.outbound_private_send_lease_timeout,
+        )
+        .map_err(|err| {
+            PaykitSdkError::Policy(format!(
+                "invalid outbound private send lease timeout: {err}"
+            ))
+        })?;
+        let retry_backoff = ChronoDuration::from_std(self.config.outbound_private_retry_backoff)
+            .map_err(|err| {
+                PaykitSdkError::Policy(format!("invalid outbound private retry backoff: {err}"))
+            })?;
+        let stale_before = now - lease_timeout;
+        let failed_retry_after = now - retry_backoff;
+        self.storage
+            .transaction(move |tx| {
+                let snapshot = tx.export_storage_state();
+                let mut by_counterparty = HashMap::new();
+                for message in snapshot.outbound_private_messages {
+                    by_counterparty
+                        .entry(message.counterparty.clone())
+                        .or_insert_with(Vec::new)
+                        .push(message);
+                }
+                let mut counterparties = by_counterparty
+                    .into_iter()
+                    .filter_map(|(counterparty, messages)| {
+                        if snapshot
+                            .linked_peers
+                            .get(&counterparty)
+                            .is_some_and(|peer| {
+                                matches!(
+                                    peer.state,
+                                    LinkedPeerState::Linking
+                                        | LinkedPeerState::RecoveryRequired
+                                        | LinkedPeerState::Blocked
+                                )
+                            })
+                        {
+                            return None;
+                        }
+                        outbound_private_queue_head_is_claimable(
+                            &messages,
+                            stale_before,
+                            failed_retry_after,
+                        )
+                        .then_some(counterparty)
+                    })
+                    .collect::<Vec<_>>();
+                counterparties.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+                Ok(counterparties)
+            })
+            .await
+    }
+
+    /// Process queued outbound private messages for every pending counterparty.
+    pub async fn process_pending_private_messages(
+        &self,
+    ) -> Result<Vec<OutboundPrivateCounterpartySendReport>> {
+        let counterparties = self.pending_outbound_private_counterparties().await?;
+        let mut reports = Vec::with_capacity(counterparties.len());
+        for counterparty in counterparties {
+            match self
+                .process_outbound_private_messages(counterparty.clone())
+                .await
+            {
+                Ok(report) => reports.push(OutboundPrivateCounterpartySendReport {
+                    counterparty,
+                    report: Some(report),
+                    error: None,
+                }),
+                Err(err) => reports.push(OutboundPrivateCounterpartySendReport {
+                    counterparty,
+                    report: None,
+                    error: Some(err.to_string()),
+                }),
+            }
+        }
+        Ok(reports)
+    }
+
+    async fn process_outbound_private_messages_with_claim(
+        &self,
+        counterparty: PubkyPublicKey,
+        mut report: OutboundPrivateSendReport,
+        lease: PeerLinkOperationLease,
+        session_access: PubkySessionAccess,
+    ) -> Result<OutboundPrivateSendReport> {
+        let secret_key = *session_access
+            .local_secret_key
+            .as_ref()
+            .ok_or_else(|| PaykitSdkError::Identity {
+                context: "local Pubky secret key is unavailable for Encrypted Links".into(),
+                source: None,
+            })?
+            .as_bytes();
+        let remote_public_key = counterparty.to_public_key()?;
+        let stored_link_state = self
+            .storage
+            .transaction(|tx| Ok(tx.encrypted_link_state(&counterparty)))
+            .await?
+            .ok_or_else(|| {
+                PaykitSdkError::RecoveryRequired(format!(
+                    "no Encrypted Link state for counterparty {counterparty}"
+                ))
+            })?;
+        let Some(snapshot_bytes) = stored_link_state.link_snapshot.as_ref() else {
+            let now = self.clock.now();
+            let mark = mark_recovery_required_with_lease(
+                &self.storage,
+                counterparty.clone(),
+                lease.clone(),
+                now,
+            )
+            .await?;
+            let _ = self
+                .publish_local_recovery_marker_with_session(
+                    &counterparty,
+                    &session_access,
+                    mark.new_episode,
+                )
+                .await;
+            return Err(PaykitSdkError::RecoveryRequired(format!(
+                "no active Encrypted Link snapshot for counterparty {counterparty}"
+            )));
+        };
+        let snapshot = match paykit_lib::EncryptedLinkSnapshot::deserialize(snapshot_bytes) {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                let now = self.clock.now();
+                let mark = mark_recovery_required_with_lease(
+                    &self.storage,
+                    counterparty.clone(),
+                    lease.clone(),
+                    now,
+                )
+                .await?;
+                let _ = self
+                    .publish_local_recovery_marker_with_session(
+                        &counterparty,
+                        &session_access,
+                        mark.new_episode,
+                    )
+                    .await;
+                return Err(err.into());
+            }
+        };
+        let mut link = match paykit_lib::restore_encrypted_link(
+            session_access.session.clone(),
+            secret_key,
+            &remote_public_key,
+            session_access.outbox_client.clone(),
+            snapshot,
+        )
+        .await
+        {
+            Ok(link) => link,
+            Err(err) => {
+                let now = self.clock.now();
+                let mark = mark_recovery_required_with_lease(
+                    &self.storage,
+                    counterparty.clone(),
+                    lease.clone(),
+                    now,
+                )
+                .await?;
+                let _ = self
+                    .publish_local_recovery_marker_with_session(
+                        &counterparty,
+                        &session_access,
+                        mark.new_episode,
+                    )
+                    .await;
+                return Err(err.into());
+            }
+        };
+        let mut link_state = stored_link_state;
+
+        loop {
+            let now = self.clock.now();
+            let lease_timeout = ChronoDuration::from_std(
+                self.config.outbound_private_send_lease_timeout,
+            )
+            .map_err(|err| {
+                PaykitSdkError::Policy(format!(
+                    "invalid outbound private send lease timeout: {err}"
+                ))
+            })?;
+            let retry_backoff = ChronoDuration::from_std(
+                self.config.outbound_private_retry_backoff,
+            )
+            .map_err(|err| {
+                PaykitSdkError::Policy(format!("invalid outbound private retry backoff: {err}"))
+            })?;
+            let stale_before = now - lease_timeout;
+            let failed_retry_after = now - retry_backoff;
+            let sending = claim_next_outbound_private_message_with_peer_lease(
+                &self.storage,
+                &counterparty,
+                now,
+                stale_before,
+                failed_retry_after,
+                lease.clone(),
+            )
+            .await?;
+            let Some(sending) = sending else {
+                report.reservation_cleanup_failures.extend(
+                    self.cancel_terminal_private_list_reservations(&counterparty, Some(&lease))
+                        .await,
+                );
+                break;
+            };
+            report.attempted.push(sending.outbound_message_id);
+
+            if let Err(err) = validate_queued_outbound_private_message(&sending) {
+                let now = self.clock.now();
+                let error = err.to_string();
+                let failed = mark_outbound_invalid(sending, error.clone(), now);
+                self.storage
+                    .transaction({
+                        let failed = failed.clone();
+                        let lease = lease.clone();
+                        move |tx| {
+                            crate::storage::require_peer_link_operation_lease(tx, &lease)?;
+                            tx.save_outbound_private_message(failed)?;
+                            Ok(())
+                        }
+                    })
+                    .await?;
+                report.failed.push(OutboundPrivateSendFailure {
+                    outbound_message_id: failed.outbound_message_id,
+                    error,
+                });
+                report.reservation_cleanup_failures.extend(
+                    self.cancel_terminal_private_list_reservations(&counterparty, Some(&lease))
+                        .await,
+                );
+                continue;
+            }
+
+            if sending.kind == PrivateMessageKind::PrivatePaymentList.as_str() {
+                let expired_releases = expired_outbound_reservation_cancellations(
+                    &self.storage,
+                    &counterparty,
+                    sending.outbound_message_id,
+                    now,
+                )
+                .await?;
+                if !expired_releases.is_empty() {
+                    let now = self.clock.now();
+                    let error =
+                        "Payment Endpoint Reservation expired before private list send".to_owned();
+                    let failed = mark_outbound_invalid(sending, error.clone(), now);
+                    self.storage
+                        .transaction({
+                            let failed = failed.clone();
+                            let lease = lease.clone();
+                            move |tx| {
+                                crate::storage::require_peer_link_operation_lease(tx, &lease)?;
+                                tx.save_outbound_private_message(failed)?;
+                                Ok(())
+                            }
+                        })
+                        .await?;
+                    report.failed.push(OutboundPrivateSendFailure {
+                        outbound_message_id: failed.outbound_message_id,
+                        error,
+                    });
+                    report.reservation_cleanup_failures.extend(
+                        self.cancel_reservation_records(expired_releases, Some(&lease))
+                            .await,
+                    );
+                    report.reservation_cleanup_failures.extend(
+                        self.cancel_terminal_private_list_reservations(&counterparty, Some(&lease))
+                            .await,
+                    );
+                    continue;
+                }
+            }
+
+            match link
+                .send_private_application_message_json(&sending.raw_json)
+                .await
+            {
+                Ok(()) => {
+                    let now = self.clock.now();
+                    let sent = mark_outbound_sent(sending, now);
+                    link_state.link_snapshot = Some(link.serialize());
+                    link_state.handshake_snapshot = None;
+                    link_state.handshake_role = None;
+                    link_state.generation = link_state.generation.saturating_add(1);
+                    link_state.checkpointed_at = now;
+                    self.storage
+                        .transaction({
+                            let sent = sent.clone();
+                            let link_state = link_state.clone();
+                            let lease = lease.clone();
+                            move |tx| {
+                                crate::storage::require_peer_link_operation_lease(tx, &lease)?;
+                                tx.save_outbound_private_message(sent)?;
+                                tx.save_encrypted_link_state(link_state);
+                                Ok(())
+                            }
+                        })
+                        .await?;
+                    report.sent.push(sent.outbound_message_id);
+                }
+                Err(err) => {
+                    let requires_recovery = err.is_non_retryable_private_send_error();
+                    let now = self.clock.now();
+                    let error = err.to_string();
+                    if requires_recovery {
+                        let failed = mark_outbound_recovery_required(sending, error.clone(), now);
+                        let (failed, mark) = self
+                            .storage
+                            .transaction({
+                                let failed = failed.clone();
+                                let lease = lease.clone();
+                                let counterparty = counterparty.clone();
+                                move |tx| {
+                                    crate::storage::require_peer_link_operation_lease(tx, &lease)?;
+                                    let mark = mark_recovery_required_in_transaction(
+                                        tx,
+                                        &counterparty,
+                                        now,
+                                    )?;
+                                    tx.save_outbound_private_message(failed.clone())?;
+                                    Ok((failed, mark))
+                                }
+                            })
+                            .await?;
+                        report.failed.push(OutboundPrivateSendFailure {
+                            outbound_message_id: failed.outbound_message_id,
+                            error,
+                        });
+                        self.record_outbound_recovery_marker_result(
+                            &mut report,
+                            &counterparty,
+                            &session_access,
+                            mark.new_episode,
+                            Some(failed.outbound_message_id),
+                        )
+                        .await;
+                    } else {
+                        let failed = mark_outbound_failed(sending, error.clone(), now);
+                        self.storage
+                            .transaction({
+                                let failed = failed.clone();
+                                let lease = lease.clone();
+                                move |tx| {
+                                    crate::storage::require_peer_link_operation_lease(tx, &lease)?;
+                                    tx.save_outbound_private_message(failed)?;
+                                    Ok(())
+                                }
+                            })
+                            .await?;
+                        report.failed.push(OutboundPrivateSendFailure {
+                            outbound_message_id: failed.outbound_message_id,
+                            error,
+                        });
+                        report.reservation_cleanup_failures.extend(
+                            self.cancel_terminal_private_list_reservations(
+                                &counterparty,
+                                Some(&lease),
+                            )
+                            .await,
+                        );
+                    }
+                    break;
+                }
+            }
+            report.reservation_cleanup_failures.extend(
+                self.cancel_terminal_private_list_reservations(&counterparty, Some(&lease))
+                    .await,
+            );
+        }
+
+        Ok(report)
+    }
+
+    async fn record_outbound_recovery_marker_result(
+        &self,
+        report: &mut OutboundPrivateSendReport,
+        counterparty: &PubkyPublicKey,
+        session_access: &PubkySessionAccess,
+        new_episode: bool,
+        outbound_message_id: Option<u64>,
+    ) {
+        if let Err(err) = self
+            .publish_local_recovery_marker_with_session(counterparty, session_access, new_episode)
+            .await
+        {
+            report
+                .recovery_marker_failures
+                .push(RecoveryMarkerPublishFailure {
+                    outbound_message_id,
+                    error: err.to_string(),
+                });
+        }
+    }
+}

--- a/paykit-sdk/src/runtime/payment_requests.rs
+++ b/paykit-sdk/src/runtime/payment_requests.rs
@@ -1,0 +1,514 @@
+use super::*;
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Return inbound Payment Requests received from one counterparty.
+    ///
+    /// This view is useful for inspecting proposals received from a
+    /// counterparty. For normal app state, including responses to locally
+    /// proposed requests, use [`Self::payment_requests_with`], which merges
+    /// inbound events with local outbound context. Malformed recognized Payment
+    /// Request events without a valid `payment_request_id` stay in the raw
+    /// private stream log and cannot be attached to a request-scoped record.
+    pub async fn received_payment_requests_from(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Vec<PaymentRequestRecord>> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.public_key.is_none() {
+            return Ok(Vec::new());
+        }
+        self.ensure_peer_not_blocked(counterparty).await?;
+        let mut records =
+            derive_received_payment_request_records(&self.storage, counterparty, self.clock.now())
+                .await?;
+        self.mark_recovery_required_payment_request_records(counterparty, &mut records)
+            .await?;
+        Ok(records)
+    }
+
+    /// Return Payment Requests involving one counterparty.
+    ///
+    /// Results combine received private-stream events and local outbound
+    /// Payment Request events. They are returned newest-first.
+    pub async fn payment_requests_with(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Vec<PaymentRequestRecord>> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.public_key.is_none() {
+            return Ok(Vec::new());
+        }
+        self.ensure_peer_not_blocked(counterparty).await?;
+        let mut records =
+            derive_payment_request_records(&self.storage, counterparty, self.clock.now()).await?;
+        self.mark_recovery_required_payment_request_records(counterparty, &mut records)
+            .await?;
+        Ok(records)
+    }
+
+    /// Return Payment Requests matching a local SDK filter.
+    ///
+    /// A filter without a counterparty lists across all non-blocked
+    /// counterparties that have inbound or outbound Payment Request activity.
+    /// Results are returned newest-first.
+    pub async fn list_payment_requests(
+        &self,
+        filter: PaymentRequestFilter,
+    ) -> Result<Vec<PaymentRequestRecord>> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.public_key.is_none() {
+            return Ok(Vec::new());
+        }
+        let now = self.clock.now();
+
+        let counterparties = if let Some(counterparty) = &filter.counterparty {
+            self.ensure_peer_not_blocked(counterparty).await?;
+            vec![counterparty.clone()]
+        } else {
+            self.payment_request_counterparties(filter.received_only)
+                .await?
+        };
+
+        let mut records = Vec::new();
+        for counterparty in counterparties {
+            let mut peer_records = if filter.received_only {
+                derive_received_payment_request_records(&self.storage, &counterparty, now).await?
+            } else {
+                derive_payment_request_records(&self.storage, &counterparty, now).await?
+            };
+            self.mark_recovery_required_payment_request_records(&counterparty, &mut peer_records)
+                .await?;
+            records.extend(
+                peer_records
+                    .into_iter()
+                    .filter(|record| filter.matches(record)),
+            );
+        }
+        sort_payment_requests_newest_first(&mut records);
+        Ok(records)
+    }
+
+    /// Return all Payment Requests across non-blocked counterparties.
+    pub async fn payment_requests(&self) -> Result<Vec<PaymentRequestRecord>> {
+        self.list_payment_requests(PaymentRequestFilter::default())
+            .await
+    }
+
+    /// Return accepted recurring Payment Requests across non-blocked counterparties.
+    pub async fn active_recurring_payment_requests(&self) -> Result<Vec<PaymentRequestRecord>> {
+        self.list_payment_requests(PaymentRequestFilter {
+            states: vec![PaymentRequestLifecycleState::ActiveRecurring],
+            recurring: Some(true),
+            ..PaymentRequestFilter::default()
+        })
+        .await
+    }
+
+    /// Return received Payment Requests that need a local payer response.
+    pub async fn actionable_received_payment_requests(&self) -> Result<Vec<PaymentRequestRecord>> {
+        self.list_payment_requests(PaymentRequestFilter {
+            local_role: Some(PaymentRequestLocalRole::Payer),
+            states: vec![
+                PaymentRequestLifecycleState::Proposed,
+                PaymentRequestLifecycleState::ProposalExpired,
+            ],
+            received_only: true,
+            ..PaymentRequestFilter::default()
+        })
+        .await
+    }
+
+    async fn payment_request_counterparties(
+        &self,
+        received_only: bool,
+    ) -> Result<Vec<PubkyPublicKey>> {
+        self.storage
+            .transaction(move |tx| {
+                let snapshot = tx.export_storage_state();
+                let mut counterparties = HashSet::new();
+                for item in snapshot.private_stream_items {
+                    if is_payment_request_kind(item.parsed_kind.as_deref()) {
+                        counterparties.insert(item.counterparty);
+                    }
+                }
+                if !received_only {
+                    for outbound in snapshot.outbound_private_messages {
+                        if is_payment_request_kind(Some(&outbound.kind)) {
+                            counterparties.insert(outbound.counterparty);
+                        }
+                    }
+                }
+                let mut counterparties = counterparties
+                    .into_iter()
+                    .filter(|counterparty| {
+                        !snapshot
+                            .linked_peers
+                            .get(counterparty)
+                            .is_some_and(|peer| peer.state == LinkedPeerState::Blocked)
+                    })
+                    .collect::<Vec<_>>();
+                counterparties.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+                Ok(counterparties)
+            })
+            .await
+    }
+
+    pub(super) async fn ensure_private_outbound_ready(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<()> {
+        let (session_access, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.capability != PubkyIdentityCapability::PrivateLinkCapable {
+            return Err(PaykitSdkError::Identity {
+                context: "local Pubky identity is not private-link-capable".into(),
+                source: None,
+            });
+        }
+        if session_access.is_none() {
+            return Err(PaykitSdkError::Identity {
+                context: "no Pubky session available".into(),
+                source: None,
+            });
+        }
+
+        self.ensure_peer_allows_private_automation(counterparty)
+            .await?;
+
+        let has_active_link = self
+            .storage
+            .transaction(|tx| {
+                Ok(tx
+                    .encrypted_link_state(counterparty)
+                    .and_then(|state| state.link_snapshot)
+                    .is_some())
+            })
+            .await?;
+        if !has_active_link {
+            return Err(PaykitSdkError::RecoveryRequired(format!(
+                "no active Encrypted Link snapshot for counterparty {counterparty}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Queue a new Payment Request proposal and return local derived state.
+    ///
+    /// The returned record reflects the local outbound queue, not delivery or
+    /// counterparty processing.
+    pub async fn propose_payment_request(
+        &self,
+        counterparty: PubkyPublicKey,
+        terms: PaymentRequestTerms,
+    ) -> Result<PaymentRequestRecord> {
+        let event = PaymentRequest::new(EventId::new_v4(), PaymentRequestId::new_v4(), terms);
+        let payment_request_id = event.payment_request_id.clone();
+        self.enqueue_raw_payment_request(counterparty.clone(), &event)
+            .await?;
+        self.load_payment_request_record(&counterparty, &payment_request_id)
+            .await
+    }
+
+    /// Queue acceptance for a received Payment Request and return local derived state.
+    ///
+    /// The returned record reflects the local outbound queue, not delivery or
+    /// counterparty processing.
+    pub async fn accept_payment_request(
+        &self,
+        counterparty: PubkyPublicKey,
+        payment_request_id: &PaymentRequestId,
+    ) -> Result<PaymentRequestRecord> {
+        let record = self
+            .load_payment_request_record(&counterparty, payment_request_id)
+            .await?;
+        require_payer_role(&record, "accept Payment Request")?;
+        require_state(
+            &record,
+            &[PaymentRequestLifecycleState::Proposed],
+            "accept Payment Request",
+        )?;
+        let event = PaymentRequestAcceptance::new(EventId::new_v4(), payment_request_id.clone());
+        self.enqueue_raw_payment_request_acceptance(counterparty.clone(), &event)
+            .await?;
+        self.load_payment_request_record(&counterparty, payment_request_id)
+            .await
+    }
+
+    /// Queue rejection for a received Payment Request and return local derived state.
+    ///
+    /// The returned record reflects the local outbound queue, not delivery or
+    /// counterparty processing.
+    pub async fn reject_payment_request(
+        &self,
+        counterparty: PubkyPublicKey,
+        payment_request_id: &PaymentRequestId,
+        reason: Option<String>,
+    ) -> Result<PaymentRequestRecord> {
+        let record = self
+            .load_payment_request_record(&counterparty, payment_request_id)
+            .await?;
+        require_payer_role(&record, "reject Payment Request")?;
+        require_state(
+            &record,
+            &[
+                PaymentRequestLifecycleState::Proposed,
+                PaymentRequestLifecycleState::ProposalExpired,
+            ],
+            "reject Payment Request",
+        )?;
+        let event =
+            PaymentRequestRejection::new(EventId::new_v4(), payment_request_id.clone(), reason);
+        self.enqueue_raw_payment_request_rejection(counterparty.clone(), &event)
+            .await?;
+        self.load_payment_request_record(&counterparty, payment_request_id)
+            .await
+    }
+
+    /// Queue cancellation for a known non-terminal Payment Request and return local derived state.
+    ///
+    /// The returned record reflects the local outbound queue, not delivery or
+    /// counterparty processing.
+    pub async fn cancel_payment_request(
+        &self,
+        counterparty: PubkyPublicKey,
+        payment_request_id: &PaymentRequestId,
+        reason: Option<String>,
+    ) -> Result<PaymentRequestRecord> {
+        let record = self
+            .load_payment_request_record(&counterparty, payment_request_id)
+            .await?;
+        require_state(
+            &record,
+            &[
+                PaymentRequestLifecycleState::Proposed,
+                PaymentRequestLifecycleState::ProposalExpired,
+                PaymentRequestLifecycleState::Accepted,
+                PaymentRequestLifecycleState::ActiveRecurring,
+                PaymentRequestLifecycleState::ProofSubmitted,
+            ],
+            "cancel Payment Request",
+        )?;
+        let event =
+            PaymentRequestCancellation::new(EventId::new_v4(), payment_request_id.clone(), reason);
+        self.enqueue_raw_payment_request_cancellation(counterparty.clone(), &event)
+            .await?;
+        self.load_payment_request_record(&counterparty, payment_request_id)
+            .await
+    }
+
+    /// Queue a Payment Proof for an accepted Payment Request and return local derived state.
+    ///
+    /// The returned record reflects the local outbound queue, not delivery or
+    /// counterparty processing.
+    pub async fn submit_payment_proof(
+        &self,
+        counterparty: PubkyPublicKey,
+        payment_request_id: &PaymentRequestId,
+        billing_period: Option<BillingPeriod>,
+        payment_endpoint_identifier: PaymentEndpointIdentifier,
+        proof: JsonMap<String, JsonValue>,
+    ) -> Result<PaymentRequestRecord> {
+        let record = self
+            .load_payment_request_record(&counterparty, payment_request_id)
+            .await?;
+        require_payer_role(&record, "submit Payment Proof")?;
+        require_state(
+            &record,
+            &[
+                PaymentRequestLifecycleState::Accepted,
+                PaymentRequestLifecycleState::ActiveRecurring,
+            ],
+            "submit Payment Proof",
+        )?;
+        let request = request_from_record(&record).ok_or_else(|| {
+            PaykitSdkError::Protocol("Payment Request terms are unavailable".into())
+        })?;
+        let event = PaymentProof::new(
+            EventId::new_v4(),
+            payment_request_id.clone(),
+            request.request.payment_reference.clone(),
+            billing_period,
+            payment_endpoint_identifier,
+            proof,
+        );
+        event.validate_for_request(&request)?;
+        self.enqueue_raw_payment_proof(counterparty.clone(), &event)
+            .await?;
+        self.load_payment_request_record(&counterparty, payment_request_id)
+            .await
+    }
+
+    async fn load_payment_request_record(
+        &self,
+        counterparty: &PubkyPublicKey,
+        payment_request_id: &PaymentRequestId,
+    ) -> Result<PaymentRequestRecord> {
+        let mut records =
+            derive_payment_request_records(&self.storage, counterparty, self.clock.now()).await?;
+        self.mark_recovery_required_payment_request_records(counterparty, &mut records)
+            .await?;
+        records
+            .into_iter()
+            .find(|record| record.payment_request_id == payment_request_id.as_str())
+            .ok_or_else(|| {
+                PaykitSdkError::Protocol(format!(
+                    "Payment Request {} is not known for counterparty {}",
+                    payment_request_id, counterparty
+                ))
+            })
+    }
+
+    async fn mark_recovery_required_payment_request_records(
+        &self,
+        counterparty: &PubkyPublicKey,
+        records: &mut [PaymentRequestRecord],
+    ) -> Result<()> {
+        let recovery_required = self
+            .storage
+            .transaction(|tx| {
+                Ok(tx
+                    .linked_peer(counterparty)
+                    .is_some_and(|peer| peer.state == LinkedPeerState::RecoveryRequired))
+            })
+            .await?;
+        if !recovery_required {
+            return Ok(());
+        }
+        for record in records {
+            if matches!(
+                record.state,
+                PaymentRequestLifecycleState::Proposed
+                    | PaymentRequestLifecycleState::ProposalExpired
+                    | PaymentRequestLifecycleState::Accepted
+                    | PaymentRequestLifecycleState::ProofSubmitted
+                    | PaymentRequestLifecycleState::ActiveRecurring
+            ) {
+                record.state = PaymentRequestLifecycleState::RecoveryRequired;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn enqueue_raw_payment_request(
+        &self,
+        counterparty: PubkyPublicKey,
+        event: &PaymentRequest,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(&counterparty).await?;
+        enqueue_payment_request_message(&self.storage, counterparty, event, self.clock.now()).await
+    }
+
+    pub(crate) async fn enqueue_raw_payment_request_acceptance(
+        &self,
+        counterparty: PubkyPublicKey,
+        event: &PaymentRequestAcceptance,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(&counterparty).await?;
+        enqueue_payment_request_acceptance_message(
+            &self.storage,
+            counterparty,
+            event,
+            self.clock.now(),
+        )
+        .await
+    }
+
+    pub(crate) async fn enqueue_raw_payment_request_rejection(
+        &self,
+        counterparty: PubkyPublicKey,
+        event: &PaymentRequestRejection,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(&counterparty).await?;
+        enqueue_payment_request_rejection_message(
+            &self.storage,
+            counterparty,
+            event,
+            self.clock.now(),
+        )
+        .await
+    }
+
+    pub(crate) async fn enqueue_raw_payment_request_cancellation(
+        &self,
+        counterparty: PubkyPublicKey,
+        event: &PaymentRequestCancellation,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(&counterparty).await?;
+        enqueue_payment_request_cancellation_message(
+            &self.storage,
+            counterparty,
+            event,
+            self.clock.now(),
+        )
+        .await
+    }
+
+    pub(crate) async fn enqueue_raw_payment_proof(
+        &self,
+        counterparty: PubkyPublicKey,
+        event: &PaymentProof,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        self.ensure_private_outbound_ready(&counterparty).await?;
+        enqueue_payment_proof_message(&self.storage, counterparty, event, self.clock.now()).await
+    }
+}
+
+fn require_payer_role(record: &PaymentRequestRecord, action: &str) -> Result<()> {
+    if record.local_role == Some(PaymentRequestLocalRole::Payer) {
+        Ok(())
+    } else {
+        Err(PaykitSdkError::Policy(format!(
+            "cannot {action}: local identity is not the payer"
+        )))
+    }
+}
+
+fn require_state(
+    record: &PaymentRequestRecord,
+    allowed: &[PaymentRequestLifecycleState],
+    action: &str,
+) -> Result<()> {
+    if allowed.contains(&record.state) {
+        Ok(())
+    } else {
+        Err(PaykitSdkError::Policy(format!(
+            "cannot {action}: Payment Request {} is in state {:?}",
+            record.payment_request_id, record.state
+        )))
+    }
+}
+
+fn is_payment_request_kind(kind: Option<&str>) -> bool {
+    matches!(
+        kind.and_then(PrivateMessageKind::parse),
+        Some(
+            PrivateMessageKind::PaymentRequest
+                | PrivateMessageKind::PaymentRequestAcceptance
+                | PrivateMessageKind::PaymentRequestRejection
+                | PrivateMessageKind::PaymentRequestCancellation
+                | PrivateMessageKind::PaymentProof
+        )
+    )
+}
+
+fn sort_payment_requests_newest_first(records: &mut [PaymentRequestRecord]) {
+    records.sort_by(|left, right| {
+        right
+            .last_event_at
+            .cmp(&left.last_event_at)
+            .then_with(|| right.last_stream_item_id.cmp(&left.last_stream_item_id))
+            .then_with(|| {
+                right
+                    .last_outbound_message_id
+                    .cmp(&left.last_outbound_message_id)
+            })
+            .then_with(|| left.counterparty.as_str().cmp(right.counterparty.as_str()))
+            .then_with(|| left.payment_request_id.cmp(&right.payment_request_id))
+    });
+}

--- a/paykit-sdk/src/runtime/payment_resolution.rs
+++ b/paykit-sdk/src/runtime/payment_resolution.rs
@@ -1,0 +1,353 @@
+use super::*;
+use crate::PaymentAmountContext;
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Resolve payable endpoints for one counterparty.
+    ///
+    /// This uses cached private state first. Call
+    /// [`receive_private_messages`](Self::receive_private_messages) before
+    /// resolving when the app needs the freshest Private Payment List.
+    pub async fn resolve_contact_payment(
+        &self,
+        request: ContactPaymentResolutionRequest,
+    ) -> Result<ContactPaymentResolution> {
+        let (session_access, identity) = self.load_session_access_and_refresh_identity().await?;
+        let mut private_allowed = identity.public_key.is_some();
+        let mut private_state = if private_allowed {
+            ContactPaymentResolutionPrivateState::NoPrivateEndpoint
+        } else {
+            ContactPaymentResolutionPrivateState::PublicOnlySession
+        };
+        if private_allowed && identity.capability == PubkyIdentityCapability::PrivateLinkCapable {
+            private_allowed = match self
+                .ensure_peer_allows_private_automation(&request.counterparty)
+                .await
+            {
+                Ok(()) => true,
+                Err(PaykitSdkError::RecoveryRequired(_)) => {
+                    private_state = ContactPaymentResolutionPrivateState::RecoveryPending;
+                    false
+                }
+                Err(err) => return Err(err),
+            };
+        }
+        if private_allowed && identity.capability == PubkyIdentityCapability::PrivateLinkCapable {
+            if let Err(err) = self
+                .observe_remote_recovery_marker_for_cached_private_state(
+                    &request.counterparty,
+                    session_access.as_ref(),
+                )
+                .await
+            {
+                if matches!(err, PaykitSdkError::RecoveryRequired(_)) {
+                    private_state = ContactPaymentResolutionPrivateState::RecoveryPending;
+                } else if !request.include_public_endpoints {
+                    return Err(err);
+                }
+                private_allowed = false;
+            }
+        }
+        if private_allowed && identity.capability == PubkyIdentityCapability::PrivateLinkCapable {
+            private_allowed = match self
+                .ensure_peer_allows_private_automation(&request.counterparty)
+                .await
+            {
+                Ok(()) => true,
+                Err(PaykitSdkError::RecoveryRequired(_)) => {
+                    private_state = ContactPaymentResolutionPrivateState::RecoveryPending;
+                    false
+                }
+                Err(err) => return Err(err),
+            };
+        }
+        let private_view = if private_allowed {
+            load_current_private_payment_list(&self.storage, &request.counterparty).await?
+        } else {
+            None
+        };
+        let mut candidates = private_candidates(&request.counterparty, private_view.as_ref());
+        if !candidates.is_empty() {
+            private_state = ContactPaymentResolutionPrivateState::Available;
+        } else if private_allowed
+            && identity.capability != PubkyIdentityCapability::PrivateLinkCapable
+        {
+            private_state = ContactPaymentResolutionPrivateState::PublicOnlySession;
+        }
+        let had_private_candidates = !candidates.is_empty();
+
+        if candidates.is_empty() && !request.include_public_endpoints {
+            if private_state == ContactPaymentResolutionPrivateState::RecoveryPending {
+                return Ok(status_resolution(
+                    ContactPaymentResolutionStatus::NoEndpoint,
+                    private_state,
+                ));
+            }
+            match self
+                .recover_private_candidates_for_resolution(&request.counterparty)
+                .await?
+            {
+                PrivateRecoveryOutcome::Refreshed(refreshed_candidates)
+                    if !refreshed_candidates.is_empty() =>
+                {
+                    candidates = refreshed_candidates;
+                    private_state = ContactPaymentResolutionPrivateState::Available;
+                }
+                PrivateRecoveryOutcome::Pending => {
+                    return Ok(status_resolution(
+                        ContactPaymentResolutionStatus::NoEndpoint,
+                        ContactPaymentResolutionPrivateState::RecoveryPending,
+                    ));
+                }
+                PrivateRecoveryOutcome::PublicOnly => {
+                    private_state = ContactPaymentResolutionPrivateState::PublicOnlySession;
+                }
+                PrivateRecoveryOutcome::NotNeeded | PrivateRecoveryOutcome::Refreshed(_) => {}
+            }
+            if private_state == ContactPaymentResolutionPrivateState::PublicOnlySession {
+                return Ok(status_resolution(
+                    ContactPaymentResolutionStatus::NoEndpoint,
+                    private_state,
+                ));
+            }
+        }
+
+        if request.include_public_endpoints {
+            candidates.extend(
+                self.public_payment_candidates(&request.counterparty)
+                    .await?,
+            );
+        }
+
+        if candidates.is_empty() {
+            return Ok(unresolved_resolution(had_private_candidates, private_state));
+        }
+
+        self.resolve_candidate_batch(
+            request.counterparty,
+            request.amount,
+            candidates,
+            private_state,
+        )
+        .await
+    }
+
+    pub(super) async fn recover_private_candidates_for_resolution(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<PrivateRecoveryOutcome> {
+        let Some(identity) = self.storage.load_identity_state().await? else {
+            return Ok(PrivateRecoveryOutcome::PublicOnly);
+        };
+        if identity.capability != PubkyIdentityCapability::PrivateLinkCapable {
+            return Ok(PrivateRecoveryOutcome::PublicOnly);
+        }
+
+        let (peer_state, has_active_link) = self
+            .storage
+            .transaction(|tx| {
+                let peer = tx.linked_peer(counterparty);
+                let link_state = tx.encrypted_link_state(counterparty);
+                let has_active_link = link_state
+                    .as_ref()
+                    .and_then(|state| state.link_snapshot.as_ref())
+                    .is_some();
+                Ok((
+                    peer.as_ref().map(|peer| peer.state.clone()),
+                    has_active_link,
+                ))
+            })
+            .await?;
+
+        if matches!(
+            peer_state,
+            Some(LinkedPeerState::Linking | LinkedPeerState::RecoveryRequired)
+        ) {
+            return Ok(PrivateRecoveryOutcome::Pending);
+        }
+
+        if has_active_link {
+            self.observe_remote_recovery_marker_for_cached_private_state(counterparty, None)
+                .await?;
+
+            match self.receive_private_messages(counterparty.clone()).await {
+                Ok(_) => {
+                    let private_view =
+                        load_current_private_payment_list(&self.storage, counterparty).await?;
+                    return Ok(PrivateRecoveryOutcome::Refreshed(private_candidates(
+                        counterparty,
+                        private_view.as_ref(),
+                    )));
+                }
+                Err(PaykitSdkError::Policy(_)) => return Ok(PrivateRecoveryOutcome::Pending),
+                Err(PaykitSdkError::Identity { .. }) => {
+                    return Ok(PrivateRecoveryOutcome::PublicOnly)
+                }
+                Err(PaykitSdkError::RecoveryRequired(_))
+                | Err(PaykitSdkError::Transport { .. })
+                | Err(PaykitSdkError::Protocol(_)) => {
+                    return Ok(PrivateRecoveryOutcome::Pending);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(PrivateRecoveryOutcome::NotNeeded)
+    }
+
+    async fn public_payment_candidates(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Vec<PaymentEndpointCandidate>> {
+        let public_storage =
+            self.pubky
+                .load_public_storage()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: "no Pubky public storage available for public Payment Endpoint lookup"
+                        .into(),
+                    source: None,
+                })?;
+        let payment_list =
+            paykit_lib::get_payment_list(&public_storage, &counterparty.to_public_key()?).await?;
+        let mut endpoints = payment_list
+            .payment_endpoints
+            .into_iter()
+            .map(|(identifier, payload)| PaymentEndpointCandidate {
+                counterparty: counterparty.clone(),
+                source: PaymentEndpointSource::PublicPaymentEndpoint,
+                identifier: identifier.as_str().to_owned(),
+                payload: payload.into_inner(),
+            })
+            .collect::<Vec<_>>();
+        endpoints.sort_by(|left, right| left.identifier.cmp(&right.identifier));
+        Ok(endpoints)
+    }
+
+    async fn build_payable_endpoints(
+        &self,
+        payable: Vec<PaymentEndpointCandidate>,
+    ) -> Result<Vec<ResolvedPaymentEndpoint>> {
+        let mut endpoints = Vec::with_capacity(payable.len());
+        for endpoint in payable {
+            let target = self.payment.build_payment_target(&endpoint).await?;
+            endpoints.push(ResolvedPaymentEndpoint { endpoint, target });
+        }
+        Ok(endpoints)
+    }
+
+    pub(super) async fn resolve_candidate_batch(
+        &self,
+        counterparty: PubkyPublicKey,
+        amount: Option<PaymentAmountContext>,
+        candidates: Vec<PaymentEndpointCandidate>,
+        private_state: ContactPaymentResolutionPrivateState,
+    ) -> Result<ContactPaymentResolution> {
+        let payable = self
+            .payment
+            .select_payment_endpoints(&PaymentEndpointSelectionRequest {
+                counterparty,
+                amount,
+                candidates: candidates.clone(),
+            })
+            .await?;
+        let payable = payable_from_batch(&payable, &candidates)?;
+        let payable_endpoints = self.build_payable_endpoints(payable).await?;
+        if !payable_endpoints.is_empty() {
+            return Ok(payable_resolution(payable_endpoints, private_state));
+        }
+
+        Ok(unresolved_resolution(true, private_state))
+    }
+}
+
+fn private_candidates(
+    counterparty: &PubkyPublicKey,
+    view: Option<&PrivatePaymentListView>,
+) -> Vec<PaymentEndpointCandidate> {
+    let Some(view) = view else {
+        return Vec::new();
+    };
+    let mut candidates = view
+        .payment_endpoints
+        .iter()
+        .map(|(identifier, payload)| PaymentEndpointCandidate {
+            counterparty: counterparty.clone(),
+            source: PaymentEndpointSource::PrivatePaymentList,
+            identifier: identifier.clone(),
+            payload: payload.clone(),
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| left.identifier.cmp(&right.identifier));
+    candidates
+}
+
+pub(super) enum PrivateRecoveryOutcome {
+    NotNeeded,
+    Pending,
+    PublicOnly,
+    Refreshed(Vec<PaymentEndpointCandidate>),
+}
+fn payable_resolution(
+    payable_endpoints: Vec<ResolvedPaymentEndpoint>,
+    private_state: ContactPaymentResolutionPrivateState,
+) -> ContactPaymentResolution {
+    ContactPaymentResolution {
+        status: ContactPaymentResolutionStatus::Payable,
+        private_state,
+        payable_endpoints,
+    }
+}
+
+fn status_resolution(
+    status: ContactPaymentResolutionStatus,
+    private_state: ContactPaymentResolutionPrivateState,
+) -> ContactPaymentResolution {
+    ContactPaymentResolution {
+        status,
+        private_state,
+        payable_endpoints: Vec::new(),
+    }
+}
+
+fn unresolved_resolution(
+    had_candidates: bool,
+    private_state: ContactPaymentResolutionPrivateState,
+) -> ContactPaymentResolution {
+    ContactPaymentResolution {
+        status: if had_candidates {
+            ContactPaymentResolutionStatus::UnsupportedEndpoint
+        } else {
+            ContactPaymentResolutionStatus::NoEndpoint
+        },
+        private_state,
+        payable_endpoints: Vec::new(),
+    }
+}
+
+pub(super) fn payable_from_batch(
+    selected: &[PaymentEndpointCandidate],
+    candidates: &[PaymentEndpointCandidate],
+) -> Result<Vec<PaymentEndpointCandidate>> {
+    let mut payable = Vec::with_capacity(selected.len());
+    for candidate in selected {
+        if !candidates.contains(candidate) {
+            return Err(PaykitSdkError::Protocol(
+                "PaymentAdapter returned a payable endpoint that was not in the candidate batch"
+                    .into(),
+            ));
+        }
+        if payable.contains(candidate) {
+            return Err(PaykitSdkError::Protocol(
+                "PaymentAdapter returned duplicate payable endpoints".into(),
+            ));
+        }
+        payable.push(candidate.clone());
+    }
+    Ok(payable)
+}

--- a/paykit-sdk/src/runtime/private_lists.rs
+++ b/paykit-sdk/src/runtime/private_lists.rs
@@ -1,0 +1,339 @@
+use super::*;
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Return the latest valid Private Payment List view for a counterparty.
+    pub async fn current_private_payment_list(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Option<crate::PrivatePaymentListView>> {
+        let (session_access, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.public_key.is_none() {
+            return Ok(None);
+        }
+        self.ensure_peer_not_blocked(counterparty).await?;
+        if session_access
+            .as_ref()
+            .is_some_and(PubkySessionAccess::private_link_capable)
+        {
+            self.observe_remote_recovery_marker_for_cached_private_state(
+                counterparty,
+                session_access.as_ref(),
+            )
+            .await?;
+        }
+        load_current_private_payment_list(&self.storage, counterparty).await
+    }
+
+    /// Enqueue the current complete Private Payment List for one counterparty.
+    pub async fn enqueue_private_payment_list(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        let lease = self.claim_peer_link_operation(&counterparty).await?;
+        let result = async {
+            self.ensure_private_outbound_ready(&counterparty).await?;
+            self.enqueue_private_payment_list_from_receiving_details_with_claim(
+                counterparty,
+                &lease,
+            )
+            .await
+        }
+        .await;
+        self.finish_peer_link_operation(lease, result).await
+    }
+
+    #[cfg(test)]
+    pub(super) async fn enqueue_private_payment_list_from_receiving_details(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        let lease = self.claim_peer_link_operation(&counterparty).await?;
+        let result = self
+            .enqueue_private_payment_list_from_receiving_details_with_claim(counterparty, &lease)
+            .await;
+        self.finish_peer_link_operation(lease, result).await
+    }
+
+    pub(super) async fn enqueue_private_payment_list_from_receiving_details_with_claim(
+        &self,
+        counterparty: PubkyPublicKey,
+        lease: &PeerLinkOperationLease,
+    ) -> Result<OutboundPrivateMessageRecord> {
+        if let Some(reservations) = self
+            .payment
+            .reserve_receiving_details(&counterparty)
+            .await?
+        {
+            let cancellations = reservations
+                .iter()
+                .map(|reservation| reservation_cancellation(&counterparty, reservation))
+                .collect::<Vec<_>>();
+            let now = self.clock.now();
+            let result = queue_private_payment_list_with_reservations_with_link_lease(
+                &self.storage,
+                &counterparty,
+                reservations,
+                now,
+                lease,
+            )
+            .await;
+            match result {
+                Ok(record) => Ok(record),
+                Err(err) => {
+                    if let Err(cancellation_err) = self
+                        .cancel_reservations_after_queue_error(&cancellations, &counterparty)
+                        .await
+                    {
+                        return Err(PaykitSdkError::Policy(format!(
+                            "failed to queue reserved receiving details: {err}; reservation cleanup also failed: {cancellation_err}"
+                        )));
+                    }
+                    Err(err)
+                }
+            }
+        } else {
+            let receiving_details = self.private_receiving_details(&counterparty).await?;
+            enqueue_private_payment_list_message_with_link_lease(
+                &self.storage,
+                counterparty,
+                receiving_details,
+                self.clock.now(),
+                lease,
+            )
+            .await
+        }
+    }
+
+    async fn cancel_reservations_after_queue_error(
+        &self,
+        cancellations: &[PaymentEndpointReservationCancellation],
+        counterparty: &PubkyPublicKey,
+    ) -> Result<()> {
+        let mut cancellation_errors = Vec::new();
+        for cancellation in cancellations {
+            let can_cancel = self
+                .storage
+                .transaction({
+                    let counterparty = counterparty.clone();
+                    let cancellation = cancellation.clone();
+                    move |tx| {
+                        Ok(!tx
+                            .payment_endpoint_reservation(
+                                &counterparty,
+                                &cancellation.reservation_id,
+                            )
+                            .is_some_and(|record| {
+                                record.reservation_id == cancellation.reservation_id
+                                    && record.counterparty == cancellation.counterparty
+                                    && record.identifier == cancellation.identifier
+                                    && record.payload_hash == cancellation.payload_hash
+                            }))
+                    }
+                })
+                .await?;
+            if !can_cancel {
+                continue;
+            }
+            if let Err(err) = self
+                .payment
+                .cancel_receiving_detail_reservation(cancellation)
+                .await
+            {
+                cancellation_errors.push(format!("{}: {err}", cancellation.reservation_id));
+            }
+        }
+        if cancellation_errors.is_empty() {
+            Ok(())
+        } else {
+            Err(PaykitSdkError::Policy(format!(
+                "failed to cancel reserved receiving details: {}",
+                cancellation_errors.join("; ")
+            )))
+        }
+    }
+
+    pub(super) async fn cancel_unattempted_superseded_reservations(
+        &self,
+        counterparty: &PubkyPublicKey,
+        lease: Option<&PeerLinkOperationLease>,
+    ) -> Vec<ReservationCleanupFailure> {
+        let cancellations =
+            match unattempted_superseded_reservation_cancellations(&self.storage, counterparty)
+                .await
+            {
+                Ok(cancellations) => cancellations,
+                Err(err) => {
+                    return vec![ReservationCleanupFailure {
+                        reservation_id: None,
+                        error: err.to_string(),
+                    }];
+                }
+            };
+        self.cancel_reservation_records(cancellations, lease).await
+    }
+
+    pub(super) async fn cancel_terminal_private_list_reservations(
+        &self,
+        counterparty: &PubkyPublicKey,
+        lease: Option<&PeerLinkOperationLease>,
+    ) -> Vec<ReservationCleanupFailure> {
+        let mut failures = self
+            .cancel_unattempted_superseded_reservations(counterparty, lease)
+            .await;
+        let cancellations =
+            match invalid_private_list_reservation_cancellations(&self.storage, counterparty).await
+            {
+                Ok(cancellations) => cancellations,
+                Err(err) => {
+                    failures.push(ReservationCleanupFailure {
+                        reservation_id: None,
+                        error: err.to_string(),
+                    });
+                    return failures;
+                }
+            };
+        failures.extend(self.cancel_reservation_records(cancellations, lease).await);
+        failures
+    }
+
+    pub(super) async fn cancel_reservation_records(
+        &self,
+        cancellations: Vec<PaymentEndpointReservationCancellationRecord>,
+        lease: Option<&PeerLinkOperationLease>,
+    ) -> Vec<ReservationCleanupFailure> {
+        let mut failures = Vec::new();
+        for cancellation_record in cancellations {
+            let cancellation = cancellation_record.cancellation;
+            match self
+                .claim_reservation_cancellation(
+                    &cancellation,
+                    cancellation_record.outbound_message_id,
+                    lease,
+                    self.clock.now(),
+                )
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) => continue,
+                Err(err) => {
+                    failures.push(ReservationCleanupFailure {
+                        reservation_id: Some(cancellation.reservation_id),
+                        error: err.to_string(),
+                    });
+                    continue;
+                }
+            }
+            match self
+                .payment
+                .cancel_receiving_detail_reservation(&cancellation)
+                .await
+            {
+                Ok(()) => {
+                    if let Err(err) = self
+                        .storage
+                        .transaction({
+                            let cancellation = cancellation.clone();
+                            let outbound_message_id = cancellation_record.outbound_message_id;
+                            move |tx| {
+                                if tx
+                                    .payment_endpoint_reservation(
+                                        &cancellation.counterparty,
+                                        &cancellation.reservation_id,
+                                    )
+                                    .is_some_and(|record| {
+                                        record.outbound_message_id == outbound_message_id
+                                            && record.identifier == cancellation.identifier
+                                            && record.payload_hash == cancellation.payload_hash
+                                            && record.cancellation_started_at.is_some()
+                                    })
+                                {
+                                    tx.remove_payment_endpoint_reservation(
+                                        &cancellation.counterparty,
+                                        &cancellation.reservation_id,
+                                    );
+                                }
+                                Ok(())
+                            }
+                        })
+                        .await
+                    {
+                        failures.push(ReservationCleanupFailure {
+                            reservation_id: Some(cancellation.reservation_id.clone()),
+                            error: err.to_string(),
+                        });
+                    }
+                }
+                Err(err) => failures.push(ReservationCleanupFailure {
+                    reservation_id: Some(cancellation.reservation_id),
+                    error: err.to_string(),
+                }),
+            }
+        }
+        failures
+    }
+
+    async fn claim_reservation_cancellation(
+        &self,
+        cancellation: &PaymentEndpointReservationCancellation,
+        outbound_message_id: u64,
+        lease: Option<&PeerLinkOperationLease>,
+        now: DateTime<Utc>,
+    ) -> Result<bool> {
+        self.storage
+            .transaction({
+                let cancellation = cancellation.clone();
+                let lease = lease.cloned();
+                move |tx| {
+                    if let Some(lease) = lease.as_ref() {
+                        crate::storage::require_peer_link_operation_lease(tx, lease)?;
+                    }
+                    let Some(mut record) = tx.payment_endpoint_reservation(
+                        &cancellation.counterparty,
+                        &cancellation.reservation_id,
+                    ) else {
+                        return Ok(false);
+                    };
+                    if record.outbound_message_id != outbound_message_id
+                        || record.identifier != cancellation.identifier
+                        || record.payload_hash != cancellation.payload_hash
+                    {
+                        return Ok(false);
+                    }
+                    record.cancellation_started_at = Some(now);
+                    tx.save_payment_endpoint_reservation(record);
+                    Ok(true)
+                }
+            })
+            .await
+    }
+
+    async fn private_receiving_details(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Vec<ReceivingDetail>> {
+        self.payment
+            .current_receiving_details(ReceivingDetailScope::Private {
+                counterparty: counterparty.clone(),
+            })
+            .await
+    }
+}
+
+fn reservation_cancellation(
+    counterparty: &PubkyPublicKey,
+    reservation: &PaymentEndpointReservation,
+) -> PaymentEndpointReservationCancellation {
+    PaymentEndpointReservationCancellation {
+        reservation_id: reservation.reservation_id.clone(),
+        counterparty: counterparty.clone(),
+        identifier: reservation.receiving_detail.identifier.clone(),
+        payload_hash: reservation_payload_hash(&reservation.receiving_detail.payload),
+        attribution: reservation.attribution.clone(),
+    }
+}

--- a/paykit-sdk/src/runtime/private_stream.rs
+++ b/paykit-sdk/src/runtime/private_stream.rs
@@ -1,0 +1,195 @@
+use super::*;
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Receive and durably persist available private messages.
+    ///
+    /// This requires a stored Encrypted Link snapshot for the counterparty.
+    /// Handshake establishment and recovery are separate workflows.
+    pub async fn receive_private_messages(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<PrivateStreamIntakeReport> {
+        let (session_access, _) = self.private_link_session_access().await?;
+        self.ensure_peer_allows_private_automation(&counterparty)
+            .await?;
+        let lease = self.claim_peer_link_operation(&counterparty).await?;
+        let result = self
+            .receive_private_messages_with_claim(counterparty, lease.clone(), session_access)
+            .await;
+        self.finish_peer_link_operation(lease, result).await
+    }
+
+    /// Receive private messages from every locally linked counterparty.
+    pub async fn receive_private_messages_from_linked_peers(
+        &self,
+    ) -> Result<Vec<PrivateStreamCounterpartyIntakeReport>> {
+        let counterparties = self
+            .linked_peers()
+            .await?
+            .into_iter()
+            .filter(|record| record.state == LinkedPeerState::Linked)
+            .map(|record| record.counterparty)
+            .collect::<Vec<_>>();
+        let mut reports = Vec::with_capacity(counterparties.len());
+        for counterparty in counterparties {
+            match self.receive_private_messages(counterparty.clone()).await {
+                Ok(report) => reports.push(PrivateStreamCounterpartyIntakeReport {
+                    counterparty,
+                    report: Some(report),
+                    error: None,
+                }),
+                Err(err) => reports.push(PrivateStreamCounterpartyIntakeReport {
+                    counterparty,
+                    report: None,
+                    error: Some(err.to_string()),
+                }),
+            }
+        }
+        Ok(reports)
+    }
+
+    async fn receive_private_messages_with_claim(
+        &self,
+        counterparty: PubkyPublicKey,
+        lease: PeerLinkOperationLease,
+        session_access: PubkySessionAccess,
+    ) -> Result<PrivateStreamIntakeReport> {
+        let secret_key = *session_access
+            .local_secret_key
+            .as_ref()
+            .ok_or_else(|| PaykitSdkError::Identity {
+                context: "local Pubky secret key is unavailable for Encrypted Links".into(),
+                source: None,
+            })?
+            .as_bytes();
+        let remote_public_key = counterparty.to_public_key()?;
+
+        let stored_link_state = self
+            .storage
+            .transaction(|tx| Ok(tx.encrypted_link_state(&counterparty)))
+            .await?
+            .ok_or_else(|| {
+                PaykitSdkError::RecoveryRequired(format!(
+                    "no Encrypted Link state for counterparty {counterparty}"
+                ))
+            })?;
+        let Some(snapshot_bytes) = stored_link_state.link_snapshot.as_ref() else {
+            let now = self.clock.now();
+            let mark = mark_recovery_required_with_lease(
+                &self.storage,
+                counterparty.clone(),
+                lease.clone(),
+                now,
+            )
+            .await?;
+            let _ = self
+                .publish_local_recovery_marker_with_session(
+                    &counterparty,
+                    &session_access,
+                    mark.new_episode,
+                )
+                .await;
+            return Err(PaykitSdkError::RecoveryRequired(format!(
+                "no active Encrypted Link snapshot for counterparty {counterparty}"
+            )));
+        };
+        let snapshot = match paykit_lib::EncryptedLinkSnapshot::deserialize(snapshot_bytes) {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                let now = self.clock.now();
+                let mark = mark_recovery_required_with_lease(
+                    &self.storage,
+                    counterparty.clone(),
+                    lease.clone(),
+                    now,
+                )
+                .await?;
+                let _ = self
+                    .publish_local_recovery_marker_with_session(
+                        &counterparty,
+                        &session_access,
+                        mark.new_episode,
+                    )
+                    .await;
+                return Err(err.into());
+            }
+        };
+
+        let mut link = match paykit_lib::restore_encrypted_link(
+            session_access.session.clone(),
+            secret_key,
+            &remote_public_key,
+            session_access.outbox_client.clone(),
+            snapshot,
+        )
+        .await
+        {
+            Ok(link) => link,
+            Err(err) => {
+                let now = self.clock.now();
+                let mark = mark_recovery_required_with_lease(
+                    &self.storage,
+                    counterparty.clone(),
+                    lease.clone(),
+                    now,
+                )
+                .await?;
+                let _ = self
+                    .publish_local_recovery_marker_with_session(
+                        &counterparty,
+                        &session_access,
+                        mark.new_episode,
+                    )
+                    .await;
+                return Err(err.into());
+            }
+        };
+        let messages = match link.receive_private_application_messages().await {
+            Ok(messages) => messages,
+            Err(err) if err.is_non_retryable_private_receive_error() => {
+                let now = self.clock.now();
+                let mark = mark_recovery_required_with_lease(
+                    &self.storage,
+                    counterparty.clone(),
+                    lease.clone(),
+                    now,
+                )
+                .await?;
+                let _ = self
+                    .publish_local_recovery_marker_with_session(
+                        &counterparty,
+                        &session_access,
+                        mark.new_episode,
+                    )
+                    .await;
+                return Err(err.into());
+            }
+            Err(err) => return Err(err.into()),
+        };
+        let now = self.clock.now();
+        let next_link_state = EncryptedLinkStateRecord {
+            counterparty: counterparty.clone(),
+            link_snapshot: Some(link.serialize()),
+            handshake_snapshot: None,
+            handshake_role: None,
+            generation: stored_link_state.generation.saturating_add(1),
+            checkpointed_at: now,
+        };
+
+        persist_private_stream_batch_with_link_lease(
+            &self.storage,
+            counterparty,
+            messages,
+            Some(next_link_state),
+            Some(lease),
+            now,
+        )
+        .await
+    }
+}

--- a/paykit-sdk/src/runtime/public_endpoints.rs
+++ b/paykit-sdk/src/runtime/public_endpoints.rs
@@ -1,0 +1,217 @@
+use super::*;
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Publish current public receiving details and remove stale SDK-managed endpoints.
+    pub async fn sync_public_endpoints(&self) -> Result<EndpointSyncReport> {
+        let _identity_guard = self.claim_identity_operation("sync public endpoints")?;
+        let (session_access, _) = self.load_session_access_and_refresh_identity().await?;
+        let session_access = session_access.ok_or_else(|| PaykitSdkError::Identity {
+            context: "no Pubky session available".into(),
+            source: None,
+        })?;
+        let details = self
+            .payment
+            .current_receiving_details(ReceivingDetailScope::Public)
+            .await?;
+        let desired = normalize_receiving_details(details)?;
+        let now = self.clock.now();
+        let mut report = EndpointSyncReport::default();
+        let mut desired_entries = desired.iter().collect::<Vec<_>>();
+        desired_entries.sort_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
+
+        for (identifier, payload) in desired_entries {
+            self.storage
+                .transaction({
+                    let record = pending_publication_record(identifier, payload, now);
+                    move |tx| {
+                        tx.save_public_endpoint_record(record);
+                        Ok(())
+                    }
+                })
+                .await?;
+            match paykit_lib::set_payment_endpoint(
+                &session_access.session,
+                identifier.clone(),
+                payload.clone(),
+            )
+            .await
+            {
+                Ok(()) => {
+                    self.storage
+                        .transaction({
+                            let record = published_record(identifier, payload, now);
+                            move |tx| {
+                                tx.save_public_endpoint_record(record);
+                                Ok(())
+                            }
+                        })
+                        .await?;
+                    report.published.push(EndpointSyncChange {
+                        identifier: identifier.as_str().to_owned(),
+                        status: PublicationStatus::Published,
+                        error: None,
+                    });
+                }
+                Err(err) => {
+                    let error = err.to_string();
+                    self.storage
+                        .transaction({
+                            let record = failed_record(
+                                identifier.as_str().to_owned(),
+                                Some(payload.as_str().to_owned()),
+                                error.clone(),
+                                now,
+                            );
+                            move |tx| {
+                                tx.save_public_endpoint_record(record);
+                                Ok(())
+                            }
+                        })
+                        .await?;
+                    report.failed.push(EndpointSyncChange {
+                        identifier: identifier.as_str().to_owned(),
+                        status: PublicationStatus::Failed,
+                        error: Some(error),
+                    });
+                }
+            }
+        }
+
+        let removal_candidates = match self.config.endpoint_management_scope {
+            EndpointManagementScope::ManagedOnly => self
+                .storage
+                .transaction(|tx| Ok(tx.public_endpoint_records()))
+                .await?
+                .into_iter()
+                .filter(|record| {
+                    record.status != PublicationStatus::Removed
+                        && !desired
+                            .keys()
+                            .any(|identifier| identifier.as_str() == record.identifier)
+                })
+                .map(|record| (record.identifier, record.payload))
+                .collect::<Vec<_>>(),
+            EndpointManagementScope::FullPaykitNamespace => {
+                let local_public_key = session_access.session.info().public_key().clone();
+                let current = paykit_lib::get_payment_list(
+                    &session_access.outbox_client.public_storage(),
+                    &local_public_key,
+                )
+                .await?;
+                let remote_identifiers = current
+                    .payment_endpoints
+                    .keys()
+                    .map(|identifier| identifier.as_str().to_owned())
+                    .collect::<HashSet<_>>();
+                let already_removed = self
+                    .storage
+                    .transaction(|tx| Ok(tx.public_endpoint_records()))
+                    .await?
+                    .into_iter()
+                    .filter(|record| {
+                        matches!(
+                            record.status,
+                            PublicationStatus::PendingRemoval | PublicationStatus::Failed
+                        ) && !remote_identifiers.contains(&record.identifier)
+                            && !desired
+                                .keys()
+                                .any(|identifier| identifier.as_str() == record.identifier)
+                    })
+                    .collect::<Vec<_>>();
+                let mut already_removed = already_removed;
+                already_removed.sort_by(|left, right| left.identifier.cmp(&right.identifier));
+                for record in already_removed {
+                    self.storage
+                        .transaction({
+                            let removed = removed_record(record.identifier.clone(), now);
+                            move |tx| {
+                                tx.save_public_endpoint_record(removed);
+                                Ok(())
+                            }
+                        })
+                        .await?;
+                    report.removed.push(EndpointSyncChange {
+                        identifier: record.identifier,
+                        status: PublicationStatus::Removed,
+                        error: None,
+                    });
+                }
+                current
+                    .payment_endpoints
+                    .into_iter()
+                    .filter(|(identifier, _)| !desired.contains_key(identifier))
+                    .map(|(identifier, payload)| {
+                        (identifier.as_str().to_owned(), Some(payload.into_inner()))
+                    })
+                    .collect::<Vec<_>>()
+            }
+        };
+
+        let mut removal_candidates = removal_candidates;
+        removal_candidates.sort_by(|(left, _), (right, _)| left.cmp(right));
+        for (identifier_text, previous_payload) in removal_candidates {
+            let identifier = paykit_lib::PaymentEndpointIdentifier::new(&identifier_text)?;
+            self.storage
+                .transaction({
+                    let record = pending_removal_record(
+                        identifier_text.clone(),
+                        previous_payload.clone(),
+                        now,
+                    );
+                    move |tx| {
+                        tx.save_public_endpoint_record(record);
+                        Ok(())
+                    }
+                })
+                .await?;
+            match paykit_lib::remove_payment_endpoint(&session_access.session, identifier).await {
+                Ok(()) => {
+                    self.storage
+                        .transaction({
+                            let record = removed_record(identifier_text.clone(), now);
+                            move |tx| {
+                                tx.save_public_endpoint_record(record);
+                                Ok(())
+                            }
+                        })
+                        .await?;
+                    report.removed.push(EndpointSyncChange {
+                        identifier: identifier_text,
+                        status: PublicationStatus::Removed,
+                        error: None,
+                    });
+                }
+                Err(err) => {
+                    let error = err.to_string();
+                    self.storage
+                        .transaction({
+                            let record = failed_record(
+                                identifier_text.clone(),
+                                previous_payload,
+                                error.clone(),
+                                now,
+                            );
+                            move |tx| {
+                                tx.save_public_endpoint_record(record);
+                                Ok(())
+                            }
+                        })
+                        .await?;
+                    report.failed.push(EndpointSyncChange {
+                        identifier: identifier_text,
+                        status: PublicationStatus::Failed,
+                        error: Some(error),
+                    });
+                }
+            }
+        }
+
+        Ok(report)
+    }
+}

--- a/paykit-sdk/src/runtime/receipts.rs
+++ b/paykit-sdk/src/runtime/receipts.rs
@@ -1,0 +1,592 @@
+use super::*;
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Prepare a receipt issuance and persist it before network side effects.
+    ///
+    /// This does not store the Encrypted Receipt or queue Receipt Access. Use
+    /// [`Self::process_receipt_issuance`] to continue the network steps, or
+    /// [`Self::issue_receipt`] when the draft already has a Receipt ID.
+    pub async fn prepare_receipt_issuance(
+        &self,
+        counterparty: PubkyPublicKey,
+        draft: ReceiptDraft,
+    ) -> Result<ReceiptIssuanceView> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.public_key.is_none() {
+            return Err(PaykitSdkError::Identity {
+                context: "no local Pubky identity available for receipt issuance".into(),
+                source: None,
+            });
+        }
+        self.ensure_peer_not_blocked(&counterparty).await?;
+
+        if let Some(receipt_id) = draft.receipt_id.as_ref() {
+            if let Some(existing) =
+                load_receipt_issuance_record_by_receipt_id(&self.storage, receipt_id.as_str())
+                    .await?
+            {
+                if existing.counterparty != counterparty {
+                    return Err(PaykitSdkError::Protocol(format!(
+                        "Receipt issuance {} already exists for a different counterparty",
+                        existing.receipt_id
+                    )));
+                }
+                if !receipt_issuance_record_matches_draft(&existing, &draft)? {
+                    return Err(PaykitSdkError::Protocol(format!(
+                        "Receipt issuance {} for counterparty {} already exists with different fields",
+                        existing.receipt_id, counterparty
+                    )));
+                }
+                return Ok(ReceiptIssuanceView::from(&existing));
+            }
+        }
+
+        let now = self.clock.now();
+        let recipient = counterparty.to_public_key()?;
+        let prepared = paykit_lib::prepare_receipt_for_recipient(recipient, draft)?;
+        let record = ReceiptIssuanceRecord::from_prepared(counterparty, prepared, now)?;
+        self.storage
+            .transaction({
+                let record = record.clone();
+                move |tx| {
+                    if tx
+                        .receipt_issuance_record_by_receipt_id(&record.receipt_id)
+                        .is_some()
+                    {
+                        return Err(PaykitSdkError::Protocol(format!(
+                            "Receipt issuance {} already exists",
+                            record.receipt_id
+                        )));
+                    }
+                    tx.save_receipt_issuance_record(record);
+                    Ok(())
+                }
+            })
+            .await?;
+        Ok(ReceiptIssuanceView::from(&record))
+    }
+
+    /// Prepare, store, and queue Receipt Access for private delivery.
+    ///
+    /// The draft must include a Receipt ID so repeated calls are retry-safe.
+    /// The returned record reflects local issuance progress. Receipt Access
+    /// delivery still depends on processing the outbound private queue.
+    pub async fn issue_receipt(
+        &self,
+        counterparty: PubkyPublicKey,
+        draft: ReceiptDraft,
+    ) -> Result<ReceiptIssuanceView> {
+        if draft.receipt_id.is_none() {
+            return Err(PaykitSdkError::Protocol(
+                "issue_receipt requires a caller-provided Receipt ID for retry-safe issuance; use prepare_receipt_issuance first when the SDK should generate one".into(),
+            ));
+        }
+        let record = self
+            .prepare_receipt_issuance(counterparty.clone(), draft)
+            .await?;
+        self.process_receipt_issuance(counterparty, &record.receipt_id)
+            .await
+    }
+
+    /// Continue storage and Receipt Access queueing for a prepared issuance.
+    pub async fn process_receipt_issuance(
+        &self,
+        counterparty: PubkyPublicKey,
+        receipt_id: &str,
+    ) -> Result<ReceiptIssuanceView> {
+        self.ensure_private_outbound_ready(&counterparty).await?;
+        let (session_access, _) = self.private_link_session_access().await?;
+        let record = load_receipt_issuance_record(&self.storage, &counterparty, receipt_id)
+            .await?
+            .ok_or_else(|| {
+                PaykitSdkError::NotFound(format!(
+                    "Receipt issuance {receipt_id} for counterparty {counterparty} was not found"
+                ))
+            })?;
+        if record.status == ReceiptIssuanceStatus::AccessQueued {
+            return Ok(ReceiptIssuanceView::from(&record));
+        }
+
+        let record = if record.stored_at.is_some() {
+            record
+        } else {
+            match store_encrypted_receipt_json(&session_access.session, &record).await {
+                Ok(()) => {
+                    let stored = record.mark_stored(self.clock.now());
+                    self.storage
+                        .transaction({
+                            let stored = stored.clone();
+                            move |tx| {
+                                tx.save_receipt_issuance_record(stored);
+                                Ok(())
+                            }
+                        })
+                        .await?;
+                    stored
+                }
+                Err(err) => {
+                    let failed = record.mark_failed(self.clock.now(), err.to_string());
+                    self.storage
+                        .transaction({
+                            let failed = failed.clone();
+                            move |tx| {
+                                tx.save_receipt_issuance_record(failed);
+                                Ok(())
+                            }
+                        })
+                        .await?;
+                    return Err(err);
+                }
+            }
+        };
+
+        match enqueue_receipt_access_for_issuance(&self.storage, record.clone(), self.clock.now())
+            .await
+        {
+            Ok(queued) => Ok(ReceiptIssuanceView::from(&queued)),
+            Err(err) => {
+                let failed = record.mark_failed(self.clock.now(), err.to_string());
+                self.storage
+                    .transaction({
+                        let failed = failed.clone();
+                        move |tx| {
+                            tx.save_receipt_issuance_record(failed);
+                            Ok(())
+                        }
+                    })
+                    .await?;
+                Err(err)
+            }
+        }
+    }
+
+    /// List local receipt issuance records for one counterparty.
+    pub async fn receipt_issuance_records(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Vec<ReceiptIssuanceView>> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.public_key.is_none() {
+            return Ok(Vec::new());
+        }
+        self.ensure_peer_not_blocked(counterparty).await?;
+        let mut records = load_receipt_issuance_records(&self.storage, counterparty)
+            .await?
+            .iter()
+            .map(ReceiptIssuanceView::from)
+            .collect::<Vec<_>>();
+        records.sort_by_key(|record| Reverse(record.created_at));
+        Ok(records)
+    }
+
+    /// List issued receipts for one counterparty, newest first.
+    pub async fn issued_receipts_to(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Vec<ReceiptIssuanceView>> {
+        self.receipt_issuance_records(counterparty).await
+    }
+
+    /// List issued receipts across non-blocked counterparties, newest first.
+    pub async fn issued_receipts(&self) -> Result<Vec<ReceiptIssuanceView>> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.public_key.is_none() {
+            return Ok(Vec::new());
+        }
+        self.storage
+            .transaction(|tx| {
+                let snapshot = tx.export_storage_state();
+                let mut records = snapshot
+                    .receipt_issuance_records
+                    .into_values()
+                    .filter(|record| {
+                        !snapshot
+                            .linked_peers
+                            .get(&record.counterparty)
+                            .is_some_and(|peer| peer.state == LinkedPeerState::Blocked)
+                    })
+                    .map(|record| ReceiptIssuanceView::from(&record))
+                    .collect::<Vec<_>>();
+                records.sort_by_key(|record| Reverse(record.created_at));
+                Ok(records)
+            })
+            .await
+    }
+
+    /// Fetch, decrypt, and store a receipt from an indexed Receipt Access event.
+    ///
+    /// The decrypted Receipt is private SDK state. This returns an already
+    /// stored Receipt record when available, and otherwise validates the
+    /// decrypted recipient against the current local Pubky identity before
+    /// saving it.
+    pub async fn retrieve_receipt(
+        &self,
+        counterparty: PubkyPublicKey,
+        receipt_id: &str,
+    ) -> Result<ReceiptRecord> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        let local_public_key = identity
+            .public_key
+            .ok_or_else(|| PaykitSdkError::Identity {
+                context: "no local Pubky identity available for receipt retrieval".into(),
+                source: None,
+            })?;
+        self.ensure_peer_not_blocked(&counterparty).await?;
+        let (stored_receipt, access_records, conflicted_access_count, stored_receipt_conflicted) =
+            self.storage
+                .transaction(|tx| {
+                    let stored_receipt = tx.receipt_record(&counterparty, receipt_id);
+                    let stored_receipt_conflicted = stored_receipt.as_ref().is_some_and(|record| {
+                        tx.event_dedup_record(&counterparty, &record.receipt_access_event_id)
+                            .is_some_and(|dedupe| !dedupe.conflicting_stream_item_ids.is_empty())
+                    });
+                    let mut access_records = Vec::new();
+                    let mut conflicted_access_count = 0usize;
+                    for record in tx
+                        .receipt_access_records(&counterparty)
+                        .into_iter()
+                        .filter(|record| record.receipt_id == receipt_id)
+                    {
+                        if Self::receipt_access_event_is_conflicted(tx, &record) {
+                            conflicted_access_count += 1;
+                        } else {
+                            access_records.push(record);
+                        }
+                    }
+                    access_records.sort_by_key(|record| Reverse(record.stream_item_id));
+                    Ok((
+                        stored_receipt,
+                        access_records,
+                        conflicted_access_count,
+                        stored_receipt_conflicted,
+                    ))
+                })
+                .await?;
+        if let Some(record) = stored_receipt {
+            if record.recipient_public_key != local_public_key {
+                return Err(PaykitSdkError::Protocol(
+                    "stored Receipt recipient does not match local identity".into(),
+                ));
+            }
+            if stored_receipt_conflicted {
+                return Err(Self::conflicted_receipt_access_error(receipt_id));
+            }
+            if access_records.is_empty() && conflicted_access_count > 0 {
+                return Err(Self::conflicted_receipt_access_error(receipt_id));
+            }
+            self.reconcile_cached_receipt_access_records(
+                &record,
+                &access_records,
+                self.clock.now(),
+            )
+            .await?;
+            return Ok(record);
+        }
+        if access_records.is_empty() && conflicted_access_count > 0 {
+            return Err(Self::conflicted_receipt_access_error(receipt_id));
+        }
+        if access_records.is_empty() {
+            return Err(PaykitSdkError::RecoveryRequired(format!(
+                "no Receipt Access record for receipt {receipt_id} from {counterparty}"
+            )));
+        }
+        let public_storage =
+            self.pubky
+                .load_public_storage()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: "no Pubky public storage available for receipt retrieval".into(),
+                    source: None,
+                })?;
+        let now = self.clock.now();
+        let all_access_records = access_records.clone();
+        let mut last_error = None;
+        for access in access_records {
+            let encrypted_json = match fetch_encrypted_receipt_json(
+                &public_storage,
+                &counterparty,
+                &access.location,
+            )
+            .await
+            {
+                Ok(Some(encrypted_json)) => encrypted_json,
+                Ok(None) => {
+                    let error = format!(
+                        "encrypted receipt {} was not found at {}",
+                        access.receipt_id, access.location
+                    );
+                    self.save_receipt_retrieval_error(
+                        &access,
+                        ReceiptRetrievalStatus::NotFound,
+                        now,
+                        error.clone(),
+                    )
+                    .await?;
+                    last_error = Some(PaykitSdkError::Transport {
+                        context: error,
+                        source: None,
+                    });
+                    continue;
+                }
+                Err(err) => {
+                    let error = err.to_string();
+                    self.save_receipt_retrieval_error(
+                        &access,
+                        ReceiptRetrievalStatus::Failed,
+                        now,
+                        error,
+                    )
+                    .await?;
+                    last_error = Some(err);
+                    continue;
+                }
+            };
+
+            match decrypt_receipt_record_from_access(
+                &access,
+                &encrypted_json,
+                now,
+                &local_public_key,
+            ) {
+                Ok(record) => {
+                    self.storage
+                        .transaction({
+                            let access = access.mark_retrieved(now);
+                            let record = record.clone();
+                            move |tx| {
+                                tx.save_receipt_access_record(access);
+                                tx.save_receipt_record(record);
+                                Ok(())
+                            }
+                        })
+                        .await?;
+                    self.reconcile_cached_receipt_access_records(&record, &all_access_records, now)
+                        .await?;
+                    return Ok(record);
+                }
+                Err(err) => {
+                    let error = err.to_string();
+                    self.save_receipt_retrieval_error(
+                        &access,
+                        ReceiptRetrievalStatus::Failed,
+                        now,
+                        error,
+                    )
+                    .await?;
+                    last_error = Some(err);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| {
+            PaykitSdkError::RecoveryRequired(format!(
+                "no usable Receipt Access record for receipt {receipt_id} from {counterparty}"
+            ))
+        }))
+    }
+
+    /// List indexed Receipt Access records for one counterparty.
+    pub async fn receipt_access_records(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Vec<ReceiptAccessView>> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.public_key.is_none() {
+            return Ok(Vec::new());
+        }
+        self.ensure_peer_not_blocked(counterparty).await?;
+        self.storage
+            .transaction(|tx| {
+                let mut records = tx
+                    .receipt_access_records(counterparty)
+                    .into_iter()
+                    .filter(|record| !Self::receipt_access_event_is_conflicted(tx, record))
+                    .map(|record| ReceiptAccessView::from(&record))
+                    .collect::<Vec<_>>();
+                records.sort_by_key(|record| Reverse(record.received_at));
+                Ok(records)
+            })
+            .await
+    }
+
+    /// List Receipt Access received from one counterparty.
+    pub async fn receipt_access_from(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Vec<ReceiptAccessView>> {
+        self.receipt_access_records(counterparty).await
+    }
+
+    /// List Receipt Access across non-blocked counterparties, newest first.
+    pub async fn receipt_access(&self) -> Result<Vec<ReceiptAccessView>> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        if identity.public_key.is_none() {
+            return Ok(Vec::new());
+        }
+        self.storage
+            .transaction(|tx| {
+                let snapshot = tx.export_storage_state();
+                let mut records = snapshot
+                    .receipt_access_records
+                    .into_values()
+                    .filter(|record| {
+                        !snapshot
+                            .linked_peers
+                            .get(&record.counterparty)
+                            .is_some_and(|peer| peer.state == LinkedPeerState::Blocked)
+                    })
+                    .filter(|record| !Self::receipt_access_event_is_conflicted(tx, record))
+                    .map(|record| ReceiptAccessView::from(&record))
+                    .collect::<Vec<_>>();
+                records.sort_by_key(|record| Reverse(record.received_at));
+                Ok(records)
+            })
+            .await
+    }
+
+    /// List decrypted Receipt records for one issuer, newest first.
+    pub async fn receipt_records(&self, issuer: &PubkyPublicKey) -> Result<Vec<ReceiptRecord>> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        let Some(local_public_key) = identity.public_key else {
+            return Ok(Vec::new());
+        };
+        self.ensure_peer_not_blocked(issuer).await?;
+        self.storage
+            .transaction(|tx| {
+                let mut records = tx
+                    .export_storage_state()
+                    .receipt_records
+                    .into_values()
+                    .filter(|record| &record.issuer == issuer)
+                    .filter(|record| record.recipient_public_key == local_public_key)
+                    .filter(|record| !Self::receipt_record_access_event_is_conflicted(tx, record))
+                    .collect::<Vec<_>>();
+                records.sort_by_key(|record| Reverse(record.retrieved_at));
+                Ok(records)
+            })
+            .await
+    }
+
+    /// List decrypted receipts from one issuer, newest first.
+    pub async fn receipts_from(&self, issuer: &PubkyPublicKey) -> Result<Vec<ReceiptRecord>> {
+        self.receipt_records(issuer).await
+    }
+
+    /// List decrypted receipts across non-blocked issuers, newest first.
+    pub async fn receipts(&self) -> Result<Vec<ReceiptRecord>> {
+        let (_, identity) = self.load_session_access_and_refresh_identity().await?;
+        let Some(local_public_key) = identity.public_key else {
+            return Ok(Vec::new());
+        };
+        self.storage
+            .transaction(|tx| {
+                let snapshot = tx.export_storage_state();
+                let mut records = snapshot
+                    .receipt_records
+                    .into_values()
+                    .filter(|record| record.recipient_public_key == local_public_key)
+                    .filter(|record| {
+                        !snapshot
+                            .linked_peers
+                            .get(&record.issuer)
+                            .is_some_and(|peer| peer.state == LinkedPeerState::Blocked)
+                    })
+                    .filter(|record| !Self::receipt_record_access_event_is_conflicted(tx, record))
+                    .collect::<Vec<_>>();
+                records.sort_by_key(|record| Reverse(record.retrieved_at));
+                Ok(records)
+            })
+            .await
+    }
+
+    async fn reconcile_cached_receipt_access_records(
+        &self,
+        record: &ReceiptRecord,
+        access_records: &[ReceiptAccessRecord],
+        now: DateTime<Utc>,
+    ) -> Result<()> {
+        let has_mismatched_access = self
+            .storage
+            .transaction({
+                let record = record.clone();
+                let access_records = access_records.to_vec();
+                move |tx| {
+                    let mut has_mismatched_access = false;
+                    for access in access_records {
+                        if receipt_record_matches_access(&record, &access) {
+                            if access.retrieval_status != ReceiptRetrievalStatus::Retrieved {
+                                tx.save_receipt_access_record(access.mark_retrieved(now));
+                            }
+                        } else {
+                            has_mismatched_access = true;
+                            if access.retrieval_status == ReceiptRetrievalStatus::Pending {
+                                tx.save_receipt_access_record(access.mark_retrieval_error(
+                                    ReceiptRetrievalStatus::Failed,
+                                    now,
+                                    "Receipt Access does not match stored Receipt".into(),
+                                ));
+                            }
+                        }
+                    }
+                    Ok(has_mismatched_access)
+                }
+            })
+            .await?;
+        if has_mismatched_access {
+            return Err(Self::mismatched_receipt_access_error(&record.receipt_id));
+        }
+        Ok(())
+    }
+
+    fn receipt_access_event_is_conflicted(
+        tx: &dyn crate::storage::StorageTransaction,
+        access: &ReceiptAccessRecord,
+    ) -> bool {
+        tx.event_dedup_record(&access.counterparty, &access.event_id)
+            .is_some_and(|dedupe| !dedupe.conflicting_stream_item_ids.is_empty())
+    }
+
+    fn receipt_record_access_event_is_conflicted(
+        tx: &dyn crate::storage::StorageTransaction,
+        record: &ReceiptRecord,
+    ) -> bool {
+        tx.event_dedup_record(&record.issuer, &record.receipt_access_event_id)
+            .is_some_and(|dedupe| !dedupe.conflicting_stream_item_ids.is_empty())
+    }
+
+    fn conflicted_receipt_access_error(receipt_id: &str) -> PaykitSdkError {
+        PaykitSdkError::Protocol(format!(
+            "Receipt Access event for receipt {receipt_id} has a conflicting Event ID"
+        ))
+    }
+
+    fn mismatched_receipt_access_error(receipt_id: &str) -> PaykitSdkError {
+        PaykitSdkError::Protocol(format!(
+            "Receipt Access descriptor for receipt {receipt_id} conflicts with stored Receipt"
+        ))
+    }
+
+    async fn save_receipt_retrieval_error(
+        &self,
+        access: &ReceiptAccessRecord,
+        status: ReceiptRetrievalStatus,
+        attempted_at: DateTime<Utc>,
+        error: String,
+    ) -> Result<()> {
+        self.storage
+            .transaction({
+                let access = access.mark_retrieval_error(status, attempted_at, error);
+                move |tx| {
+                    tx.save_receipt_access_record(access);
+                    Ok(())
+                }
+            })
+            .await
+    }
+}

--- a/paykit-sdk/src/runtime/recovery.rs
+++ b/paykit-sdk/src/runtime/recovery.rs
@@ -1,0 +1,638 @@
+use super::*;
+
+impl<S, K, P, C> PaykitSdk<S, K, P, C>
+where
+    S: StorageAdapter,
+    K: PubkySessionProvider,
+    P: PaymentAdapter,
+    C: Clock,
+{
+    /// Return tracked Encrypted Link recovery marker state for a counterparty.
+    pub async fn encrypted_link_recovery_marker_status(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Option<EncryptedLinkRecoveryMarkerReport>> {
+        recovery_marker_report(&self.storage, counterparty).await
+    }
+
+    /// Publish a minimal local recovery marker for a counterparty.
+    pub async fn publish_encrypted_link_recovery_marker(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        self.ensure_recovery_marker_publishing_enabled()?;
+        let (session_access, _) = self.private_link_session_access().await?;
+        let lease = self.claim_peer_link_operation(&counterparty).await?;
+        let result = self
+            .publish_encrypted_link_recovery_marker_with_claim(
+                counterparty,
+                session_access,
+                lease.clone(),
+            )
+            .await;
+        self.finish_peer_link_operation(lease, result).await
+    }
+
+    /// Observe a counterparty's public recovery marker.
+    pub async fn observe_encrypted_link_recovery_marker(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        let (session_access, _) = self.private_link_session_access().await?;
+        self.observe_remote_recovery_marker_with_session(&counterparty, &session_access)
+            .await
+    }
+
+    /// Remove the local public recovery marker for a counterparty.
+    pub async fn remove_encrypted_link_recovery_marker(
+        &self,
+        counterparty: PubkyPublicKey,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        let (session_access, secret_key) = self.private_link_session_access().await?;
+        let remote_public_key = counterparty.to_public_key()?;
+        paykit_lib::remove_encrypted_link_recovery_marker(
+            &session_access.session,
+            &secret_key,
+            &remote_public_key,
+        )
+        .await?;
+
+        self.storage
+            .transaction(|tx| {
+                if let Some(mut peer) = tx.linked_peer(&counterparty) {
+                    peer.local_recovery_attempt_id = None;
+                    peer.local_recovery_marker_created_at = None;
+                    peer.local_recovery_marker_last_error = None;
+                    tx.save_linked_peer(peer);
+                }
+                Ok(())
+            })
+            .await?;
+        self.recovery_marker_report_or_default(&counterparty, false)
+            .await
+    }
+
+    #[cfg(test)]
+    pub(super) async fn mark_private_recovery_pending(
+        &self,
+        counterparty: &PubkyPublicKey,
+        expected_link_generation: Option<u64>,
+    ) -> Result<RecoveryRequiredUpdate> {
+        self.mark_private_recovery_pending_inner(counterparty, expected_link_generation, None)
+            .await
+    }
+
+    #[cfg(test)]
+    async fn mark_private_recovery_pending_inner(
+        &self,
+        counterparty: &PubkyPublicKey,
+        expected_link_generation: Option<u64>,
+        lease: Option<PeerLinkOperationLease>,
+    ) -> Result<RecoveryRequiredUpdate> {
+        let now = self.clock.now();
+        self.storage
+            .transaction(|tx| {
+                if let Some(lease) = lease.as_ref() {
+                    crate::storage::require_peer_link_operation_lease(tx, lease)?;
+                } else if tx.peer_link_operation_lease(counterparty).is_some() {
+                    return Ok(RecoveryRequiredUpdate::Skipped);
+                }
+                let current_generation = tx
+                    .encrypted_link_state(counterparty)
+                    .map(|state| state.generation);
+                if current_generation != expected_link_generation {
+                    return Ok(RecoveryRequiredUpdate::Skipped);
+                }
+                let mark = mark_recovery_required_in_transaction(tx, counterparty, now)?;
+                Ok(RecoveryRequiredUpdate::Marked {
+                    new_episode: mark.new_episode,
+                })
+            })
+            .await
+    }
+
+    async fn publish_encrypted_link_recovery_marker_with_claim(
+        &self,
+        counterparty: PubkyPublicKey,
+        session_access: PubkySessionAccess,
+        lease: PeerLinkOperationLease,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        let new_episode = self
+            .mark_recovery_required_for_marker_with_lease(&counterparty, lease)
+            .await?;
+        self.publish_local_recovery_marker_with_session(&counterparty, &session_access, new_episode)
+            .await
+    }
+
+    async fn mark_recovery_required_for_marker_with_lease(
+        &self,
+        counterparty: &PubkyPublicKey,
+        lease: PeerLinkOperationLease,
+    ) -> Result<bool> {
+        let now = self.clock.now();
+        self.storage
+            .transaction(|tx| {
+                crate::storage::require_peer_link_operation_lease(tx, &lease)?;
+                let existing_peer = tx.linked_peer(counterparty);
+                let has_link_state = tx.encrypted_link_state(counterparty).is_some();
+                if !can_publish_recovery_marker(existing_peer.as_ref(), has_link_state) {
+                    return Err(PaykitSdkError::Policy(format!(
+                        "cannot publish Encrypted Link recovery marker without existing private link state for counterparty {counterparty}"
+                    )));
+                }
+                let mark =
+                    mark_recovery_required_for_marker_in_transaction(tx, counterparty, now)?;
+                Ok(mark.new_episode)
+            })
+            .await
+    }
+
+    pub(super) async fn publish_local_recovery_marker_if_possible(
+        &self,
+        counterparty: &PubkyPublicKey,
+        force_new_attempt: bool,
+    ) {
+        let (session_access, _) = match self.private_link_session_access().await {
+            Ok(value) => value,
+            Err(err) => {
+                let _ = self
+                    .save_local_recovery_marker_last_error(
+                        counterparty,
+                        Some(recovery_marker_error_text(&err)),
+                    )
+                    .await;
+                return;
+            }
+        };
+        if let Err(err) = self
+            .publish_local_recovery_marker_with_session(
+                counterparty,
+                &session_access,
+                force_new_attempt,
+            )
+            .await
+        {
+            let _ = self
+                .save_local_recovery_marker_last_error(counterparty, Some(err.to_string()))
+                .await;
+        }
+    }
+
+    async fn save_local_recovery_marker_last_error(
+        &self,
+        counterparty: &PubkyPublicKey,
+        error: Option<String>,
+    ) -> Result<()> {
+        self.storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| {
+                    if let Some(mut peer) = tx.linked_peer(&counterparty) {
+                        peer.local_recovery_marker_last_error = error;
+                        tx.save_linked_peer(peer);
+                    }
+                    Ok(())
+                }
+            })
+            .await
+    }
+
+    pub(super) async fn publish_local_recovery_marker_with_session(
+        &self,
+        counterparty: &PubkyPublicKey,
+        session_access: &PubkySessionAccess,
+        force_new_attempt: bool,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        if self.config.encrypted_link_recovery_markers
+            == EncryptedLinkRecoveryMarkerPolicy::Disabled
+        {
+            return self
+                .recovery_marker_report_or_default(counterparty, false)
+                .await;
+        }
+
+        let secret_key = session_access
+            .local_secret_key
+            .as_ref()
+            .ok_or_else(|| PaykitSdkError::Identity {
+                context:
+                    "local Pubky secret key is unavailable for Encrypted Link recovery markers"
+                        .into(),
+                source: None,
+            })?
+            .as_bytes();
+        let remote_public_key = counterparty.to_public_key()?;
+        let now = self.clock.now();
+        let marker = self
+            .storage
+            .transaction(|tx| {
+                let mut peer = recovery_peer_or_default(tx.linked_peer(counterparty), counterparty);
+                if peer.state != LinkedPeerState::RecoveryRequired {
+                    return Err(PaykitSdkError::Policy(format!(
+                        "cannot publish Encrypted Link recovery marker unless counterparty {counterparty} is recovery-required"
+                    )));
+                }
+                let has_link_state = tx.encrypted_link_state(counterparty).is_some();
+                if !can_publish_recovery_marker(Some(&peer), has_link_state) {
+                    return Err(PaykitSdkError::Policy(format!(
+                        "cannot publish Encrypted Link recovery marker without existing private link state for counterparty {counterparty}"
+                    )));
+                }
+                let reusable_marker = if !force_new_attempt
+                    && peer.state == LinkedPeerState::RecoveryRequired
+                    && local_recovery_marker_belongs_to_current_episode(&peer)
+                {
+                    peer.local_recovery_attempt_id
+                        .as_ref()
+                        .zip(peer.local_recovery_marker_created_at)
+                        .map(|(attempt_id, created_at)| {
+                            let created_at_text =
+                                created_at.to_rfc3339_opts(SecondsFormat::Secs, true);
+                            EncryptedLinkRecoveryMarker::new(attempt_id.clone(), created_at_text)
+                                .map(|marker| (marker, created_at))
+                        })
+                        .transpose()?
+                } else {
+                    None
+                };
+                let (marker, marker_created_at) = reusable_marker
+                    .map(Ok)
+                    .unwrap_or_else(|| {
+                        EncryptedLinkRecoveryMarker::new_v4(
+                            now.to_rfc3339_opts(SecondsFormat::Secs, true),
+                        )
+                        .map(|marker| (marker, now))
+                    })?;
+                peer.local_recovery_attempt_id = Some(marker.attempt_id().to_owned());
+                peer.local_recovery_marker_created_at = Some(marker_created_at);
+                tx.save_linked_peer(peer);
+                Ok(marker)
+            })
+            .await?;
+        if let Err(err) = paykit_lib::publish_encrypted_link_recovery_marker(
+            &session_access.session,
+            secret_key,
+            &remote_public_key,
+            &marker,
+        )
+        .await
+        {
+            let sdk_err = PaykitSdkError::from(err);
+            self.save_local_recovery_marker_last_error(counterparty, Some(sdk_err.to_string()))
+                .await?;
+            return Err(sdk_err);
+        }
+
+        self.save_local_recovery_marker_last_error(counterparty, None)
+            .await?;
+
+        self.recovery_marker_report_or_default(counterparty, false)
+            .await
+    }
+
+    pub(super) async fn observe_remote_recovery_marker_for_cached_private_state(
+        &self,
+        counterparty: &PubkyPublicKey,
+        session_access: Option<&PubkySessionAccess>,
+    ) -> Result<()> {
+        if self.config.encrypted_link_recovery_markers
+            == EncryptedLinkRecoveryMarkerPolicy::Disabled
+        {
+            return Ok(());
+        }
+
+        let session_access = match session_access {
+            Some(session_access) => session_access,
+            None => {
+                let (session_access, _) = self.private_link_session_access().await?;
+                return self
+                    .observe_remote_recovery_marker_with_session(counterparty, &session_access)
+                    .await
+                    .map(|_| ());
+            }
+        };
+
+        self.observe_remote_recovery_marker_with_session(counterparty, session_access)
+            .await
+            .map(|_| ())
+    }
+
+    pub(super) async fn observe_remote_recovery_marker_with_session(
+        &self,
+        counterparty: &PubkyPublicKey,
+        session_access: &PubkySessionAccess,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        if self.config.encrypted_link_recovery_markers
+            == EncryptedLinkRecoveryMarkerPolicy::Disabled
+        {
+            return self
+                .recovery_marker_report_or_default(counterparty, false)
+                .await;
+        }
+
+        let public_storage =
+            self.pubky
+                .load_public_storage()
+                .await?
+                .ok_or_else(|| PaykitSdkError::Identity {
+                    context: "no Pubky public storage available for recovery marker lookup".into(),
+                    source: None,
+                })?;
+        let secret_key = session_access
+            .local_secret_key
+            .as_ref()
+            .ok_or_else(|| PaykitSdkError::Identity {
+                context:
+                    "local Pubky secret key is unavailable for Encrypted Link recovery markers"
+                        .into(),
+                source: None,
+            })?
+            .as_bytes();
+        let remote_public_key = counterparty.to_public_key()?;
+        let Some(marker) = paykit_lib::fetch_encrypted_link_recovery_marker(
+            &public_storage,
+            secret_key,
+            &remote_public_key,
+        )
+        .await?
+        else {
+            return self
+                .recovery_marker_report_or_default(counterparty, false)
+                .await;
+        };
+
+        let attempt_id = marker.attempt_id().to_owned();
+        let marker_created_at = parse_recovery_marker_created_at(&marker)?;
+        let changed = self
+            .mark_remote_recovery_marker_observed_if_needed(
+                counterparty,
+                &attempt_id,
+                marker_created_at,
+            )
+            .await?;
+        self.recovery_marker_report_or_default(counterparty, changed)
+            .await
+    }
+
+    pub(super) async fn mark_remote_recovery_marker_observed_if_needed(
+        &self,
+        counterparty: &PubkyPublicKey,
+        attempt_id: &str,
+        marker_created_at: DateTime<Utc>,
+    ) -> Result<bool> {
+        let should_mutate = self
+            .storage
+            .transaction(|tx| {
+                let existing_peer = tx.linked_peer(counterparty);
+                let link_state = tx.encrypted_link_state(counterparty);
+                if remote_recovery_marker_is_stale(link_state.as_ref(), marker_created_at) {
+                    return Ok(false);
+                }
+                let has_link_state = link_state.is_some();
+                if !can_publish_recovery_marker(existing_peer.as_ref(), has_link_state) {
+                    return Ok(false);
+                }
+                let peer = recovery_peer_or_default(existing_peer, counterparty);
+                if peer.remote_recovery_attempt_id.as_deref() == Some(attempt_id) {
+                    return Ok(false);
+                }
+                if peer.state == LinkedPeerState::Blocked {
+                    return Err(PaykitSdkError::Policy(format!(
+                        "counterparty {counterparty} is blocked"
+                    )));
+                }
+                Ok(true)
+            })
+            .await?;
+        if !should_mutate {
+            return Ok(false);
+        }
+
+        let lease = self.claim_peer_link_operation(counterparty).await?;
+        let result = self
+            .mark_remote_recovery_marker_observed_with_lease(
+                counterparty,
+                attempt_id,
+                marker_created_at,
+                lease.clone(),
+            )
+            .await;
+        self.finish_peer_link_operation(lease, result).await
+    }
+
+    async fn mark_remote_recovery_marker_observed_with_lease(
+        &self,
+        counterparty: &PubkyPublicKey,
+        attempt_id: &str,
+        marker_created_at: DateTime<Utc>,
+        lease: PeerLinkOperationLease,
+    ) -> Result<bool> {
+        let now = self.clock.now();
+        self.storage
+            .transaction(|tx| {
+                crate::storage::require_peer_link_operation_lease(tx, &lease)?;
+                let existing_peer = tx.linked_peer(counterparty);
+                let link_state = tx.encrypted_link_state(counterparty);
+                if remote_recovery_marker_is_stale(link_state.as_ref(), marker_created_at) {
+                    return Ok(false);
+                }
+                let has_link_state = link_state.is_some();
+                if !can_publish_recovery_marker(existing_peer.as_ref(), has_link_state) {
+                    return Ok(false);
+                }
+                let peer = recovery_peer_or_default(existing_peer, counterparty);
+                if peer.remote_recovery_attempt_id.as_deref() == Some(attempt_id) {
+                    return Ok(false);
+                }
+                if peer.state == LinkedPeerState::Blocked {
+                    return Err(PaykitSdkError::Policy(format!(
+                        "counterparty {counterparty} is blocked"
+                    )));
+                }
+                mark_recovery_required_in_transaction(tx, counterparty, now)?;
+                let mut peer = recovery_peer_or_default(tx.linked_peer(counterparty), counterparty);
+                peer.remote_recovery_attempt_id = Some(attempt_id.to_owned());
+                peer.remote_recovery_marker_observed_at = Some(now);
+                peer.last_sync_at = Some(now);
+                tx.save_linked_peer(peer);
+                Ok(true)
+            })
+            .await
+    }
+
+    pub(super) async fn recovery_marker_report_or_default(
+        &self,
+        counterparty: &PubkyPublicKey,
+        remote_marker_changed: bool,
+    ) -> Result<EncryptedLinkRecoveryMarkerReport> {
+        let peer = self
+            .storage
+            .transaction(|tx| {
+                Ok(recovery_peer_or_default(
+                    tx.linked_peer(counterparty),
+                    counterparty,
+                ))
+            })
+            .await?;
+        Ok(EncryptedLinkRecoveryMarkerReport::from_peer(
+            &peer,
+            remote_marker_changed,
+        ))
+    }
+
+    pub(super) async fn remove_local_recovery_marker_if_recorded(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<()> {
+        let (session_access, secret_key) = match self.private_link_session_access().await {
+            Ok(value) => value,
+            Err(err) => {
+                if self
+                    .has_local_recovery_marker(counterparty)
+                    .await
+                    .unwrap_or(false)
+                {
+                    let _ = self
+                        .save_local_recovery_marker_last_error(
+                            counterparty,
+                            Some(recovery_marker_error_text(&err)),
+                        )
+                        .await;
+                }
+                return Ok(());
+            }
+        };
+        let has_local_marker = self
+            .has_local_recovery_marker(counterparty)
+            .await
+            .unwrap_or(false);
+        if !has_local_marker {
+            return Ok(());
+        }
+
+        let Ok(remote_public_key) = counterparty.to_public_key() else {
+            let _ = self
+                .save_local_recovery_marker_last_error(
+                    counterparty,
+                    Some("invalid counterparty Pubky public key".into()),
+                )
+                .await;
+            return Ok(());
+        };
+        if let Err(err) = paykit_lib::remove_encrypted_link_recovery_marker(
+            &session_access.session,
+            &secret_key,
+            &remote_public_key,
+        )
+        .await
+        {
+            let _ = self
+                .save_local_recovery_marker_last_error(counterparty, Some(err.to_string()))
+                .await;
+            return Ok(());
+        }
+        self.storage
+            .transaction(|tx| {
+                if let Some(mut peer) = tx.linked_peer(counterparty) {
+                    peer.local_recovery_attempt_id = None;
+                    peer.local_recovery_marker_created_at = None;
+                    peer.local_recovery_marker_last_error = None;
+                    tx.save_linked_peer(peer);
+                }
+                Ok(())
+            })
+            .await
+    }
+
+    pub(super) async fn has_local_recovery_marker(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<bool> {
+        self.storage
+            .transaction(|tx| {
+                Ok(tx
+                    .linked_peer(counterparty)
+                    .and_then(|peer| peer.local_recovery_attempt_id)
+                    .is_some())
+            })
+            .await
+    }
+}
+
+fn recovery_marker_error_text(err: &PaykitSdkError) -> String {
+    match err {
+        PaykitSdkError::Identity { context, .. } => context.clone(),
+        PaykitSdkError::Storage { context, .. } => context.clone(),
+        PaykitSdkError::Transport { context, .. } => context.clone(),
+        PaykitSdkError::PaymentAdapter { context, .. } => context.clone(),
+        PaykitSdkError::NotFound(_)
+        | PaykitSdkError::Protocol(_)
+        | PaykitSdkError::Policy(_)
+        | PaykitSdkError::RecoveryRequired(_) => err.to_string(),
+    }
+}
+fn recovery_peer_or_default(
+    peer: Option<LinkedPeerRecord>,
+    counterparty: &PubkyPublicKey,
+) -> LinkedPeerRecord {
+    peer.unwrap_or_else(|| LinkedPeerRecord {
+        counterparty: counterparty.clone(),
+        state: LinkedPeerState::NotLinked,
+        last_sync_at: None,
+        last_private_receive_at: None,
+        failure_count: 0,
+        local_recovery_attempt_id: None,
+        local_recovery_marker_created_at: None,
+        local_recovery_marker_last_error: None,
+        remote_recovery_attempt_id: None,
+        remote_recovery_marker_observed_at: None,
+    })
+}
+
+fn can_publish_recovery_marker(peer: Option<&LinkedPeerRecord>, has_link_state: bool) -> bool {
+    has_link_state
+        || peer.is_some_and(|peer| {
+            matches!(
+                peer.state,
+                LinkedPeerState::Linking
+                    | LinkedPeerState::Linked
+                    | LinkedPeerState::RecoveryRequired
+            )
+        })
+}
+
+fn parse_recovery_marker_created_at(marker: &EncryptedLinkRecoveryMarker) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(marker.created_at())
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .map_err(|err| {
+            PaykitSdkError::Protocol(format!("invalid recovery marker timestamp: {err}"))
+        })
+}
+
+fn remote_recovery_marker_is_stale(
+    link_state: Option<&EncryptedLinkStateRecord>,
+    marker_created_at: DateTime<Utc>,
+) -> bool {
+    // Recovery marker timestamps are serialized with second precision, so
+    // same-second markers are treated as fresh and fail closed.
+    link_state
+        .and_then(|state| {
+            (state.link_snapshot.is_some() || state.handshake_snapshot.is_some())
+                .then_some(state.checkpointed_at)
+        })
+        .is_some_and(|checkpointed_at| marker_created_at.timestamp() < checkpointed_at.timestamp())
+}
+
+pub(super) fn local_recovery_marker_belongs_to_current_episode(peer: &LinkedPeerRecord) -> bool {
+    let Some(created_at) = peer.local_recovery_marker_created_at else {
+        return false;
+    };
+    peer.last_sync_at
+        .map(|recovery_started_at| created_at >= recovery_started_at)
+        .unwrap_or(true)
+}
+#[cfg(test)]
+pub(super) enum RecoveryRequiredUpdate {
+    Skipped,
+    Marked { new_episode: bool },
+}


### PR DESCRIPTION
## Summary

Replacement stack PR 2/5 for the Paykit SDK split.

Adds the SDK runtime workflow layer on top of the domain/storage foundation:

- initialization and sign-out handling
- public Payment Endpoint sync
- Encrypted Link initiate/accept/advance flows
- private stream receive/checkpoint flow
- outbound private message processing
- Private Payment List publication and contact payment resolution
- Payment Request workflow APIs
- receipt issuance/retrieval workflows
- backup/restore entry points
- recovery marker workflows

## Stack

Base: `codex/sdk-review-01-foundation`

The final stack branch was verified to match draft reference PR #55 exactly.

## Verification

- `cargo fmt --check`
- `cargo check -p paykit-sdk`
