### PR TITLE
Add SDK domain and storage tests

### DIFF
--- a/paykit-sdk/src/backup.rs
+++ b/paykit-sdk/src/backup.rs
@@ -527,3 +527,6 @@ impl SdkBackupState {
             || !self.receipt_issuance_records.is_empty()
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/backup/tests.rs
+++ b/paykit-sdk/src/backup/tests.rs
@@ -1,0 +1,132 @@
+use chrono::{TimeZone, Utc};
+
+use super::*;
+use crate::{
+    identity::PubkyIdentityCapability, outbound_private::OutboundPrivateMessageStatus,
+    private_stream::PrivateStreamParseStatus, storage::InMemoryStorage,
+};
+
+fn timestamp() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+}
+
+fn public_key() -> PubkyPublicKey {
+    PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+}
+
+fn identity(public_key: PubkyPublicKey) -> IdentityState {
+    IdentityState {
+        public_key: Some(public_key),
+        capability: PubkyIdentityCapability::PrivateLinkCapable,
+        local_secret_available: true,
+        initialized_at: timestamp(),
+        sign_out_generation: 0,
+    }
+}
+
+fn signed_out_identity(sign_out_generation: u64) -> IdentityState {
+    IdentityState {
+        public_key: None,
+        capability: PubkyIdentityCapability::SignedOut,
+        local_secret_available: false,
+        initialized_at: timestamp(),
+        sign_out_generation,
+    }
+}
+
+fn contact_record(public_key: PubkyPublicKey) -> ContactRecord {
+    ContactRecord {
+        public_key,
+        label: Some("Alice".into()),
+        profile: None,
+        profile_fetched_at: None,
+        created_at: timestamp(),
+        updated_at: timestamp(),
+        public_contact_marker_status: crate::PublicationStatus::NotPublished,
+        public_contact_published_at: None,
+        public_contact_removed_at: None,
+        public_contact_last_error: None,
+    }
+}
+
+fn payment_request_json(event_id: &str) -> String {
+    format!(
+        r#"{{"version":1,"kind":"paykit.payment_request","event_id":"{event_id}","payment_request_id":"550e8400-e29b-41d4-a716-446655440000","request":{{"amount":{{"value":"1","asset":"btc"}},"payment_reference":"invoice-2026-0001","proposal_expires_at":null,"recurrence":null,"accepted_payment_endpoint_identifiers":["btc-lightning-bolt11"],"metadata":{{}}}}}}"#
+    )
+}
+
+fn private_payment_list_outbound(
+    counterparty: PubkyPublicKey,
+    outbound_message_id: u64,
+    payload: &str,
+) -> OutboundPrivateMessageRecord {
+    OutboundPrivateMessageRecord {
+        outbound_message_id,
+        counterparty,
+        kind: PrivateMessageKind::PrivatePaymentList.as_str().into(),
+        raw_json: format!(
+            r#"{{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{{"btc-lightning-bolt11":"{payload}"}}}}"#
+        ),
+        status: OutboundPrivateMessageStatus::Pending,
+        attempt_count: 0,
+        created_at: timestamp(),
+        updated_at: timestamp(),
+        last_attempt_at: None,
+        sent_at: None,
+        last_error: None,
+    }
+}
+
+async fn assert_restore_rejects_outbound_record(record: OutboundPrivateMessageRecord) {
+    let storage = InMemoryStorage::new();
+    let counterparty = record.counterparty.clone();
+    let next_id = record.outbound_message_id.saturating_add(1);
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty)),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: vec![record],
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: next_id,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+fn receipt_access_raw_with_context(
+    event_id: &str,
+    receipt_id: &str,
+    payment_reference: &str,
+    payment_request_id: &str,
+    billing_period: &BillingPeriodRecord,
+) -> (String, String, String) {
+    let receipt_id = ReceiptId::new(receipt_id).unwrap();
+    let location = paykit_lib::ReceiptAccess::location_for(&receipt_id);
+    let key = paykit_lib::ReceiptDecryptionKey::generate()
+        .as_str()
+        .to_owned();
+    let raw_json = format!(
+        r#"{{"version":1,"kind":"paykit.receipt_access","event_id":"{event_id}","receipt_id":"{}","payment_reference":"{payment_reference}","payment_request_id":"{payment_request_id}","billing_period":{{"starts_at":"{}","ends_at":"{}"}},"location":"{location}","key":"{key}"}}"#,
+        receipt_id.as_str(),
+        billing_period.starts_at,
+        billing_period.ends_at
+    );
+    (raw_json, location, key)
+}
+
+mod basic;
+mod counters;
+mod recovery;
+mod validation;

--- a/paykit-sdk/src/backup/tests/basic.rs
+++ b/paykit-sdk/src/backup/tests/basic.rs
@@ -1,0 +1,271 @@
+use super::*;
+
+#[tokio::test]
+async fn test_export_backup_state_redacts_debug() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| {
+                    tx.save_identity_state(identity(counterparty.clone()));
+                    tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                        counterparty: counterparty.clone(),
+                        link_snapshot: Some(vec![1, 2, 3]),
+                        handshake_snapshot: None,
+                        handshake_role: None,
+                        generation: 0,
+                        checkpointed_at: timestamp(),
+                    });
+                    tx.insert_outbound_private_message(crate::storage::NewOutboundPrivateMessage::new(
+                        counterparty,
+                        "paykit.private_payment_list".into(),
+                        r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{"btc-lightning-bolt11":"ln-private-payload-marker"}}"#.into(),
+                        timestamp(),
+                    ));
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+
+    let backup = export_backup_state(&storage).await.unwrap();
+    let debug = format!("{backup:?}");
+
+    assert!(!debug.contains("ln-private-payload-marker"));
+    assert!(!debug.contains("[1, 2, 3]"));
+    assert!(!debug.contains(counterparty.as_str()));
+    assert_eq!(backup.outbound_private_messages.len(), 1);
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_marks_missing_link_checkpoint_recovery_required() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: vec![LinkedPeerRecord {
+            counterparty: counterparty.clone(),
+            state: LinkedPeerState::Linked,
+            last_sync_at: Some(timestamp()),
+            last_private_receive_at: None,
+            failure_count: 0,
+            local_recovery_attempt_id: None,
+            local_recovery_marker_created_at: None,
+            local_recovery_marker_last_error: None,
+            remote_recovery_attempt_id: None,
+            remote_recovery_marker_observed_at: None,
+        }],
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: vec![EncryptedLinkStateRecord {
+            counterparty: counterparty.clone(),
+            link_snapshot: None,
+            handshake_snapshot: None,
+            handshake_role: None,
+            generation: 0,
+            checkpointed_at: timestamp(),
+        }],
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let report = restore_backup_state(&storage, backup).await.unwrap();
+    let restored = storage.snapshot().unwrap();
+
+    assert_eq!(report.recovery_required_peers, vec![counterparty.clone()]);
+    assert_eq!(
+        restored.linked_peers.get(&counterparty).unwrap().state,
+        LinkedPeerState::RecoveryRequired
+    );
+    assert!(restored.peer_link_operation_leases.is_empty());
+}
+
+#[tokio::test]
+async fn test_backup_state_round_trips_contact_records() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = public_key();
+    let contact_public_key = public_key();
+    storage
+        .transaction({
+            let local_public_key = local_public_key.clone();
+            let contact_public_key = contact_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(identity(local_public_key));
+                tx.save_contact_record(contact_record(contact_public_key));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let backup = export_backup_state(&storage).await.unwrap();
+    let restore_storage = InMemoryStorage::new();
+    let report = restore_backup_state(&restore_storage, backup)
+        .await
+        .unwrap();
+    let restored = restore_storage.snapshot().unwrap();
+
+    assert_eq!(report.contact_records, 1);
+    assert_eq!(
+        restored.contact_records[&contact_public_key]
+            .label
+            .as_deref(),
+        Some("Alice")
+    );
+    assert!(report.recovery_required_peers.is_empty());
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_inconsistent_contact_marker_state() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = public_key();
+    let contact_public_key = public_key();
+    let mut contact = contact_record(contact_public_key);
+    contact.public_contact_published_at = Some(timestamp());
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(local_public_key)),
+        linked_peers: Vec::new(),
+        contact_records: vec![contact],
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_dual_contact_marker_timestamps() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = public_key();
+    let contact_public_key = public_key();
+    let mut contact = contact_record(contact_public_key)
+        .mark_public_contact_published(timestamp())
+        .mark_public_contact_removed(timestamp());
+    contact.public_contact_published_at = Some(timestamp());
+    contact.public_contact_marker_status = crate::PublicationStatus::Failed;
+    contact.public_contact_last_error = Some("failed".into());
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(local_public_key)),
+        linked_peers: Vec::new(),
+        contact_records: vec![contact],
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_accepts_pending_contact_marker_removal() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = public_key();
+    let contact_public_key = public_key();
+    let contact = contact_record(contact_public_key)
+        .mark_public_contact_published(timestamp())
+        .mark_public_contact_removal_pending(timestamp());
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(local_public_key)),
+        linked_peers: Vec::new(),
+        contact_records: vec![contact],
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let report = restore_backup_state(&storage, backup).await.unwrap();
+
+    assert_eq!(report.contact_records, 1);
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_preserves_next_peer_lease_id() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let lease = tx
+                    .claim_peer_link_operation(
+                        &counterparty,
+                        timestamp(),
+                        timestamp() + chrono::Duration::seconds(60),
+                    )
+                    .unwrap();
+                assert_eq!(lease.lease_id, 0);
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: None,
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    restore_backup_state(&storage, backup).await.unwrap();
+    let snapshot = storage.snapshot().unwrap();
+
+    assert!(snapshot.peer_link_operation_leases.is_empty());
+    assert_eq!(snapshot.next_peer_link_operation_lease_id, 1);
+}

--- a/paykit-sdk/src/backup/tests/counters.rs
+++ b/paykit-sdk/src/backup/tests/counters.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+#[tokio::test]
+async fn test_restore_backup_state_advances_counters() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: vec![OutboundPrivateMessageRecord {
+            outbound_message_id: 7,
+            counterparty: counterparty.clone(),
+            kind: "paykit.private_payment_list".into(),
+            raw_json:
+                r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#
+                    .into(),
+            status: OutboundPrivateMessageStatus::Pending,
+            attempt_count: 0,
+            created_at: timestamp(),
+            updated_at: timestamp(),
+            last_attempt_at: None,
+            sent_at: None,
+            last_error: None,
+        }],
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 9,
+            counterparty,
+            receive_batch_id: 3,
+            raw_json: "{}".into(),
+            parsed_version: None,
+            parsed_kind: None,
+            known_paykit_kind: None,
+            parse_status: PrivateStreamParseStatus::InvalidJson,
+            parse_error: None,
+            received_at: timestamp(),
+        }],
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 1,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 1,
+    };
+
+    restore_backup_state(&storage, backup).await.unwrap();
+    let restored = storage.snapshot().unwrap();
+
+    assert_eq!(restored.next_outbound_private_message_id, 8);
+    assert_eq!(restored.next_receive_batch_id, 4);
+    assert_eq!(restored.next_private_stream_item_id, 10);
+}

--- a/paykit-sdk/src/backup/tests/recovery.rs
+++ b/paykit-sdk/src/backup/tests/recovery.rs
@@ -1,0 +1,82 @@
+use super::*;
+
+#[tokio::test]
+async fn test_restore_backup_state_marks_link_state_without_peer_recovery_required() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: vec![EncryptedLinkStateRecord {
+            counterparty: counterparty.clone(),
+            link_snapshot: None,
+            handshake_snapshot: None,
+            handshake_role: None,
+            generation: 0,
+            checkpointed_at: timestamp(),
+        }],
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    restore_backup_state(&storage, backup).await.unwrap();
+    let restored = storage.snapshot().unwrap();
+
+    assert_eq!(
+        restored.linked_peers.get(&counterparty).unwrap().state,
+        LinkedPeerState::RecoveryRequired
+    );
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_preserves_private_stream_without_forcing_recovery() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 1,
+            counterparty: counterparty.clone(),
+            receive_batch_id: 0,
+            raw_json:
+                r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#
+                    .into(),
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.private_payment_list".into()),
+            known_paykit_kind: Some("paykit.private_payment_list".into()),
+            parse_status: PrivateStreamParseStatus::Valid,
+            parse_error: None,
+            received_at: timestamp(),
+        }],
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 2,
+    };
+
+    restore_backup_state(&storage, backup).await.unwrap();
+    let restored = storage.snapshot().unwrap();
+
+    assert!(!restored.linked_peers.contains_key(&counterparty));
+}

--- a/paykit-sdk/src/backup/tests/validation.rs
+++ b/paykit-sdk/src/backup/tests/validation.rs
@@ -1,0 +1,1635 @@
+use super::*;
+use crate::EncryptedLinkHandshakeRole;
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_malformed_link_snapshot() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: vec![EncryptedLinkStateRecord {
+            counterparty,
+            link_snapshot: Some(vec![1, 2, 3]),
+            handshake_snapshot: None,
+            handshake_role: None,
+            generation: 0,
+            checkpointed_at: timestamp(),
+        }],
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[test]
+fn test_recovery_required_restore_state_drops_link_snapshots() {
+    let counterparty = public_key();
+    let mut states = std::collections::HashMap::from([(
+        counterparty.clone(),
+        EncryptedLinkStateRecord {
+            counterparty: counterparty.clone(),
+            link_snapshot: Some(vec![1]),
+            handshake_snapshot: Some(vec![2]),
+            handshake_role: Some(EncryptedLinkHandshakeRole::Initiator),
+            generation: 7,
+            checkpointed_at: timestamp(),
+        },
+    )]);
+
+    clear_recovery_required_link_snapshots(&mut states, std::slice::from_ref(&counterparty));
+
+    let state = states.get(&counterparty).unwrap();
+    assert!(state.link_snapshot.is_none());
+    assert!(state.handshake_snapshot.is_none());
+    assert!(state.handshake_role.is_none());
+    assert_eq!(state.generation, 8);
+}
+
+#[test]
+fn test_restore_reconciliation_preserves_active_link_checkpoint() {
+    let counterparty = public_key();
+    let mut peers = std::collections::HashMap::from([(
+        counterparty.clone(),
+        LinkedPeerRecord {
+            counterparty: counterparty.clone(),
+            state: LinkedPeerState::Linked,
+            last_sync_at: Some(timestamp()),
+            last_private_receive_at: None,
+            failure_count: 0,
+            local_recovery_attempt_id: None,
+            local_recovery_marker_created_at: None,
+            local_recovery_marker_last_error: None,
+            remote_recovery_attempt_id: None,
+            remote_recovery_marker_observed_at: None,
+        },
+    )]);
+    let link_states = std::collections::HashMap::from([(
+        counterparty.clone(),
+        EncryptedLinkStateRecord {
+            counterparty: counterparty.clone(),
+            link_snapshot: Some(vec![1]),
+            handshake_snapshot: None,
+            handshake_role: None,
+            generation: 7,
+            checkpointed_at: timestamp(),
+        },
+    )]);
+
+    let recovery_required = reconcile_restored_linked_peers(&mut peers, &link_states, &Vec::new());
+
+    assert!(recovery_required.is_empty());
+    assert_eq!(
+        peers.get(&counterparty).unwrap().state,
+        LinkedPeerState::Linked
+    );
+}
+
+#[test]
+fn test_restore_reconciliation_preserves_handshake_checkpoint() {
+    let counterparty = public_key();
+    let mut peers = std::collections::HashMap::new();
+    let link_states = std::collections::HashMap::from([(
+        counterparty.clone(),
+        EncryptedLinkStateRecord {
+            counterparty: counterparty.clone(),
+            link_snapshot: None,
+            handshake_snapshot: Some(vec![2]),
+            handshake_role: Some(EncryptedLinkHandshakeRole::Initiator),
+            generation: 7,
+            checkpointed_at: timestamp(),
+        },
+    )]);
+
+    let recovery_required = reconcile_restored_linked_peers(&mut peers, &link_states, &Vec::new());
+
+    assert!(recovery_required.is_empty());
+    assert_eq!(
+        peers.get(&counterparty).unwrap().state,
+        LinkedPeerState::Linking
+    );
+}
+
+#[test]
+fn test_restore_reconciliation_preserves_existing_recovery_required_peer() {
+    let counterparty = public_key();
+    let mut peers = std::collections::HashMap::from([(
+        counterparty.clone(),
+        LinkedPeerRecord {
+            counterparty: counterparty.clone(),
+            state: LinkedPeerState::RecoveryRequired,
+            last_sync_at: Some(timestamp()),
+            last_private_receive_at: None,
+            failure_count: 1,
+            local_recovery_attempt_id: None,
+            local_recovery_marker_created_at: None,
+            local_recovery_marker_last_error: None,
+            remote_recovery_attempt_id: None,
+            remote_recovery_marker_observed_at: None,
+        },
+    )]);
+    let link_states = std::collections::HashMap::from([(
+        counterparty.clone(),
+        EncryptedLinkStateRecord {
+            counterparty: counterparty.clone(),
+            link_snapshot: Some(vec![1]),
+            handshake_snapshot: None,
+            handshake_role: None,
+            generation: 7,
+            checkpointed_at: timestamp(),
+        },
+    )]);
+
+    let recovery_required = reconcile_restored_linked_peers(&mut peers, &link_states, &Vec::new());
+
+    assert_eq!(recovery_required, vec![counterparty.clone()]);
+    assert_eq!(
+        peers.get(&counterparty).unwrap().state,
+        LinkedPeerState::RecoveryRequired
+    );
+}
+
+#[test]
+fn test_restore_reconciliation_marks_missing_checkpoint_recovery_required() {
+    let counterparty = public_key();
+    let mut peers = std::collections::HashMap::from([(
+        counterparty.clone(),
+        LinkedPeerRecord {
+            counterparty: counterparty.clone(),
+            state: LinkedPeerState::Linked,
+            last_sync_at: Some(timestamp()),
+            last_private_receive_at: None,
+            failure_count: 0,
+            local_recovery_attempt_id: None,
+            local_recovery_marker_created_at: None,
+            local_recovery_marker_last_error: None,
+            remote_recovery_attempt_id: None,
+            remote_recovery_marker_observed_at: None,
+        },
+    )]);
+    let link_states = std::collections::HashMap::from([(
+        counterparty.clone(),
+        EncryptedLinkStateRecord {
+            counterparty: counterparty.clone(),
+            link_snapshot: None,
+            handshake_snapshot: None,
+            handshake_role: None,
+            generation: 7,
+            checkpointed_at: timestamp(),
+        },
+    )]);
+
+    let recovery_required = reconcile_restored_linked_peers(&mut peers, &link_states, &Vec::new());
+
+    assert_eq!(recovery_required, vec![counterparty.clone()]);
+    assert_eq!(
+        peers.get(&counterparty).unwrap().state,
+        LinkedPeerState::RecoveryRequired
+    );
+}
+
+#[test]
+fn test_restore_reconciliation_marks_missing_link_state_recovery_required() {
+    let counterparty = public_key();
+    let mut peers = std::collections::HashMap::from([(
+        counterparty.clone(),
+        LinkedPeerRecord {
+            counterparty: counterparty.clone(),
+            state: LinkedPeerState::Linked,
+            last_sync_at: Some(timestamp()),
+            last_private_receive_at: None,
+            failure_count: 0,
+            local_recovery_attempt_id: None,
+            local_recovery_marker_created_at: None,
+            local_recovery_marker_last_error: None,
+            remote_recovery_attempt_id: None,
+            remote_recovery_marker_observed_at: None,
+        },
+    )]);
+    let link_states = std::collections::HashMap::new();
+
+    let recovery_required = reconcile_restored_linked_peers(&mut peers, &link_states, &Vec::new());
+
+    assert_eq!(recovery_required, vec![counterparty.clone()]);
+    assert_eq!(
+        peers.get(&counterparty).unwrap().state,
+        LinkedPeerState::RecoveryRequired
+    );
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_local_recovery_marker_without_created_at() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: vec![LinkedPeerRecord {
+            counterparty,
+            state: LinkedPeerState::RecoveryRequired,
+            last_sync_at: Some(timestamp()),
+            last_private_receive_at: None,
+            failure_count: 1,
+            local_recovery_attempt_id: Some("650e8400-e29b-41d4-a716-446655440000".into()),
+            local_recovery_marker_created_at: None,
+            local_recovery_marker_last_error: None,
+            remote_recovery_attempt_id: None,
+            remote_recovery_marker_observed_at: None,
+        }],
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_invalid_remote_recovery_attempt_id() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: vec![LinkedPeerRecord {
+            counterparty,
+            state: LinkedPeerState::RecoveryRequired,
+            last_sync_at: Some(timestamp()),
+            last_private_receive_at: None,
+            failure_count: 1,
+            local_recovery_attempt_id: None,
+            local_recovery_marker_created_at: None,
+            local_recovery_marker_last_error: None,
+            remote_recovery_attempt_id: Some("not-a-uuid".into()),
+            remote_recovery_marker_observed_at: Some(timestamp()),
+        }],
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_records_without_identity() {
+    let storage = InMemoryStorage::new();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: None,
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: vec![PublicEndpointRecord {
+            identifier: "btc-lightning-bolt11".into(),
+            payload: Some("ln".into()),
+            status: crate::PublicationStatus::Published,
+            updated_at: timestamp(),
+            last_error: None,
+        }],
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_invalid_public_endpoint_record() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(local_public_key)),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: vec![PublicEndpointRecord {
+            identifier: "private".into(),
+            payload: Some("ln".into()),
+            status: crate::PublicationStatus::Published,
+            updated_at: timestamp(),
+            last_error: None,
+        }],
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_inconsistent_public_endpoint_status() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(local_public_key)),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: vec![PublicEndpointRecord {
+            identifier: "btc-lightning-bolt11".into(),
+            payload: None,
+            status: crate::PublicationStatus::Published,
+            updated_at: timestamp(),
+            last_error: None,
+        }],
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_stale_private_stream_metadata() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 1,
+            counterparty,
+            receive_batch_id: 0,
+            raw_json:
+                r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#
+                    .into(),
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.receipt_access".into()),
+            known_paykit_kind: Some("paykit.receipt_access".into()),
+            parse_status: PrivateStreamParseStatus::Valid,
+            parse_error: None,
+            received_at: timestamp(),
+        }],
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 2,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_stale_private_stream_parse_status() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 1,
+            counterparty,
+            receive_batch_id: 0,
+            raw_json:
+                r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#
+                    .into(),
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.private_payment_list".into()),
+            known_paykit_kind: Some("paykit.private_payment_list".into()),
+            parse_status: PrivateStreamParseStatus::MalformedRecognized,
+            parse_error: Some("stale".into()),
+            received_at: timestamp(),
+        }],
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 2,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_stale_private_stream_parse_error() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let period = BillingPeriodRecord {
+        starts_at: "2026-06-01T00:00:00Z".into(),
+        ends_at: "2026-07-01T00:00:00Z".into(),
+    };
+    let (raw_json, location, _) = receipt_access_raw_with_context(
+        "650e8400-e29b-41d4-a716-446655440000",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "invoice-2026-0001",
+        "750e8400-e29b-41d4-a716-446655440000",
+        &period,
+    );
+    let raw_json = raw_json.replace(
+        &location,
+        "/pub/paykit/v0/private/receipts/not-the-receipt-id",
+    );
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 1,
+            counterparty,
+            receive_batch_id: 0,
+            raw_json,
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.receipt_access".into()),
+            known_paykit_kind: Some("paykit.receipt_access".into()),
+            parse_status: PrivateStreamParseStatus::MalformedRecognized,
+            parse_error: Some("stale".into()),
+            received_at: timestamp(),
+        }],
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 2,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_stale_dedupe_event_header() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let raw_json = payment_request_json("650e8400-e29b-41d4-a716-446655440000");
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 1,
+            counterparty: counterparty.clone(),
+            receive_batch_id: 0,
+            raw_json: raw_json.clone(),
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.payment_request".into()),
+            known_paykit_kind: Some("paykit.payment_request".into()),
+            parse_status: PrivateStreamParseStatus::Valid,
+            parse_error: None,
+            received_at: timestamp(),
+        }],
+        event_dedup_records: vec![EventDedupRecord {
+            counterparty,
+            event_id: "750e8400-e29b-41d4-a716-446655440000".into(),
+            event_kind: "paykit.payment_request".into(),
+            payload_hash: payload_hash(&raw_json),
+            first_stream_item_id: 1,
+            duplicate_stream_item_ids: Vec::new(),
+            conflicting_stream_item_ids: Vec::new(),
+        }],
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 2,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_overlapping_event_dedupe_membership() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let raw_json = payment_request_json("650e8400-e29b-41d4-a716-446655440000");
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 1,
+            counterparty: counterparty.clone(),
+            receive_batch_id: 0,
+            raw_json: raw_json.clone(),
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.payment_request".into()),
+            known_paykit_kind: Some("paykit.payment_request".into()),
+            parse_status: PrivateStreamParseStatus::Valid,
+            parse_error: None,
+            received_at: timestamp(),
+        }],
+        event_dedup_records: vec![EventDedupRecord {
+            counterparty,
+            event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+            event_kind: "paykit.payment_request".into(),
+            payload_hash: payload_hash(&raw_json),
+            first_stream_item_id: 1,
+            duplicate_stream_item_ids: vec![1],
+            conflicting_stream_item_ids: Vec::new(),
+        }],
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 2,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_accepts_cross_kind_event_id_conflict() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let event_id = "650e8400-e29b-41d4-a716-446655440000";
+    let request_json = payment_request_json(event_id);
+    let period = BillingPeriodRecord {
+        starts_at: "2026-06-01T00:00:00Z".into(),
+        ends_at: "2026-07-01T00:00:00Z".into(),
+    };
+    let (receipt_access_json, _, _) = receipt_access_raw_with_context(
+        event_id,
+        "750e8400-e29b-41d4-a716-446655440000",
+        "invoice-2026-0001",
+        "550e8400-e29b-41d4-a716-446655440000",
+        &period,
+    );
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![
+            PrivateStreamItemRecord {
+                stream_item_id: 1,
+                counterparty: counterparty.clone(),
+                receive_batch_id: 0,
+                raw_json: request_json.clone(),
+                parsed_version: Some(1),
+                parsed_kind: Some("paykit.payment_request".into()),
+                known_paykit_kind: Some("paykit.payment_request".into()),
+                parse_status: PrivateStreamParseStatus::Valid,
+                parse_error: None,
+                received_at: timestamp(),
+            },
+            PrivateStreamItemRecord {
+                stream_item_id: 2,
+                counterparty: counterparty.clone(),
+                receive_batch_id: 0,
+                raw_json: receipt_access_json,
+                parsed_version: Some(1),
+                parsed_kind: Some("paykit.receipt_access".into()),
+                known_paykit_kind: Some("paykit.receipt_access".into()),
+                parse_status: PrivateStreamParseStatus::Valid,
+                parse_error: None,
+                received_at: timestamp(),
+            },
+        ],
+        event_dedup_records: vec![EventDedupRecord {
+            counterparty,
+            event_id: event_id.into(),
+            event_kind: "paykit.payment_request".into(),
+            payload_hash: payload_hash(&request_json),
+            first_stream_item_id: 1,
+            duplicate_stream_item_ids: Vec::new(),
+            conflicting_stream_item_ids: vec![2],
+        }],
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 3,
+    };
+
+    restore_backup_state(&storage, backup).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_missing_event_dedupe_index() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let raw_json = payment_request_json("650e8400-e29b-41d4-a716-446655440000");
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 1,
+            counterparty,
+            receive_batch_id: 0,
+            raw_json,
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.payment_request".into()),
+            known_paykit_kind: Some("paykit.payment_request".into()),
+            parse_status: PrivateStreamParseStatus::Valid,
+            parse_error: None,
+            received_at: timestamp(),
+        }],
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 2,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_missing_receipt_access_index() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let event_id = "650e8400-e29b-41d4-a716-446655440000";
+    let period = BillingPeriodRecord {
+        starts_at: "2026-06-01T00:00:00Z".into(),
+        ends_at: "2026-07-01T00:00:00Z".into(),
+    };
+    let (raw_json, _, _) = receipt_access_raw_with_context(
+        event_id,
+        "550e8400-e29b-41d4-a716-446655440000",
+        "invoice-2026-0001",
+        "750e8400-e29b-41d4-a716-446655440000",
+        &period,
+    );
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 1,
+            counterparty: counterparty.clone(),
+            receive_batch_id: 0,
+            raw_json: raw_json.clone(),
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.receipt_access".into()),
+            known_paykit_kind: Some("paykit.receipt_access".into()),
+            parse_status: PrivateStreamParseStatus::Valid,
+            parse_error: None,
+            received_at: timestamp(),
+        }],
+        event_dedup_records: vec![EventDedupRecord {
+            counterparty,
+            event_id: event_id.into(),
+            event_kind: "paykit.receipt_access".into(),
+            payload_hash: payload_hash(&raw_json),
+            first_stream_item_id: 1,
+            duplicate_stream_item_ids: Vec::new(),
+            conflicting_stream_item_ids: Vec::new(),
+        }],
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 2,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_receipt_access_context_mismatch() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let event_id = "650e8400-e29b-41d4-a716-446655440000";
+    let receipt_id = "550e8400-e29b-41d4-a716-446655440000";
+    let payment_reference = "invoice-2026-0001";
+    let period = BillingPeriodRecord {
+        starts_at: "2026-06-01T00:00:00Z".into(),
+        ends_at: "2026-07-01T00:00:00Z".into(),
+    };
+    let (raw_json, location, key) = receipt_access_raw_with_context(
+        event_id,
+        receipt_id,
+        payment_reference,
+        "750e8400-e29b-41d4-a716-446655440000",
+        &period,
+    );
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 1,
+            counterparty: counterparty.clone(),
+            receive_batch_id: 0,
+            raw_json,
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.receipt_access".into()),
+            known_paykit_kind: Some("paykit.receipt_access".into()),
+            parse_status: PrivateStreamParseStatus::Valid,
+            parse_error: None,
+            received_at: timestamp(),
+        }],
+        event_dedup_records: Vec::new(),
+        receipt_access_records: vec![ReceiptAccessRecord {
+            counterparty,
+            stream_item_id: 1,
+            receive_batch_id: 0,
+            event_id: event_id.into(),
+            receipt_id: receipt_id.into(),
+            payment_reference: payment_reference.into(),
+            payment_request_id: Some("850e8400-e29b-41d4-a716-446655440000".into()),
+            billing_period: Some(period),
+            location,
+            key,
+            retrieval_status: crate::ReceiptRetrievalStatus::Pending,
+            retrieval_attempted_at: None,
+            retrieved_at: None,
+            last_retrieval_error: None,
+            received_at: timestamp(),
+        }],
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 2,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_inconsistent_receipt_access_status() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let event_id = "650e8400-e29b-41d4-a716-446655440000";
+    let receipt_id = "550e8400-e29b-41d4-a716-446655440000";
+    let payment_reference = "invoice-2026-0001";
+    let period = BillingPeriodRecord {
+        starts_at: "2026-06-01T00:00:00Z".into(),
+        ends_at: "2026-07-01T00:00:00Z".into(),
+    };
+    let payment_request_id = "750e8400-e29b-41d4-a716-446655440000";
+    let (raw_json, location, key) = receipt_access_raw_with_context(
+        event_id,
+        receipt_id,
+        payment_reference,
+        payment_request_id,
+        &period,
+    );
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 1,
+            counterparty: counterparty.clone(),
+            receive_batch_id: 0,
+            raw_json,
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.receipt_access".into()),
+            known_paykit_kind: Some("paykit.receipt_access".into()),
+            parse_status: PrivateStreamParseStatus::Valid,
+            parse_error: None,
+            received_at: timestamp(),
+        }],
+        event_dedup_records: Vec::new(),
+        receipt_access_records: vec![ReceiptAccessRecord {
+            counterparty,
+            stream_item_id: 1,
+            receive_batch_id: 0,
+            event_id: event_id.into(),
+            receipt_id: receipt_id.into(),
+            payment_reference: payment_reference.into(),
+            payment_request_id: Some(payment_request_id.into()),
+            billing_period: Some(period),
+            location,
+            key,
+            retrieval_status: crate::ReceiptRetrievalStatus::Retrieved,
+            retrieval_attempted_at: None,
+            retrieved_at: Some(timestamp()),
+            last_retrieval_error: None,
+            received_at: timestamp(),
+        }],
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 2,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_preserves_invalid_outbound_audit_record() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let mut invalid = private_payment_list_outbound(counterparty.clone(), 7, "ln-private");
+    invalid.raw_json = "{malformed".into();
+    invalid.status = OutboundPrivateMessageStatus::Invalid;
+    invalid.last_error = Some("invalid private message JSON".into());
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty)),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: vec![invalid],
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 8,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    restore_backup_state(&storage, backup).await.unwrap();
+    let restored = storage.snapshot().unwrap();
+
+    assert_eq!(restored.outbound_private_messages.len(), 1);
+    assert_eq!(
+        restored.outbound_private_messages[0].status,
+        OutboundPrivateMessageStatus::Invalid
+    );
+    assert_eq!(restored.outbound_private_messages[0].raw_json, "{malformed");
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_preserves_recovery_required_outbound_audit_record() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let mut recovery_required =
+        private_payment_list_outbound(counterparty.clone(), 7, "ln-private");
+    recovery_required.raw_json = "{malformed".into();
+    recovery_required.status = OutboundPrivateMessageStatus::RecoveryRequired;
+    recovery_required.last_error = Some("Encrypted Link recovery is required".into());
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty)),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: vec![recovery_required],
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 8,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    restore_backup_state(&storage, backup).await.unwrap();
+    let restored = storage.snapshot().unwrap();
+
+    assert_eq!(restored.outbound_private_messages.len(), 1);
+    assert_eq!(
+        restored.outbound_private_messages[0].status,
+        OutboundPrivateMessageStatus::RecoveryRequired
+    );
+    assert_eq!(restored.outbound_private_messages[0].raw_json, "{malformed");
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_marks_sending_outbound_recovery_required() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let mut sending = private_payment_list_outbound(counterparty.clone(), 7, "ln-private");
+    sending.status = OutboundPrivateMessageStatus::Sending;
+    sending.attempt_count = 1;
+    sending.last_attempt_at = Some(timestamp());
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty)),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: vec![sending],
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 8,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    restore_backup_state(&storage, backup).await.unwrap();
+    let restored = storage.snapshot().unwrap();
+
+    assert_eq!(
+        restored.outbound_private_messages[0].status,
+        OutboundPrivateMessageStatus::RecoveryRequired
+    );
+    assert!(restored.outbound_private_messages[0]
+        .last_error
+        .as_deref()
+        .is_some_and(|error| error.contains("recovery")));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_sent_outbound_without_sent_time() {
+    let counterparty = public_key();
+    let mut sent = private_payment_list_outbound(counterparty, 7, "ln-private");
+    sent.status = OutboundPrivateMessageStatus::Sent;
+    sent.attempt_count = 1;
+    sent.last_attempt_at = Some(timestamp());
+
+    assert_restore_rejects_outbound_record(sent).await;
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_invalid_outbound_without_error() {
+    let counterparty = public_key();
+    let mut invalid = private_payment_list_outbound(counterparty, 7, "ln-private");
+    invalid.status = OutboundPrivateMessageStatus::Invalid;
+
+    assert_restore_rejects_outbound_record(invalid).await;
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_recovery_required_outbound_with_sent_time() {
+    let counterparty = public_key();
+    let mut recovery_required = private_payment_list_outbound(counterparty, 7, "ln-private");
+    recovery_required.status = OutboundPrivateMessageStatus::RecoveryRequired;
+    recovery_required.last_error = Some("Encrypted Link recovery is required".into());
+    recovery_required.sent_at = Some(timestamp());
+
+    assert_restore_rejects_outbound_record(recovery_required).await;
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_wrong_identity() {
+    let storage = InMemoryStorage::new();
+    let current = public_key();
+    let backup_public_key = public_key();
+    storage
+        .save_identity_state(identity(current))
+        .await
+        .unwrap();
+
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(backup_public_key)),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_preserves_current_sign_out_generation() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = public_key();
+    let mut current_identity = identity(local_public_key.clone());
+    current_identity.sign_out_generation = 7;
+    storage.save_identity_state(current_identity).await.unwrap();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(local_public_key.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    restore_backup_state(&storage, backup).await.unwrap();
+
+    assert_eq!(
+        storage
+            .snapshot()
+            .unwrap()
+            .identity_state
+            .unwrap()
+            .sign_out_generation,
+        7
+    );
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_allows_trusted_identity_switch() {
+    let storage = InMemoryStorage::new();
+    let stored_public_key = public_key();
+    let backup_public_key = public_key();
+    storage
+        .save_identity_state(identity(stored_public_key))
+        .await
+        .unwrap();
+    let mut trusted_identity = identity(backup_public_key.clone());
+    trusted_identity.sign_out_generation = 3;
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(backup_public_key.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    restore_backup_state_with_identity(&storage, backup, Some(trusted_identity))
+        .await
+        .unwrap();
+
+    let identity = storage.snapshot().unwrap().identity_state.unwrap();
+    assert_eq!(identity.public_key.as_ref(), Some(&backup_public_key));
+    assert_eq!(identity.sign_out_generation, 3);
+}
+
+#[tokio::test]
+async fn test_restore_identity_less_backup_preserves_signed_out_generation() {
+    let storage = InMemoryStorage::new();
+    storage
+        .save_identity_state(signed_out_identity(7))
+        .await
+        .unwrap();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: None,
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    restore_backup_state(&storage, backup).await.unwrap();
+
+    let identity = storage.snapshot().unwrap().identity_state.unwrap();
+    assert_eq!(identity.capability, PubkyIdentityCapability::SignedOut);
+    assert_eq!(identity.sign_out_generation, 7);
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_orphan_endpoint_reservation() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: vec![PaymentEndpointReservationRecord {
+            reservation_id: "reservation-1".into(),
+            counterparty,
+            identifier: "btc-lightning-bolt11".into(),
+            payload_hash: reservation_payload_hash("ln-private"),
+            outbound_message_id: 7,
+            attribution: HashMap::new(),
+            expires_at: None,
+            cancellation_started_at: None,
+            created_at: timestamp(),
+        }],
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_invalid_endpoint_reservation_id() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: vec![PaymentEndpointReservationRecord {
+            reservation_id: "reservation\n1".into(),
+            counterparty: counterparty.clone(),
+            identifier: "btc-lightning-bolt11".into(),
+            payload_hash: reservation_payload_hash("ln-private"),
+            outbound_message_id: 7,
+            attribution: HashMap::new(),
+            expires_at: None,
+            cancellation_started_at: None,
+            created_at: timestamp(),
+        }],
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: vec![private_payment_list_outbound(
+            counterparty,
+            7,
+            "ln-private",
+        )],
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_mismatched_endpoint_reservation_payload() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty.clone())),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: vec![PaymentEndpointReservationRecord {
+            reservation_id: "reservation-1".into(),
+            counterparty: counterparty.clone(),
+            identifier: "btc-lightning-bolt11".into(),
+            payload_hash: reservation_payload_hash("different-payload"),
+            outbound_message_id: 7,
+            attribution: HashMap::new(),
+            expires_at: None,
+            cancellation_started_at: None,
+            created_at: timestamp(),
+        }],
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: vec![private_payment_list_outbound(
+            counterparty,
+            7,
+            "ln-private",
+        )],
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_receipt_key_hash_mismatch() {
+    let storage = InMemoryStorage::new();
+    let counterparty = public_key();
+    let receipt_id = "550e8400-e29b-41d4-a716-446655440000";
+    let access = ReceiptAccessRecord {
+        counterparty: counterparty.clone(),
+        stream_item_id: 0,
+        receive_batch_id: 0,
+        event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+        receipt_id: receipt_id.into(),
+        payment_reference: "invoice-2026-0001".into(),
+        payment_request_id: None,
+        billing_period: None,
+        location: format!("/pub/paykit/v0/private/receipts/{receipt_id}"),
+        key: "receipt-secret".into(),
+        retrieval_status: crate::ReceiptRetrievalStatus::Pending,
+        retrieval_attempted_at: None,
+        retrieved_at: None,
+        last_retrieval_error: None,
+        received_at: timestamp(),
+    };
+    let receipt = ReceiptRecord {
+        issuer: counterparty.clone(),
+        receipt_access_event_id: access.event_id.clone(),
+        receipt_access_key_hash: receipt_access_key_hash("wrong-secret"),
+        receipt_id: receipt_id.into(),
+        payment_reference: access.payment_reference.clone(),
+        payment_request_id: None,
+        billing_period: None,
+        recipient_public_key: counterparty.clone(),
+        payment_endpoint_identifier: None,
+        amount: None,
+        metadata: serde_json::Map::new(),
+        location: access.location.clone(),
+        retrieved_at: timestamp(),
+    };
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(counterparty)),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: vec![access],
+        receipt_records: vec![receipt],
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 1,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_receipt_recipient_mismatch() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = public_key();
+    let issuer = public_key();
+    let wrong_recipient = public_key();
+    let receipt_id = "550e8400-e29b-41d4-a716-446655440000";
+    let event_id = "650e8400-e29b-41d4-a716-446655440000";
+    let payment_request_id = "750e8400-e29b-41d4-a716-446655440000";
+    let period = BillingPeriodRecord {
+        starts_at: "2026-06-01T00:00:00Z".into(),
+        ends_at: "2026-07-01T00:00:00Z".into(),
+    };
+    let (raw_json, location, key) = receipt_access_raw_with_context(
+        event_id,
+        receipt_id,
+        "invoice-2026-0001",
+        payment_request_id,
+        &period,
+    );
+    let access = ReceiptAccessRecord {
+        counterparty: issuer.clone(),
+        stream_item_id: 1,
+        receive_batch_id: 0,
+        event_id: event_id.into(),
+        receipt_id: receipt_id.into(),
+        payment_reference: "invoice-2026-0001".into(),
+        payment_request_id: Some(payment_request_id.into()),
+        billing_period: Some(period.clone()),
+        location: location.clone(),
+        key: key.clone(),
+        retrieval_status: crate::ReceiptRetrievalStatus::Pending,
+        retrieval_attempted_at: None,
+        retrieved_at: None,
+        last_retrieval_error: None,
+        received_at: timestamp(),
+    };
+    let receipt = ReceiptRecord {
+        issuer: issuer.clone(),
+        receipt_access_event_id: event_id.into(),
+        receipt_access_key_hash: receipt_access_key_hash(&key),
+        receipt_id: receipt_id.into(),
+        payment_reference: access.payment_reference.clone(),
+        payment_request_id: access.payment_request_id.clone(),
+        billing_period: access.billing_period.clone(),
+        recipient_public_key: wrong_recipient,
+        payment_endpoint_identifier: None,
+        amount: None,
+        metadata: serde_json::Map::new(),
+        location,
+        retrieved_at: timestamp(),
+    };
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(local_public_key)),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: vec![PrivateStreamItemRecord {
+            stream_item_id: 1,
+            counterparty: issuer.clone(),
+            receive_batch_id: 0,
+            raw_json: raw_json.clone(),
+            parsed_version: Some(1),
+            parsed_kind: Some("paykit.receipt_access".into()),
+            known_paykit_kind: Some("paykit.receipt_access".into()),
+            parse_status: PrivateStreamParseStatus::Valid,
+            parse_error: None,
+            received_at: timestamp(),
+        }],
+        event_dedup_records: vec![EventDedupRecord {
+            counterparty: issuer,
+            event_id: event_id.into(),
+            event_kind: "paykit.receipt_access".into(),
+            payload_hash: payload_hash(&raw_json),
+            first_stream_item_id: 1,
+            duplicate_stream_item_ids: Vec::new(),
+            conflicting_stream_item_ids: Vec::new(),
+        }],
+        receipt_access_records: vec![access],
+        receipt_records: vec![receipt],
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 1,
+        next_private_stream_item_id: 2,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_receipt_issuance_access_mismatch() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = public_key();
+    let counterparty = public_key();
+    let prepared = paykit_lib::prepare_receipt_for_recipient(
+        counterparty.to_public_key().unwrap(),
+        paykit_lib::ReceiptDraft {
+            receipt_id: Some(
+                paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+            ),
+            payment_reference: paykit_lib::PaymentReference::new("invoice-2026-0001").unwrap(),
+            payment_request_id: None,
+            billing_period: None,
+            payment_endpoint_identifier: Some(
+                paykit_lib::PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap(),
+            ),
+            amount: Some(paykit_lib::PaymentAmount::new("0.001", "btc").unwrap()),
+            metadata: serde_json::Map::new(),
+        },
+    )
+    .unwrap();
+    let mut issuance =
+        ReceiptIssuanceRecord::from_prepared(counterparty, prepared, timestamp()).unwrap();
+    issuance.payment_reference = "different-reference".into();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(local_public_key)),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: vec![issuance],
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_duplicate_receipt_issuance_ids() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = public_key();
+    let first_counterparty = public_key();
+    let second_counterparty = public_key();
+    let receipt_id = paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let draft = || paykit_lib::ReceiptDraft {
+        receipt_id: Some(receipt_id.clone()),
+        payment_reference: paykit_lib::PaymentReference::new("invoice-2026-0001").unwrap(),
+        payment_request_id: None,
+        billing_period: None,
+        payment_endpoint_identifier: Some(
+            paykit_lib::PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap(),
+        ),
+        amount: Some(paykit_lib::PaymentAmount::new("0.001", "btc").unwrap()),
+        metadata: serde_json::Map::new(),
+    };
+    let first = ReceiptIssuanceRecord::from_prepared(
+        first_counterparty.clone(),
+        paykit_lib::prepare_receipt_for_recipient(
+            first_counterparty.to_public_key().unwrap(),
+            draft(),
+        )
+        .unwrap(),
+        timestamp(),
+    )
+    .unwrap();
+    let second = ReceiptIssuanceRecord::from_prepared(
+        second_counterparty.clone(),
+        paykit_lib::prepare_receipt_for_recipient(
+            second_counterparty.to_public_key().unwrap(),
+            draft(),
+        )
+        .unwrap(),
+        timestamp(),
+    )
+    .unwrap();
+    let backup = SdkBackupState {
+        version: SDK_BACKUP_VERSION,
+        identity_state: Some(identity(local_public_key)),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: vec![first, second],
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+
+    let result = restore_backup_state(&storage, backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}

--- a/paykit-sdk/src/contacts.rs
+++ b/paykit-sdk/src/contacts.rs
@@ -750,3 +750,6 @@ fn normalize_label(label: Option<String>) -> Option<String> {
         }
     })
 }
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/contacts/tests.rs
+++ b/paykit-sdk/src/contacts/tests.rs
@@ -1,0 +1,368 @@
+use super::*;
+use crate::PaykitSdkConfig;
+
+fn public_key() -> PubkyPublicKey {
+    PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+}
+
+#[test]
+fn test_paykit_profile_json_round_trips() {
+    let profile = PaykitProfile {
+        display_name: Some("Alice".into()),
+        image_uri: Some("/pub/paykit/blobs/avatar.png".into()),
+        extra: Some(serde_json::Map::from_iter([(
+            "bio".into(),
+            serde_json::Value::String("Builder".into()),
+        )])),
+    };
+
+    let json = profile_json(&profile).unwrap();
+    let parsed = parse_profile_json(&json).unwrap();
+
+    assert!(json.contains(r#""kind":"paykit.profile""#));
+    assert_eq!(parsed, profile);
+    assert_eq!(
+        parsed
+            .extra
+            .as_ref()
+            .and_then(|extra| extra.get("bio"))
+            .and_then(|value| value.as_str()),
+        Some("Builder")
+    );
+}
+
+#[test]
+fn test_paykit_profile_json_rejects_wrong_kind() {
+    let result = parse_profile_json(
+        r#"{"version":1,"kind":"paykit.other","display_name":"Alice","image_uri":null}"#,
+    );
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[test]
+fn test_paykit_profile_json_rejects_empty_body() {
+    let result = parse_profile_json("");
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[test]
+fn test_paykit_profile_json_ignores_unknown_fields() {
+    let parsed = parse_profile_json(
+        r#"{"version":1,"kind":"paykit.profile","display_name":"Alice","image_uri":null,"color":"blue"}"#,
+    )
+    .unwrap();
+
+    assert_eq!(parsed.display_name.as_deref(), Some("Alice"));
+}
+
+#[test]
+fn test_paykit_profile_rejects_empty_display_name() {
+    let profile = PaykitProfile {
+        display_name: Some(" ".into()),
+        image_uri: None,
+        extra: None,
+    };
+
+    assert!(matches!(
+        profile.validate(),
+        Err(PaykitSdkError::Protocol(_))
+    ));
+}
+
+#[test]
+fn test_paykit_profile_rejects_control_characters() {
+    let profile = PaykitProfile {
+        display_name: Some("Alice\nAdmin".into()),
+        image_uri: None,
+        extra: None,
+    };
+
+    assert!(matches!(
+        profile.validate(),
+        Err(PaykitSdkError::Protocol(_))
+    ));
+}
+
+#[test]
+fn test_paykit_profile_rejects_oversized_extra() {
+    let profile = PaykitProfile {
+        display_name: Some("Alice".into()),
+        image_uri: None,
+        extra: Some(serde_json::Map::from_iter([(
+            "bio".into(),
+            serde_json::Value::String("x".repeat(20 * 1024)),
+        )])),
+    };
+
+    assert!(matches!(
+        profile.validate(),
+        Err(PaykitSdkError::Protocol(_))
+    ));
+}
+
+#[test]
+fn test_pubky_profile_json_parses_bitkit_shape() {
+    let parsed = parse_pubky_profile_json(
+        r#"{"name":"Alice","bio":"Builder","image":"pubky://alice/avatar.jpg","links":[{"title":"site","url":"https://example.com"}],"status":"online"}"#,
+    )
+    .unwrap();
+
+    assert_eq!(parsed.name, "Alice");
+    assert_eq!(parsed.bio.as_deref(), Some("Builder"));
+    assert_eq!(parsed.links.unwrap()[0].title, "site");
+}
+
+#[test]
+fn test_pubky_profile_json_rejects_control_characters() {
+    let result = parse_pubky_profile_json(r#"{"name":"Alice\nAdmin"}"#);
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[test]
+fn test_contact_profile_resolution_from_paykit_profile() {
+    let public_key = public_key();
+    let record = PaykitProfileRecord {
+        public_key: public_key.clone(),
+        profile: PaykitProfile {
+            display_name: Some("Alice".into()),
+            image_uri: Some("/pub/paykit/blobs/avatar.png".into()),
+            extra: None,
+        },
+        path: PAYKIT_PROFILE_PATH.into(),
+        updated_at: chrono::Utc::now(),
+    };
+
+    let resolution = ContactProfileResolution::from_paykit(record);
+
+    assert_eq!(resolution.public_key, public_key);
+    assert_eq!(resolution.source, ContactProfileSource::PaykitProfile);
+    assert_eq!(resolution.display_name.as_deref(), Some("Alice"));
+    assert!(resolution.paykit_profile.is_some());
+    assert!(resolution.pubky_profile.is_none());
+}
+
+#[test]
+fn test_contact_profile_resolution_from_pubky_profile() {
+    let public_key = public_key();
+    let record = PubkyProfileRecord {
+        public_key: public_key.clone(),
+        profile: PubkyProfile {
+            name: "Alice".into(),
+            bio: Some("Builder".into()),
+            image: Some("pubky://alice/avatar.jpg".into()),
+            links: None,
+            status: None,
+        },
+        path: PUBKY_PROFILE_PATH.into(),
+        fetched_at: chrono::Utc::now(),
+    };
+
+    let resolution = ContactProfileResolution::from_pubky(record);
+
+    assert_eq!(resolution.public_key, public_key);
+    assert_eq!(resolution.source, ContactProfileSource::PubkyProfile);
+    assert_eq!(resolution.display_name.as_deref(), Some("Alice"));
+    assert_eq!(
+        resolution.image_uri.as_deref(),
+        Some("pubky://alice/avatar.jpg")
+    );
+    assert!(resolution.paykit_profile.is_none());
+    assert!(resolution.pubky_profile.is_some());
+}
+
+#[test]
+fn test_contact_profile_resolution_debug_redacts_display_data() {
+    let resolution = ContactProfileResolution::from_pubky(PubkyProfileRecord {
+        public_key: public_key(),
+        profile: PubkyProfile {
+            name: "Alice".into(),
+            bio: None,
+            image: Some("pubky://alice/avatar.jpg".into()),
+            links: None,
+            status: None,
+        },
+        path: PUBKY_PROFILE_PATH.into(),
+        fetched_at: chrono::Utc::now(),
+    });
+    let debug = format!("{resolution:?}");
+
+    assert!(!debug.contains("Alice"));
+    assert!(!debug.contains("avatar.jpg"));
+    assert!(debug.contains("<redacted>"));
+}
+
+#[test]
+fn test_contact_update_allows_empty_label_to_clear_display_text() {
+    let update = ContactUpdate {
+        public_key: public_key(),
+        label: Some(String::new()),
+    };
+
+    assert!(update.validate().is_ok());
+}
+
+#[test]
+fn test_contact_update_rejects_control_characters() {
+    let update = ContactUpdate {
+        public_key: public_key(),
+        label: Some("Alice\tLocal".into()),
+    };
+
+    assert!(matches!(
+        update.validate(),
+        Err(PaykitSdkError::Protocol(_))
+    ));
+}
+
+#[test]
+fn test_contact_update_debug_redacts_label() {
+    let public_key = public_key();
+    let public_key_text = public_key.to_string();
+    let update = ContactUpdate {
+        public_key,
+        label: Some("Alice Local".into()),
+    };
+    let debug = format!("{update:?}");
+
+    assert!(!debug.contains("Alice Local"));
+    assert!(!debug.contains(&public_key_text));
+    assert!(debug.contains("<redacted>"));
+}
+
+#[test]
+fn test_contact_record_normalizes_whitespace_labels() {
+    let public_key = public_key();
+    let labeled = ContactRecord::from_update(
+        ContactUpdate {
+            public_key: public_key.clone(),
+            label: Some("  Alice  ".into()),
+        },
+        None,
+        chrono::Utc::now(),
+    );
+    let cleared = ContactRecord::from_update(
+        ContactUpdate {
+            public_key,
+            label: Some("   ".into()),
+        },
+        Some(labeled.clone()),
+        chrono::Utc::now(),
+    );
+
+    assert_eq!(labeled.label.as_deref(), Some("Alice"));
+    assert_eq!(cleared.label, None);
+}
+
+#[test]
+fn test_pending_public_contact_marker_may_exist_remotely() {
+    let record = ContactRecord::from_update(
+        ContactUpdate {
+            public_key: public_key(),
+            label: None,
+        },
+        None,
+        chrono::Utc::now(),
+    )
+    .mark_public_contact_publication_pending(chrono::Utc::now());
+
+    assert!(record.may_have_public_marker());
+}
+
+#[test]
+fn test_public_contact_path_uses_default_profile_namespace() {
+    let public_key = public_key();
+
+    assert_eq!(
+        PaykitSdkConfig::default().public_contact_path(&public_key),
+        format!("/pub/paykit/contacts/{}.json", public_key.as_str())
+    );
+}
+
+#[test]
+fn test_paykit_blob_path_and_uri_are_scoped_to_configured_prefix() {
+    let public_key = public_key();
+    let path = paykit_blob_path("/pub/bitkit.to/blobs/", "avatar-1.jpg").unwrap();
+
+    assert_eq!(path, "/pub/bitkit.to/blobs/avatar-1.jpg");
+    assert_eq!(
+        paykit_blob_uri(&public_key, &path),
+        format!("pubky://{}/pub/bitkit.to/blobs/avatar-1.jpg", public_key)
+    );
+}
+
+#[test]
+fn test_paykit_blob_name_rejects_path_segments() {
+    assert!(matches!(
+        paykit_blob_path("/pub/paykit/blobs/", "../avatar.jpg"),
+        Err(PaykitSdkError::Protocol(_))
+    ));
+    assert!(matches!(
+        paykit_blob_path("/pub/paykit/blobs/", "avatars/avatar.jpg"),
+        Err(PaykitSdkError::Protocol(_))
+    ));
+}
+
+#[test]
+fn test_paykit_blob_path_from_uri_or_path_accepts_owned_blob_only() {
+    let owner_public_key = public_key();
+    let other_public_key = public_key();
+    let prefix = "/pub/paykit/blobs/";
+
+    assert_eq!(
+        paykit_blob_path_from_uri_or_path(
+            &owner_public_key,
+            prefix,
+            "/pub/paykit/blobs/avatar.jpg"
+        )
+        .unwrap(),
+        "/pub/paykit/blobs/avatar.jpg"
+    );
+    assert_eq!(
+        paykit_blob_path_from_uri_or_path(
+            &owner_public_key,
+            prefix,
+            &format!("pubky://{}/pub/paykit/blobs/avatar.jpg", owner_public_key)
+        )
+        .unwrap(),
+        "/pub/paykit/blobs/avatar.jpg"
+    );
+    assert!(matches!(
+        paykit_blob_path_from_uri_or_path(
+            &owner_public_key,
+            prefix,
+            &format!("pubky://{}/pub/paykit/blobs/avatar.jpg", other_public_key)
+        ),
+        Err(PaykitSdkError::Protocol(_))
+    ));
+    assert!(matches!(
+        paykit_blob_path_from_uri_or_path(&owner_public_key, prefix, "/pub/paykit/profile.json"),
+        Err(PaykitSdkError::Protocol(_))
+    ));
+}
+
+#[test]
+fn test_pubky_follow_keys_from_follow_entries_keeps_direct_valid_keys_only() {
+    let owner = pubky::Keypair::random().public_key();
+    let alice = pubky::Keypair::random().public_key().z32();
+    let bob = pubky::Keypair::random().public_key().z32();
+    let resource = |path: String| pubky::PubkyResource::new(owner.clone(), path).unwrap();
+
+    let contacts = pubky_follow_keys_from_follow_entries(vec![
+        resource(format!("{PUBKY_FOLLOWS_PATH_PREFIX}{bob}")),
+        resource(format!("{PUBKY_FOLLOWS_PATH_PREFIX}{alice}/nested.json")),
+        resource(format!("{PUBKY_FOLLOWS_PATH_PREFIX}not-a-public-key")),
+        resource(format!("{PUBKY_FOLLOWS_PATH_PREFIX}{bob}")),
+        resource("/pub/pubky.app/profile.json".to_string()),
+    ]);
+
+    assert_eq!(contacts, vec![PubkyPublicKey::new(bob).unwrap()]);
+}
+
+#[test]
+fn test_pubky_paths_are_read_only_pubky_app_namespace() {
+    assert_eq!(PUBKY_PROFILE_PATH, "/pub/pubky.app/profile.json");
+    assert_eq!(PUBKY_FOLLOWS_PATH_PREFIX, "/pub/pubky.app/follows/");
+}

--- a/paykit-sdk/src/endpoint_reservations.rs
+++ b/paykit-sdk/src/endpoint_reservations.rs
@@ -391,3 +391,6 @@ impl fmt::Debug for PaymentEndpointReservationRecord {
             .finish()
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/endpoint_reservations/tests.rs
+++ b/paykit-sdk/src/endpoint_reservations/tests.rs
@@ -1,0 +1,430 @@
+use chrono::{Duration as ChronoDuration, TimeZone};
+
+use super::*;
+use crate::storage::InMemoryStorage;
+use paykit_lib::PaymentEndpointIdentifier;
+
+fn timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+}
+
+fn counterparty() -> PubkyPublicKey {
+    PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+}
+
+fn reservation(id: &str, payload: &str) -> PaymentEndpointReservation {
+    PaymentEndpointReservation {
+        reservation_id: id.into(),
+        receiving_detail: ReceivingDetail {
+            identifier: "btc-lightning-bolt11".into(),
+            payload: payload.into(),
+        },
+        expires_at: None,
+        attribution: HashMap::from([("contact".into(), "alice".into())]),
+    }
+}
+
+#[tokio::test]
+async fn test_queue_private_payment_list_with_reservations_stores_linked_records() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let outbound = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![reservation("res-1", "ln-secret")],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let list = paykit_lib::parse_private_payment_list_json(&outbound.raw_json).unwrap();
+    let records = payment_endpoint_reservations(&storage, &counterparty)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        list.get(&PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap())
+            .unwrap()
+            .as_str(),
+        "ln-secret"
+    );
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].outbound_message_id, outbound.outbound_message_id);
+    assert_ne!(records[0].payload_hash, "ln-secret");
+    assert!(!format!("{:?}", records[0]).contains("ln-secret"));
+    assert!(!format!("{:?}", records[0]).contains("alice"));
+}
+
+#[tokio::test]
+async fn test_queue_private_payment_list_with_reservations_rejects_stale_lease() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let stale_lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx
+                    .claim_peer_link_operation(
+                        &counterparty,
+                        timestamp(),
+                        timestamp() + ChronoDuration::seconds(10),
+                    )
+                    .unwrap())
+            }
+        })
+        .await
+        .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let _ = tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp() + ChronoDuration::seconds(11),
+                    timestamp() + ChronoDuration::seconds(71),
+                );
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let result = queue_private_payment_list_with_reservations_with_link_lease(
+        &storage,
+        &counterparty,
+        vec![reservation("res-1", "ln-secret")],
+        timestamp(),
+        &stale_lease,
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    let snapshot = storage.snapshot().unwrap();
+    assert!(snapshot.outbound_private_messages.is_empty());
+    assert!(snapshot.payment_endpoint_reservations.is_empty());
+}
+
+#[tokio::test]
+async fn test_queue_private_payment_list_with_reservations_rejects_duplicate_identifiers() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let result = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![reservation("res-1", "one"), reservation("res-2", "two")],
+        timestamp(),
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    assert!(storage
+        .snapshot()
+        .unwrap()
+        .payment_endpoint_reservations
+        .is_empty());
+}
+
+#[tokio::test]
+async fn test_queue_private_payment_list_with_reservations_rejects_invalid_ids() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let long_id = "x".repeat(MAX_RESERVATION_ID_LEN + 1);
+
+    for reservation_id in [" ", "res\n1", long_id.as_str()] {
+        let result = queue_private_payment_list_with_reservations(
+            &storage,
+            &counterparty,
+            vec![reservation(reservation_id, "one")],
+            timestamp(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    }
+    assert!(storage
+        .snapshot()
+        .unwrap()
+        .payment_endpoint_reservations
+        .is_empty());
+}
+
+#[tokio::test]
+async fn test_queue_private_payment_list_with_reservations_preserves_existing_metadata() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![reservation("res-1", "one")],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let outbound = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "res-1".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "one".into(),
+            },
+            expires_at: Some(timestamp()),
+            attribution: HashMap::from([("contact".into(), "bob".into())]),
+        }],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    let snapshot = storage.snapshot().unwrap();
+
+    assert_eq!(snapshot.payment_endpoint_reservations.len(), 1);
+    assert_eq!(
+        snapshot
+            .payment_endpoint_reservations
+            .get(&(counterparty.clone(), "res-1".into()))
+            .unwrap()
+            .outbound_message_id,
+        outbound.outbound_message_id
+    );
+    let record = snapshot
+        .payment_endpoint_reservations
+        .get(&(counterparty.clone(), "res-1".into()))
+        .unwrap();
+    assert_eq!(record.attribution.get("contact").unwrap(), "alice");
+    assert_eq!(record.expires_at, None);
+    assert_eq!(record.created_at, timestamp());
+}
+
+#[tokio::test]
+async fn test_queue_private_payment_list_with_reservations_rejects_cancellation_claimed_id() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![reservation("res-1", "one")],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut record = tx
+                    .payment_endpoint_reservation(&counterparty, "res-1")
+                    .unwrap();
+                record.cancellation_started_at = Some(timestamp());
+                tx.save_payment_endpoint_reservation(record);
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let result = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![reservation("res-1", "one")],
+        timestamp(),
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+}
+
+#[tokio::test]
+async fn test_unattempted_superseded_reservation_cancellations() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![reservation("res-1", "one")],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![reservation("res-2", "two")],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    crate::outbound_private::claim_next_outbound_private_message(
+        &storage,
+        &counterparty,
+        timestamp(),
+        timestamp() - chrono::Duration::seconds(1),
+        timestamp() - chrono::Duration::seconds(1),
+    )
+    .await
+    .unwrap();
+
+    let cancellations = unattempted_superseded_reservation_cancellations(&storage, &counterparty)
+        .await
+        .unwrap();
+
+    assert_eq!(cancellations.len(), 1);
+    assert_eq!(cancellations[0].cancellation.reservation_id, "res-1");
+}
+
+#[tokio::test]
+async fn test_unattempted_superseded_reservation_cancellations_skip_attempted_lists() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let first = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![reservation("res-1", "one")],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![reservation("res-2", "two")],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut attempted = tx
+                    .outbound_private_messages(&counterparty)
+                    .into_iter()
+                    .find(|message| message.outbound_message_id == first.outbound_message_id)
+                    .unwrap();
+                attempted.status = crate::OutboundPrivateMessageStatus::Failed;
+                attempted.last_attempt_at = Some(timestamp() - ChronoDuration::seconds(2));
+                tx.save_outbound_private_message(attempted)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    crate::outbound_private::claim_next_outbound_private_message(
+        &storage,
+        &counterparty,
+        timestamp(),
+        timestamp() - chrono::Duration::seconds(1),
+        timestamp() - chrono::Duration::seconds(1),
+    )
+    .await
+    .unwrap();
+
+    let cancellations = unattempted_superseded_reservation_cancellations(&storage, &counterparty)
+        .await
+        .unwrap();
+
+    assert!(cancellations.is_empty());
+    let snapshot = storage.snapshot().unwrap();
+    assert_eq!(snapshot.payment_endpoint_reservations.len(), 2);
+}
+
+#[tokio::test]
+async fn test_expired_outbound_reservation_cancellations() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let outbound = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "res-1".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "one".into(),
+            },
+            expires_at: Some(timestamp() + chrono::Duration::seconds(5)),
+            attribution: HashMap::new(),
+        }],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    assert!(expired_outbound_reservation_cancellations(
+        &storage,
+        &counterparty,
+        outbound.outbound_message_id,
+        timestamp()
+    )
+    .await
+    .unwrap()
+    .is_empty());
+    let cancellations = expired_outbound_reservation_cancellations(
+        &storage,
+        &counterparty,
+        outbound.outbound_message_id,
+        timestamp() + chrono::Duration::seconds(6),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(cancellations.len(), 1);
+    assert_eq!(cancellations[0].cancellation.reservation_id, "res-1");
+}
+
+#[tokio::test]
+async fn test_queue_private_payment_list_with_reservations_rejects_conflicting_existing_id() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![reservation("res-1", "one")],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let result = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![reservation("res-1", "two")],
+        timestamp(),
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_queue_private_payment_list_with_reservations_scopes_ids_by_counterparty() {
+    let storage = InMemoryStorage::new();
+    let first = counterparty();
+    let second = counterparty();
+
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &first,
+        vec![reservation("res-1", "one")],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &second,
+        vec![reservation("res-1", "two")],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        storage
+            .snapshot()
+            .unwrap()
+            .payment_endpoint_reservations
+            .len(),
+        2
+    );
+}

--- a/paykit-sdk/src/endpoints.rs
+++ b/paykit-sdk/src/endpoints.rs
@@ -131,3 +131,6 @@ pub(crate) fn failed_record(
         last_error: Some(error),
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/endpoints/tests.rs
+++ b/paykit-sdk/src/endpoints/tests.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+#[test]
+fn test_normalize_receiving_details_rejects_invalid_identifier() {
+    let result = normalize_receiving_details(vec![ReceivingDetail {
+        identifier: "../bad".into(),
+        payload: "payload".into(),
+    }]);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_normalize_receiving_details_rejects_duplicates() {
+    let result = normalize_receiving_details(vec![
+        ReceivingDetail {
+            identifier: "btc-lightning-bolt11".into(),
+            payload: "one".into(),
+        },
+        ReceivingDetail {
+            identifier: "btc-lightning-bolt11".into(),
+            payload: "two".into(),
+        },
+    ]);
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}

--- a/paykit-sdk/src/linked_peers.rs
+++ b/paykit-sdk/src/linked_peers.rs
@@ -632,3 +632,6 @@ where
         .transaction(|tx| Ok(tx.encrypted_link_state(counterparty)))
         .await
 }
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/linked_peers/tests.rs
+++ b/paykit-sdk/src/linked_peers/tests.rs
@@ -1,0 +1,441 @@
+use chrono::{TimeZone, Utc};
+
+use super::*;
+use crate::storage::InMemoryStorage;
+
+fn timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 4, 12, 0, 0).unwrap()
+}
+
+fn counterparty() -> PubkyPublicKey {
+    PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+}
+
+#[tokio::test]
+async fn test_save_link_handshake_state_marks_peer_linking() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let report = save_link_handshake_state(
+        &storage,
+        counterparty.clone(),
+        EncryptedLinkHandshakeRole::Initiator,
+        vec![1, 2, 3],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(report.state, LinkedPeerState::Linking);
+    assert_eq!(
+        report.handshake_role,
+        Some(EncryptedLinkHandshakeRole::Initiator)
+    );
+    let peer = load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::Linking);
+    let link_state = load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(link_state.handshake_snapshot, Some(vec![1, 2, 3]));
+    assert!(link_state.link_snapshot.is_none());
+}
+
+#[tokio::test]
+async fn test_save_linked_peer_link_state_clears_pending_handshake() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    save_link_handshake_state(
+        &storage,
+        counterparty.clone(),
+        EncryptedLinkHandshakeRole::Responder,
+        vec![1, 2, 3],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let report =
+        save_linked_peer_link_state(&storage, counterparty.clone(), vec![4, 5, 6], timestamp())
+            .await
+            .unwrap();
+
+    assert_eq!(report.state, LinkedPeerState::Linked);
+    assert_eq!(report.handshake_role, None);
+    assert_eq!(report.generation, 1);
+    let link_state = load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(link_state.link_snapshot, Some(vec![4, 5, 6]));
+    assert!(link_state.handshake_snapshot.is_none());
+    assert!(link_state.handshake_role.is_none());
+}
+
+#[tokio::test]
+async fn test_unleased_recovery_rejects_active_peer_lease() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    save_linked_peer_link_state(&storage, counterparty.clone(), vec![4, 5, 6], timestamp())
+        .await
+        .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp(),
+                    timestamp() + chrono::Duration::seconds(10),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let result =
+        mark_recovery_required_inner(&storage, counterparty.clone(), None, timestamp()).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    let peer = load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::Linked);
+    let link_state = load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(link_state.link_snapshot, Some(vec![4, 5, 6]));
+    assert!(link_state.handshake_snapshot.is_none());
+    assert!(link_state.handshake_role.is_none());
+    assert_eq!(link_state.generation, 0);
+    assert!(storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+        })
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_lease_checked_recovery_preserves_current_lease_for_caller() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    save_linked_peer_state(
+        &storage,
+        counterparty.clone(),
+        LinkedPeerState::Linked,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    let lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp(),
+                    timestamp() + chrono::Duration::seconds(10),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    mark_recovery_required_with_lease(
+        &storage,
+        counterparty.clone(),
+        lease,
+        timestamp() + chrono::Duration::seconds(1),
+    )
+    .await
+    .unwrap();
+
+    assert!(storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+        })
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_mark_recovery_required_clears_handshake_snapshot() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    save_link_handshake_state(
+        &storage,
+        counterparty.clone(),
+        EncryptedLinkHandshakeRole::Responder,
+        vec![1, 2, 3],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let mark = mark_recovery_required_inner(&storage, counterparty.clone(), None, timestamp())
+        .await
+        .unwrap();
+
+    assert!(mark.new_episode);
+    let peer = load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::RecoveryRequired);
+    let link_state = load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(link_state.link_snapshot.is_none());
+    assert!(link_state.handshake_snapshot.is_none());
+    assert!(link_state.handshake_role.is_none());
+    assert_eq!(link_state.generation, 1);
+}
+
+#[tokio::test]
+async fn test_save_link_handshake_state_rejects_blocked_peer() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    save_linked_peer_state(
+        &storage,
+        counterparty.clone(),
+        LinkedPeerState::Blocked,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let result = save_link_handshake_state(
+        &storage,
+        counterparty,
+        EncryptedLinkHandshakeRole::Initiator,
+        vec![1, 2, 3],
+        timestamp(),
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+}
+
+#[tokio::test]
+async fn test_generation_checked_handshake_save_keeps_newer_link() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    save_link_handshake_state(
+        &storage,
+        counterparty.clone(),
+        EncryptedLinkHandshakeRole::Initiator,
+        vec![1, 2, 3],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    save_linked_peer_link_state(&storage, counterparty.clone(), vec![4, 5, 6], timestamp())
+        .await
+        .unwrap();
+
+    let report = save_link_handshake_state_if_generation(
+        &storage,
+        counterparty.clone(),
+        EncryptedLinkHandshakeRole::Initiator,
+        vec![7, 8, 9],
+        0,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(report.state, LinkedPeerState::Linked);
+    assert_eq!(report.generation, 1);
+    let link_state = load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(link_state.link_snapshot, Some(vec![4, 5, 6]));
+    assert!(link_state.handshake_snapshot.is_none());
+}
+
+#[tokio::test]
+async fn test_generation_checked_handshake_save_preserves_recovery_required() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    save_link_handshake_state(
+        &storage,
+        counterparty.clone(),
+        EncryptedLinkHandshakeRole::Initiator,
+        vec![1, 2, 3],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    mark_recovery_required_inner(&storage, counterparty.clone(), None, timestamp())
+        .await
+        .unwrap();
+
+    let report = save_link_handshake_state_if_generation(
+        &storage,
+        counterparty.clone(),
+        EncryptedLinkHandshakeRole::Initiator,
+        vec![7, 8, 9],
+        0,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(report.state, LinkedPeerState::RecoveryRequired);
+    assert_eq!(report.generation, 1);
+    assert_eq!(report.handshake_role, None);
+    let peer = load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::RecoveryRequired);
+    let link_state = load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(link_state.link_snapshot.is_none());
+    assert!(link_state.handshake_snapshot.is_none());
+}
+
+#[tokio::test]
+async fn test_lease_checked_handshake_save_rejects_stale_lease() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let first_lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp(),
+                    timestamp() + chrono::Duration::seconds(10),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let active_lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp() + chrono::Duration::seconds(11),
+                    timestamp() + chrono::Duration::seconds(71),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let result = save_link_handshake_state_with_lease(
+        &storage,
+        counterparty.clone(),
+        EncryptedLinkHandshakeRole::Initiator,
+        vec![1, 2, 3],
+        first_lease,
+        timestamp() + chrono::Duration::seconds(12),
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    let link_state = load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap();
+    assert!(link_state.is_none());
+    assert_eq!(
+        storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+            })
+            .await
+            .unwrap(),
+        Some(active_lease)
+    );
+}
+
+#[tokio::test]
+async fn test_lease_checked_recovery_rejects_stale_lease() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    save_linked_peer_state(
+        &storage,
+        counterparty.clone(),
+        LinkedPeerState::Linked,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let first_lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp(),
+                    timestamp() + chrono::Duration::seconds(10),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let active_lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp() + chrono::Duration::seconds(11),
+                    timestamp() + chrono::Duration::seconds(71),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let result = mark_recovery_required_with_lease(
+        &storage,
+        counterparty.clone(),
+        first_lease,
+        timestamp() + chrono::Duration::seconds(12),
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    let peer = load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::Linked);
+    assert_eq!(
+        storage
+            .transaction({
+                let counterparty = counterparty.clone();
+                move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+            })
+            .await
+            .unwrap(),
+        Some(active_lease)
+    );
+}

--- a/paykit-sdk/src/outbound_private.rs
+++ b/paykit-sdk/src/outbound_private.rs
@@ -379,3 +379,6 @@ fn private_application_message(
         raw_json: raw_json.to_owned(),
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/outbound_private/tests.rs
+++ b/paykit-sdk/src/outbound_private/tests.rs
@@ -1,0 +1,231 @@
+use chrono::{TimeZone, Utc};
+
+use super::*;
+use crate::storage::InMemoryStorage;
+
+fn timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+}
+
+fn counterparty() -> PubkyPublicKey {
+    PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+}
+
+fn raw_private_list() -> String {
+    r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#.into()
+}
+
+#[test]
+fn test_failure_report_debug_redacts_errors() {
+    let report = OutboundPrivateCounterpartySendReport {
+        counterparty: counterparty(),
+        report: Some(OutboundPrivateSendReport {
+            attempted: vec![1],
+            sent: vec![],
+            failed: vec![OutboundPrivateSendFailure {
+                outbound_message_id: 1,
+                error: "payment-reference-secret".into(),
+            }],
+            reservation_cleanup_failures: vec![ReservationCleanupFailure {
+                reservation_id: Some("reservation-id".into()),
+                error: "reservation-secret".into(),
+            }],
+            recovery_marker_failures: vec![RecoveryMarkerPublishFailure {
+                outbound_message_id: Some(1),
+                error: "marker-secret".into(),
+            }],
+        }),
+        error: Some("counterparty-secret".into()),
+    };
+
+    let debug = format!("{report:?}");
+    assert!(debug.contains("<redacted:"));
+    assert!(!debug.contains("payment-reference-secret"));
+    assert!(!debug.contains("reservation-secret"));
+    assert!(!debug.contains("marker-secret"));
+    assert!(!debug.contains("counterparty-secret"));
+}
+
+#[tokio::test]
+async fn test_enqueue_private_message_stores_pending_record() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let record = enqueue_private_message(
+        &storage,
+        counterparty.clone(),
+        raw_private_list(),
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let queued = queued_outbound_private_messages(&storage, &counterparty)
+        .await
+        .unwrap();
+    assert_eq!(record.outbound_message_id, 0);
+    assert_eq!(queued.len(), 1);
+    assert_eq!(queued[0].status, OutboundPrivateMessageStatus::Pending);
+}
+
+#[tokio::test]
+async fn test_enqueue_private_message_rejects_unknown_kind() {
+    let result = enqueue_private_message(
+        &InMemoryStorage::new(),
+        counterparty(),
+        r#"{"version":1,"kind":"paykit.unknown"}"#.into(),
+        timestamp(),
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_enqueue_private_message_rejects_malformed_known_body() {
+    let result = enqueue_private_message(
+        &InMemoryStorage::new(),
+        counterparty(),
+        r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{"../bad":"ln"}}"#
+            .into(),
+        timestamp(),
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[test]
+fn test_validate_queued_outbound_private_message_rejects_malformed_known_body() {
+    let record = OutboundPrivateMessageRecord {
+            outbound_message_id: 7,
+            counterparty: counterparty(),
+            kind: "paykit.private_payment_list".into(),
+            raw_json:
+                r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{"../bad":"ln"}}"#
+                    .into(),
+            status: OutboundPrivateMessageStatus::Pending,
+            attempt_count: 0,
+            created_at: timestamp(),
+            updated_at: timestamp(),
+            last_attempt_at: None,
+            sent_at: None,
+            last_error: None,
+        };
+
+    let result = validate_queued_outbound_private_message(&record);
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_claim_next_outbound_private_message_reclaims_stale_sending() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    enqueue_private_message(
+        &storage,
+        counterparty.clone(),
+        raw_private_list(),
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let claimed = claim_next_outbound_private_message(
+        &storage,
+        &counterparty,
+        timestamp(),
+        timestamp() - chrono::Duration::seconds(60),
+        timestamp() - chrono::Duration::seconds(60),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(claimed.status, OutboundPrivateMessageStatus::Sending);
+    assert_eq!(claimed.attempt_count, 1);
+
+    let duplicate_claim = claim_next_outbound_private_message(
+        &storage,
+        &counterparty,
+        timestamp(),
+        timestamp() - chrono::Duration::seconds(60),
+        timestamp() - chrono::Duration::seconds(60),
+    )
+    .await
+    .unwrap();
+    assert!(duplicate_claim.is_none());
+
+    let stale_claim = claim_next_outbound_private_message(
+        &storage,
+        &counterparty,
+        timestamp() + chrono::Duration::seconds(61),
+        timestamp(),
+        timestamp(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(stale_claim.outbound_message_id, claimed.outbound_message_id);
+    assert_eq!(stale_claim.status, OutboundPrivateMessageStatus::Sending);
+    assert_eq!(stale_claim.attempt_count, 2);
+}
+
+#[tokio::test]
+async fn test_claim_next_outbound_private_message_rejects_stale_peer_lease() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    enqueue_private_message(
+        &storage,
+        counterparty.clone(),
+        raw_private_list(),
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let first_lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx
+                    .claim_peer_link_operation(
+                        &counterparty,
+                        timestamp(),
+                        timestamp() + chrono::Duration::seconds(10),
+                    )
+                    .unwrap())
+            }
+        })
+        .await
+        .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp() + chrono::Duration::seconds(11),
+                    timestamp() + chrono::Duration::seconds(71),
+                );
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let result = claim_next_outbound_private_message_with_peer_lease(
+        &storage,
+        &counterparty,
+        timestamp() + chrono::Duration::seconds(12),
+        timestamp(),
+        timestamp(),
+        first_lease,
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    let queued = queued_outbound_private_messages(&storage, &counterparty)
+        .await
+        .unwrap();
+    assert_eq!(queued[0].status, OutboundPrivateMessageStatus::Pending);
+    assert_eq!(queued[0].attempt_count, 0);
+}

--- a/paykit-sdk/src/payment_requests.rs
+++ b/paykit-sdk/src/payment_requests.rs
@@ -458,3 +458,6 @@ where
     let event = PaymentRequestEvent::Proof(event.clone());
     enqueue_payment_request_event(storage, counterparty, &event, now).await
 }
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/payment_requests/tests.rs
+++ b/paykit-sdk/src/payment_requests/tests.rs
@@ -1,0 +1,121 @@
+use chrono::{Duration as ChronoDuration, TimeZone};
+
+use super::*;
+use crate::{
+    outbound_private::{
+        enqueue_private_message as enqueue_untyped_private_message,
+        queued_outbound_private_messages,
+    },
+    private_stream::persist_private_stream_batch,
+    storage::InMemoryStorage,
+};
+
+fn timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+}
+
+fn counterparty() -> PubkyPublicKey {
+    PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+}
+
+fn private_message(raw_json: String) -> PrivateApplicationMessage {
+    let value: serde_json::Value = serde_json::from_str(&raw_json).unwrap();
+    PrivateApplicationMessage {
+        version: value
+            .get("version")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|version| u8::try_from(version).ok()),
+        kind: value
+            .get("kind")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned),
+        raw_json,
+    }
+}
+
+fn parsed_event(raw_json: String) -> PaymentRequestEvent {
+    parse_payment_request_event_message(&private_message(raw_json))
+        .unwrap()
+        .parsed_event()
+        .unwrap()
+        .clone()
+}
+
+fn request_raw(
+    event_id: &str,
+    request_id: &str,
+    reference: &str,
+    expires_at: Option<&str>,
+    recurrence: Option<&str>,
+) -> String {
+    let expiry = expires_at
+        .map(|value| format!(r#""{value}""#))
+        .unwrap_or_else(|| "null".into());
+    let recurrence = recurrence.unwrap_or("null");
+    format!(
+        r#"{{"version":1,"kind":"paykit.payment_request","event_id":"{event_id}","payment_request_id":"{request_id}","request":{{"amount":{{"value":"0.001","asset":"btc"}},"payment_reference":"{reference}","proposal_expires_at":{expiry},"recurrence":{recurrence},"accepted_payment_endpoint_identifiers":["btc-lightning-bolt11"],"metadata":{{"note":"private"}}}}}}"#
+    )
+}
+
+fn acceptance_raw(event_id: &str, request_id: &str) -> String {
+    format!(
+        r#"{{"version":1,"kind":"paykit.payment_request_acceptance","event_id":"{event_id}","payment_request_id":"{request_id}"}}"#
+    )
+}
+
+fn rejection_raw(event_id: &str, request_id: &str) -> String {
+    format!(
+        r#"{{"version":1,"kind":"paykit.payment_request_rejection","event_id":"{event_id}","payment_request_id":"{request_id}"}}"#
+    )
+}
+
+fn cancellation_raw(event_id: &str, request_id: &str) -> String {
+    format!(
+        r#"{{"version":1,"kind":"paykit.payment_request_cancellation","event_id":"{event_id}","payment_request_id":"{request_id}"}}"#
+    )
+}
+
+fn malformed_cancellation_raw(event_id: &str, request_id: &str) -> String {
+    format!(
+        r#"{{"version":1,"kind":"paykit.payment_request_cancellation","event_id":"{event_id}","payment_request_id":"{request_id}","reason":null}}"#
+    )
+}
+
+fn malformed_missing_request_id_raw(event_id: &str) -> String {
+    format!(r#"{{"version":1,"kind":"paykit.payment_request_acceptance","event_id":"{event_id}"}}"#)
+}
+
+fn proof_raw(event_id: &str, request_id: &str, reference: &str) -> String {
+    format!(
+        r#"{{"version":1,"kind":"paykit.payment_proof","event_id":"{event_id}","payment_request_id":"{request_id}","payment_reference":"{reference}","billing_period":null,"payment_endpoint_identifier":"btc-lightning-bolt11","proof":{{"txid":"secret"}}}}"#
+    )
+}
+
+async fn persist_messages(
+    storage: &InMemoryStorage,
+    counterparty: PubkyPublicKey,
+    messages: Vec<String>,
+) {
+    persist_messages_at(storage, counterparty, messages, timestamp()).await
+}
+
+async fn persist_messages_at(
+    storage: &InMemoryStorage,
+    counterparty: PubkyPublicKey,
+    messages: Vec<String>,
+    received_at: DateTime<Utc>,
+) {
+    persist_private_stream_batch(
+        storage,
+        counterparty,
+        messages.into_iter().map(private_message).collect(),
+        None,
+        received_at,
+    )
+    .await
+    .unwrap();
+}
+
+mod enqueue;
+mod outbound_records;
+mod received_records;

--- a/paykit-sdk/src/payment_requests/tests/enqueue.rs
+++ b/paykit-sdk/src/payment_requests/tests/enqueue.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+#[tokio::test]
+async fn test_enqueue_payment_request_event_stores_canonical_payload() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let event = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+        "invoice-2026-0001",
+        None,
+        None,
+    ));
+
+    let record = enqueue_payment_request_event(&storage, counterparty.clone(), &event, timestamp())
+        .await
+        .unwrap();
+    let queued = queued_outbound_private_messages(&storage, &counterparty)
+        .await
+        .unwrap();
+
+    assert_eq!(queued, vec![record.clone()]);
+    assert_eq!(record.kind, "paykit.payment_request");
+    assert_eq!(
+        record.raw_json,
+        serialize_payment_request_event(&event).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_enqueue_payment_request_acceptance_sets_kind() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let PaymentRequestEvent::Acceptance(event) = parsed_event(acceptance_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+        "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+    )) else {
+        panic!("expected acceptance event");
+    };
+
+    let record = enqueue_payment_request_acceptance(&storage, counterparty, &event, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(record.kind, "paykit.payment_request_acceptance");
+}
+
+#[tokio::test]
+async fn test_enqueue_payment_request_rejects_invalid_terms() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let PaymentRequestEvent::Request(mut event) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+        "invoice-2026-0001",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    event.request.accepted_payment_endpoint_identifiers.clear();
+
+    let err = enqueue_payment_request(&storage, counterparty.clone(), &event, timestamp())
+        .await
+        .unwrap_err();
+    let queued = queued_outbound_private_messages(&storage, &counterparty)
+        .await
+        .unwrap();
+
+    assert!(matches!(err, crate::PaykitSdkError::Protocol(_)));
+    assert!(queued.is_empty());
+}

--- a/paykit-sdk/src/payment_requests/tests/outbound_records.rs
+++ b/paykit-sdk/src/payment_requests/tests/outbound_records.rs
@@ -1,0 +1,998 @@
+use super::*;
+
+#[tokio::test]
+async fn test_payment_request_records_merge_outbound_acceptance() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            None,
+            None,
+        )],
+    )
+    .await;
+    let PaymentRequestEvent::Acceptance(acceptance) = parsed_event(acceptance_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+        request_id,
+    )) else {
+        panic!("expected acceptance event");
+    };
+    enqueue_payment_request_acceptance(&storage, counterparty.clone(), &acceptance, timestamp())
+        .await
+        .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records[0].local_role, Some(PaymentRequestLocalRole::Payer));
+    assert_eq!(records[0].state, PaymentRequestLifecycleState::Accepted);
+    assert_eq!(
+        records[0].accepted_event_id.as_deref(),
+        Some("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102")
+    );
+    assert_eq!(
+        records[0].accepted_outbound_status,
+        Some(OutboundPrivateMessageStatus::Pending)
+    );
+    assert_eq!(
+        records[0].last_outbound_status,
+        Some(OutboundPrivateMessageStatus::Pending)
+    );
+}
+
+#[tokio::test]
+async fn test_payment_request_records_allow_rejection_after_proposal_expiry() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            Some("2026-06-03T11:59:59Z"),
+            None,
+        )],
+    )
+    .await;
+    let PaymentRequestEvent::Rejection(rejection) = parsed_event(rejection_raw(
+        "8a0d8b4c-913f-4e31-bfc9-2a6f5bb4d102",
+        request_id,
+    )) else {
+        panic!("expected rejection event");
+    };
+    enqueue_payment_request_rejection(&storage, counterparty.clone(), &rejection, timestamp())
+        .await
+        .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records[0].state, PaymentRequestLifecycleState::Rejected);
+    assert!(records[0].invalid_reason.is_none());
+    assert_eq!(
+        records[0].rejected_event_id.as_deref(),
+        Some("8a0d8b4c-913f-4e31-bfc9-2a6f5bb4d102")
+    );
+}
+
+#[tokio::test]
+async fn test_payment_request_records_use_outbound_update_time_for_freshness() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            None,
+            None,
+        )],
+    )
+    .await;
+    let PaymentRequestEvent::Acceptance(acceptance) = parsed_event(acceptance_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+        request_id,
+    )) else {
+        panic!("expected acceptance event");
+    };
+    enqueue_payment_request_acceptance(&storage, counterparty.clone(), &acceptance, timestamp())
+        .await
+        .unwrap();
+    let updated_at = timestamp() + ChronoDuration::minutes(5);
+    storage
+        .transaction(|tx| {
+            let mut outbound = tx.outbound_private_messages(&counterparty)[0].clone();
+            outbound.status = OutboundPrivateMessageStatus::Sent;
+            outbound.updated_at = updated_at;
+            outbound.sent_at = Some(updated_at);
+            tx.save_outbound_private_message(outbound)?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records[0].last_event_at, Some(updated_at));
+    assert_eq!(
+        records[0].last_outbound_status,
+        Some(OutboundPrivateMessageStatus::Sent)
+    );
+}
+
+#[tokio::test]
+async fn test_payment_request_records_keep_latest_freshness_after_later_applied_inbound() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        request_id,
+        "invoice-2026-0001",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+        .await
+        .unwrap();
+    let updated_at = timestamp() + ChronoDuration::minutes(5);
+    storage
+        .transaction(|tx| {
+            let mut outbound = tx.outbound_private_messages(&counterparty)[0].clone();
+            outbound.status = OutboundPrivateMessageStatus::Sent;
+            outbound.updated_at = updated_at;
+            outbound.sent_at = Some(updated_at);
+            tx.save_outbound_private_message(outbound)?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![acceptance_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            request_id,
+        )],
+    )
+    .await;
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records[0].state, PaymentRequestLifecycleState::Accepted);
+    assert_eq!(records[0].last_event_at, Some(updated_at));
+}
+
+#[tokio::test]
+async fn test_payment_request_records_merge_sent_request_acceptance() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        request_id,
+        "invoice-2026-0001",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+        .await
+        .unwrap();
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![acceptance_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            request_id,
+        )],
+    )
+    .await;
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records[0].local_role, Some(PaymentRequestLocalRole::Payee));
+    assert_eq!(records[0].state, PaymentRequestLifecycleState::Accepted);
+    assert!(records[0].proposal_outbound_message_id.is_some());
+}
+
+#[tokio::test]
+async fn test_payment_request_records_do_not_compare_independent_source_ids() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    enqueue_untyped_private_message(
+        &storage,
+        counterparty.clone(),
+        r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#.into(),
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        request_id,
+        "invoice-2026-0001",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+        .await
+        .unwrap();
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![acceptance_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            request_id,
+        )],
+    )
+    .await;
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records[0].state, PaymentRequestLifecycleState::Accepted);
+    assert_eq!(records[0].proposal_outbound_message_id, Some(1));
+    assert_eq!(
+        records[0].proposal_outbound_status,
+        Some(OutboundPrivateMessageStatus::Pending)
+    );
+    assert_eq!(records[0].last_stream_item_id, Some(0));
+}
+
+#[tokio::test]
+async fn test_payment_request_records_merge_outbound_proof() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            None,
+            None,
+        )],
+    )
+    .await;
+    let PaymentRequestEvent::Acceptance(acceptance) = parsed_event(acceptance_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+        request_id,
+    )) else {
+        panic!("expected acceptance event");
+    };
+    enqueue_payment_request_acceptance(&storage, counterparty.clone(), &acceptance, timestamp())
+        .await
+        .unwrap();
+    let PaymentRequestEvent::Proof(proof) = parsed_event(proof_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+        request_id,
+        "invoice-2026-0001",
+    )) else {
+        panic!("expected proof event");
+    };
+    enqueue_payment_proof(&storage, counterparty.clone(), &proof, timestamp())
+        .await
+        .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::ProofSubmitted
+    );
+    assert_eq!(records[0].payment_proofs.len(), 1);
+    assert_eq!(
+        records[0].payment_proofs[0].outbound_status,
+        Some(OutboundPrivateMessageStatus::Pending)
+    );
+    assert_eq!(
+        records[0].last_outbound_status,
+        Some(OutboundPrivateMessageStatus::Pending)
+    );
+    assert!(!format!("{:?}", records[0].payment_proofs[0]).contains("secret"));
+}
+
+#[tokio::test]
+async fn test_payment_request_records_preserve_outbound_fifo_when_clock_moves_backward() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            None,
+            None,
+        )],
+    )
+    .await;
+    let PaymentRequestEvent::Acceptance(acceptance) = parsed_event(acceptance_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+        request_id,
+    )) else {
+        panic!("expected acceptance event");
+    };
+    enqueue_payment_request_acceptance(
+        &storage,
+        counterparty.clone(),
+        &acceptance,
+        timestamp() + ChronoDuration::minutes(5),
+    )
+    .await
+    .unwrap();
+    let PaymentRequestEvent::Proof(proof) = parsed_event(proof_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+        request_id,
+        "invoice-2026-0001",
+    )) else {
+        panic!("expected proof event");
+    };
+    enqueue_payment_proof(
+        &storage,
+        counterparty.clone(),
+        &proof,
+        timestamp() + ChronoDuration::minutes(1),
+    )
+    .await
+    .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::ProofSubmitted
+    );
+    assert_eq!(records[0].payment_proofs.len(), 1);
+}
+
+#[tokio::test]
+async fn test_payment_request_records_apply_proposal_before_cross_source_acceptance() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        request_id,
+        "invoice-2026-0001",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(
+        &storage,
+        counterparty.clone(),
+        &request,
+        timestamp() + ChronoDuration::minutes(5),
+    )
+    .await
+    .unwrap();
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![acceptance_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            request_id,
+        )],
+    )
+    .await;
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records[0].local_role, Some(PaymentRequestLocalRole::Payee));
+    assert_eq!(records[0].state, PaymentRequestLifecycleState::Accepted);
+}
+
+#[tokio::test]
+async fn test_payment_request_records_flag_later_acceptance_after_local_cancellation() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        request_id,
+        "invoice-2026-0001",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+        .await
+        .unwrap();
+    let PaymentRequestEvent::Cancellation(cancellation) = parsed_event(cancellation_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+        request_id,
+    )) else {
+        panic!("expected cancellation event");
+    };
+    enqueue_payment_request_cancellation(
+        &storage,
+        counterparty.clone(),
+        &cancellation,
+        timestamp() + ChronoDuration::minutes(1),
+    )
+    .await
+    .unwrap();
+    persist_messages_at(
+        &storage,
+        counterparty.clone(),
+        vec![acceptance_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            request_id,
+        )],
+        timestamp() + ChronoDuration::minutes(2),
+    )
+    .await;
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("acceptance arrived after transition")));
+}
+
+#[tokio::test]
+async fn test_payment_request_records_apply_later_cancellation_after_acceptance() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        request_id,
+        "invoice-2026-0001",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+        .await
+        .unwrap();
+    persist_messages_at(
+        &storage,
+        counterparty.clone(),
+        vec![acceptance_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+            request_id,
+        )],
+        timestamp() + ChronoDuration::minutes(1),
+    )
+    .await;
+    let PaymentRequestEvent::Cancellation(cancellation) = parsed_event(cancellation_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+        request_id,
+    )) else {
+        panic!("expected cancellation event");
+    };
+    enqueue_payment_request_cancellation(
+        &storage,
+        counterparty.clone(),
+        &cancellation,
+        timestamp() + ChronoDuration::minutes(2),
+    )
+    .await
+    .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records[0].state, PaymentRequestLifecycleState::Canceled);
+    assert_eq!(
+        records[0].accepted_event_id.as_deref(),
+        Some("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102")
+    );
+    assert_eq!(
+        records[0].canceled_event_id.as_deref(),
+        Some("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103")
+    );
+}
+
+#[tokio::test]
+async fn test_payment_request_records_surface_recovery_required_outbound_event() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            None,
+            None,
+        )],
+    )
+    .await;
+    let PaymentRequestEvent::Acceptance(acceptance) = parsed_event(acceptance_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+        request_id,
+    )) else {
+        panic!("expected acceptance event");
+    };
+    enqueue_payment_request_acceptance(&storage, counterparty.clone(), &acceptance, timestamp())
+        .await
+        .unwrap();
+    storage
+        .transaction(|tx| {
+            let mut outbound = tx.outbound_private_messages(&counterparty)[0].clone();
+            outbound.status = OutboundPrivateMessageStatus::RecoveryRequired;
+            outbound.updated_at = timestamp() + ChronoDuration::minutes(1);
+            outbound.last_error = Some("Encrypted Link recovery is required".into());
+            tx.save_outbound_private_message(outbound)?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::RecoveryRequired
+    );
+    assert_eq!(
+        records[0].accepted_outbound_status,
+        Some(OutboundPrivateMessageStatus::RecoveryRequired)
+    );
+    assert_eq!(
+        records[0].last_outbound_status,
+        Some(OutboundPrivateMessageStatus::RecoveryRequired)
+    );
+}
+
+#[tokio::test]
+async fn test_payment_request_records_preserve_inbound_fifo_with_same_timestamp() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        request_id,
+        "invoice-2026-0001",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+        .await
+        .unwrap();
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            proof_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+                request_id,
+                "invoice-2026-0001",
+            ),
+            acceptance_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102", request_id),
+        ],
+    )
+    .await;
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("before acceptance")));
+}
+
+#[tokio::test]
+async fn test_payment_request_records_ignore_duplicate_outbound_event() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            None,
+            None,
+        )],
+    )
+    .await;
+    let PaymentRequestEvent::Acceptance(acceptance) = parsed_event(acceptance_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+        request_id,
+    )) else {
+        panic!("expected acceptance event");
+    };
+    enqueue_payment_request_acceptance(&storage, counterparty.clone(), &acceptance, timestamp())
+        .await
+        .unwrap();
+    enqueue_payment_request_acceptance(&storage, counterparty.clone(), &acceptance, timestamp())
+        .await
+        .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records[0].state, PaymentRequestLifecycleState::Accepted);
+    assert_eq!(
+        records[0].accepted_event_id.as_deref(),
+        Some("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102")
+    );
+}
+
+#[tokio::test]
+async fn test_payment_request_records_flag_outbound_event_id_conflict() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id,
+            "invoice-2026-0001",
+            None,
+            None,
+        )],
+    )
+    .await;
+    let PaymentRequestEvent::Acceptance(acceptance) = parsed_event(acceptance_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+        request_id,
+    )) else {
+        panic!("expected acceptance event");
+    };
+    let PaymentRequestEvent::Rejection(rejection) = parsed_event(rejection_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+        request_id,
+    )) else {
+        panic!("expected rejection event");
+    };
+    enqueue_payment_request_acceptance(&storage, counterparty.clone(), &acceptance, timestamp())
+        .await
+        .unwrap();
+    enqueue_payment_request_rejection(&storage, counterparty.clone(), &rejection, timestamp())
+        .await
+        .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("Event ID")));
+    assert_eq!(records[0].last_outbound_message_id, Some(1));
+    assert!(records[0].last_stream_item_id.is_none());
+}
+
+#[tokio::test]
+async fn test_payment_request_records_flag_outbound_reuse_of_tainted_event_id() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let inbound_request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    let outbound_request_id = "c7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                inbound_request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            ),
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                inbound_request_id,
+                "invoice-2026-0002",
+                None,
+                None,
+            ),
+        ],
+    )
+    .await;
+    let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        outbound_request_id,
+        "invoice-2026-0003",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+        .await
+        .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+    let outbound = records
+        .iter()
+        .find(|record| record.payment_request_id == outbound_request_id)
+        .unwrap();
+
+    assert_eq!(
+        outbound.state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(outbound
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("Event ID")));
+}
+
+#[tokio::test]
+async fn test_payment_request_records_flag_cross_direction_duplicate_event_id() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    let raw = request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        request_id,
+        "invoice-2026-0001",
+        None,
+        None,
+    );
+    let PaymentRequestEvent::Request(request) = parsed_event(raw.clone()) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+        .await
+        .unwrap();
+    persist_messages(&storage, counterparty.clone(), vec![raw]).await;
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("Event ID")));
+}
+
+#[tokio::test]
+async fn test_payment_request_records_keep_preinvalid_position_during_later_conflict() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let inbound_request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    let outbound_request_id = "c7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                inbound_request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            ),
+            malformed_cancellation_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104", inbound_request_id),
+        ],
+    )
+    .await;
+    let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+        outbound_request_id,
+        "invoice-2026-0002",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+        .await
+        .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+    let inbound = records
+        .iter()
+        .find(|record| record.payment_request_id == inbound_request_id)
+        .unwrap();
+    let outbound = records
+        .iter()
+        .find(|record| record.payment_request_id == outbound_request_id)
+        .unwrap();
+
+    assert_eq!(inbound.state, PaymentRequestLifecycleState::InvalidConflict);
+    assert_eq!(inbound.last_stream_item_id, Some(1));
+    assert_eq!(
+        outbound.state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+}
+
+#[tokio::test]
+async fn test_payment_request_records_flag_outbound_reuse_of_malformed_event_id() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let inbound_request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    let outbound_request_id = "c7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![malformed_cancellation_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104",
+            inbound_request_id,
+        )],
+    )
+    .await;
+    let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104",
+        outbound_request_id,
+        "invoice-2026-0002",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+        .await
+        .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+    let outbound = records
+        .iter()
+        .find(|record| record.payment_request_id == outbound_request_id)
+        .unwrap();
+
+    assert_eq!(
+        outbound.state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(outbound
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("Event ID")));
+}
+
+#[tokio::test]
+async fn test_payment_request_records_taint_event_id_without_request_id() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let outbound_request_id = "c7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![malformed_missing_request_id_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104",
+        )],
+    )
+    .await;
+    let PaymentRequestEvent::Request(request) = parsed_event(request_raw(
+        "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104",
+        outbound_request_id,
+        "invoice-2026-0002",
+        None,
+        None,
+    )) else {
+        panic!("expected request event");
+    };
+    enqueue_payment_request(&storage, counterparty.clone(), &request, timestamp())
+        .await
+        .unwrap();
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("Event ID")));
+}
+
+#[tokio::test]
+async fn test_payment_request_records_keep_malformed_inbound_audit_position() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            ),
+            malformed_cancellation_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104", request_id),
+        ],
+    )
+    .await;
+
+    let records = payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert_eq!(records[0].last_stream_item_id, Some(1));
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("reason must be a string")));
+}

--- a/paykit-sdk/src/payment_requests/tests/received_records.rs
+++ b/paykit-sdk/src/payment_requests/tests/received_records.rs
@@ -1,0 +1,360 @@
+use super::*;
+
+#[tokio::test]
+async fn test_received_payment_request_records_flag_inbound_acceptance_for_received_proposal() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            ),
+            acceptance_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102", request_id),
+        ],
+    )
+    .await;
+
+    let records = received_payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert_eq!(
+        records[0].terms.as_ref().unwrap().payment_reference,
+        "invoice-2026-0001"
+    );
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("outbound payer event")));
+    assert!(!format!("{:?}", records[0]).contains("private"));
+}
+
+#[tokio::test]
+async fn test_received_payment_request_records_mark_proposal_expired() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![request_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+            "invoice-2026-0001",
+            Some("2026-06-03T11:59:59Z"),
+            None,
+        )],
+    )
+    .await;
+
+    let records = received_payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::ProposalExpired
+    );
+}
+
+#[tokio::test]
+async fn test_received_payment_request_records_flag_inbound_proof_for_received_proposal() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            ),
+            proof_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+                request_id,
+                "invoice-2026-0001",
+            ),
+        ],
+    )
+    .await;
+
+    let records = received_payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("outbound payer event")));
+}
+
+#[tokio::test]
+async fn test_received_payment_request_records_flag_event_id_conflict() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            ),
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0002",
+                None,
+                None,
+            ),
+        ],
+    )
+    .await;
+
+    let records = received_payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("Event ID")));
+}
+
+#[tokio::test]
+async fn test_received_payment_request_records_flag_invalid_transition() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![proof_raw(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+            "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+            "invoice-2026-0001",
+        )],
+    )
+    .await;
+
+    let records = received_payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("before acceptance")));
+}
+
+#[tokio::test]
+async fn test_received_payment_request_records_preserve_first_invalid_reason() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            proof_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+                request_id,
+                "invoice-2026-0001",
+            ),
+            malformed_cancellation_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104", request_id),
+        ],
+    )
+    .await;
+
+    let records = received_payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("before acceptance")));
+}
+
+#[tokio::test]
+async fn test_received_payment_request_records_keep_invalid_before_later_proposal() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            proof_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d103",
+                request_id,
+                "invoice-2026-0001",
+            ),
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            ),
+        ],
+    )
+    .await;
+
+    let records = received_payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert!(records[0].terms.is_none());
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("before acceptance")));
+}
+
+#[tokio::test]
+async fn test_received_payment_request_records_derive_cancellation() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            ),
+            cancellation_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104", request_id),
+        ],
+    )
+    .await;
+
+    let records = received_payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records[0].state, PaymentRequestLifecycleState::Canceled);
+    assert_eq!(
+        records[0].canceled_event_id.as_deref(),
+        Some("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104")
+    );
+}
+
+#[tokio::test]
+async fn test_received_payment_request_records_flag_second_cancellation() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            ),
+            cancellation_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104", request_id),
+            cancellation_raw("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d105", request_id),
+        ],
+    )
+    .await;
+
+    let records = received_payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::InvalidConflict
+    );
+    assert_eq!(
+        records[0].canceled_event_id.as_deref(),
+        Some("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d104")
+    );
+    assert!(records[0]
+        .invalid_reason
+        .as_ref()
+        .is_some_and(|reason| reason.contains("terminal state")));
+}
+
+#[tokio::test]
+async fn test_received_payment_request_records_return_newest_first() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let older_request_id = "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    let newer_request_id = "c7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33";
+    persist_messages(
+        &storage,
+        counterparty.clone(),
+        vec![
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+                older_request_id,
+                "invoice-2026-0001",
+                None,
+                None,
+            ),
+            request_raw(
+                "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102",
+                newer_request_id,
+                "invoice-2026-0002",
+                None,
+                None,
+            ),
+        ],
+    )
+    .await;
+
+    let records = received_payment_request_records(&storage, &counterparty, timestamp())
+        .await
+        .unwrap();
+
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].payment_request_id, newer_request_id);
+    assert_eq!(records[1].payment_request_id, older_request_id);
+}

--- a/paykit-sdk/src/private_lists.rs
+++ b/paykit-sdk/src/private_lists.rs
@@ -125,3 +125,6 @@ pub(crate) fn derive_private_payment_list_view(
         last_refresh_at: Some(item.received_at),
     }))
 }
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/private_lists/tests.rs
+++ b/paykit-sdk/src/private_lists/tests.rs
@@ -1,0 +1,210 @@
+use chrono::{Duration as ChronoDuration, TimeZone, Utc};
+
+use super::*;
+use crate::{
+    adapters::ReceivingDetail,
+    outbound_private::queued_outbound_private_messages,
+    private_stream::persist_private_stream_batch,
+    storage::{InMemoryStorage, PrivateStreamItemRecord},
+    PaykitSdkError,
+};
+use paykit_lib::PrivateApplicationMessage;
+
+fn timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+}
+
+fn counterparty() -> PubkyPublicKey {
+    PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+}
+
+fn stream_item(
+    stream_item_id: u64,
+    raw_json: &str,
+    status: PrivateStreamParseStatus,
+) -> PrivateStreamItemRecord {
+    PrivateStreamItemRecord {
+        stream_item_id,
+        counterparty: counterparty(),
+        receive_batch_id: 0,
+        raw_json: raw_json.into(),
+        parsed_version: Some(1),
+        parsed_kind: Some(PrivateMessageKind::PrivatePaymentList.as_str().into()),
+        known_paykit_kind: Some(PrivateMessageKind::PrivatePaymentList.as_str().into()),
+        parse_status: status,
+        parse_error: None,
+        received_at: timestamp(),
+    }
+}
+
+fn list_json(payload: &str) -> String {
+    format!(
+        r#"{{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{{"btc-lightning-bolt11":"{payload}"}}}}"#
+    )
+}
+
+fn private_message(raw_json: String) -> PrivateApplicationMessage {
+    PrivateApplicationMessage {
+        version: Some(1),
+        kind: Some(PrivateMessageKind::PrivatePaymentList.as_str().into()),
+        raw_json,
+    }
+}
+
+#[test]
+fn test_derive_private_payment_list_view_uses_latest_valid_list() {
+    let first = list_json("ln-old");
+    let latest = list_json("ln-new");
+
+    let view = derive_private_payment_list_view(vec![
+        stream_item(1, &latest, PrivateStreamParseStatus::Valid),
+        stream_item(0, &first, PrivateStreamParseStatus::Valid),
+    ])
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(view.latest_stream_item_id, Some(1));
+    assert_eq!(view.payment_endpoints["btc-lightning-bolt11"], "ln-new");
+    assert_eq!(view.last_refresh_at, Some(timestamp()));
+}
+
+#[test]
+fn test_private_payment_list_view_debug_redacts_payloads() {
+    let mut payment_endpoints = HashMap::new();
+    payment_endpoints.insert("btc-lightning-bolt11".into(), "ln-private-secret".into());
+    let view = PrivatePaymentListView {
+        latest_stream_item_id: Some(42),
+        payment_endpoints,
+        last_refresh_at: Some(timestamp()),
+    };
+
+    let debug = format!("{view:?}");
+
+    assert!(debug.contains("btc-lightning-bolt11"));
+    assert!(!debug.contains("ln-private-secret"));
+}
+
+#[test]
+fn test_derive_private_payment_list_view_ignores_malformed_newer_list() {
+    let valid = list_json("ln-valid");
+    let malformed = r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{"../bad":"ln-bad"}}"#;
+
+    let view = derive_private_payment_list_view(vec![
+        stream_item(0, &valid, PrivateStreamParseStatus::Valid),
+        stream_item(1, malformed, PrivateStreamParseStatus::MalformedRecognized),
+    ])
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(view.latest_stream_item_id, Some(0));
+    assert_eq!(view.payment_endpoints["btc-lightning-bolt11"], "ln-valid");
+}
+
+#[tokio::test]
+async fn test_current_private_payment_list_loads_from_storage() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let json = list_json("ln-storage");
+
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![private_message(json)],
+        None,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let view = current_private_payment_list(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(view.latest_stream_item_id, Some(0));
+    assert_eq!(view.payment_endpoints["btc-lightning-bolt11"], "ln-storage");
+}
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_stores_exact_list_message() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+
+    let record = enqueue_private_payment_list(
+        &storage,
+        counterparty.clone(),
+        vec![ReceivingDetail {
+            identifier: "btc-lightning-bolt11".into(),
+            payload: "ln-private".into(),
+        }],
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let queued = queued_outbound_private_messages(&storage, &counterparty)
+        .await
+        .unwrap();
+    assert_eq!(record.outbound_message_id, queued[0].outbound_message_id);
+    let list = parse_private_payment_list_json(&queued[0].raw_json).unwrap();
+    assert_eq!(list.kind(), PrivateMessageKind::PrivatePaymentList);
+    assert_eq!(
+        list.get(&paykit_lib::PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap())
+            .unwrap()
+            .as_str(),
+        "ln-private"
+    );
+}
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_with_link_lease_rejects_stale_lease() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let stale_lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx
+                    .claim_peer_link_operation(
+                        &counterparty,
+                        timestamp(),
+                        timestamp() + ChronoDuration::seconds(10),
+                    )
+                    .unwrap())
+            }
+        })
+        .await
+        .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let _ = tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp() + ChronoDuration::seconds(11),
+                    timestamp() + ChronoDuration::seconds(71),
+                );
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let result = enqueue_private_payment_list_with_link_lease(
+        &storage,
+        counterparty.clone(),
+        vec![ReceivingDetail {
+            identifier: "btc-lightning-bolt11".into(),
+            payload: "ln-private".into(),
+        }],
+        timestamp(),
+        &stale_lease,
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    assert!(queued_outbound_private_messages(&storage, &counterparty)
+        .await
+        .unwrap()
+        .is_empty());
+}

--- a/paykit-sdk/src/private_stream.rs
+++ b/paykit-sdk/src/private_stream.rs
@@ -334,3 +334,6 @@ pub(crate) fn payload_hash(raw_json: &str) -> String {
     let digest = Sha256::digest(raw_json.as_bytes());
     format!("sha256:{digest:x}")
 }
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/private_stream/tests.rs
+++ b/paykit-sdk/src/private_stream/tests.rs
@@ -1,0 +1,495 @@
+use chrono::{TimeZone, Utc};
+
+use super::*;
+use crate::{
+    linked_peers::LinkedPeerState,
+    storage::{EncryptedLinkStateRecord, InMemoryStorage, LinkedPeerRecord},
+    PaykitSdkError, PrivateStreamParseStatus,
+};
+
+fn counterparty() -> PubkyPublicKey {
+    PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+}
+
+fn timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+}
+
+fn private_message(raw_json: &str) -> PrivateApplicationMessage {
+    let value: serde_json::Value = serde_json::from_str(raw_json).unwrap();
+    PrivateApplicationMessage {
+        version: value
+            .get("version")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|version| u8::try_from(version).ok()),
+        kind: value
+            .get("kind")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned),
+        raw_json: raw_json.to_owned(),
+    }
+}
+
+fn payment_request_raw(reference: &str) -> String {
+    format!(
+        r#"{{"version":1,"kind":"paykit.payment_request","event_id":"8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101","payment_request_id":"b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33","request":{{"amount":{{"value":"0.001","asset":"btc"}},"payment_reference":"{reference}","proposal_expires_at":null,"recurrence":null,"accepted_payment_endpoint_identifiers":["btc-lightning-bolt11"],"metadata":{{}}}}}}"#
+    )
+}
+
+fn receipt_access_raw(event_id: &str, receipt_id: &str, reference: &str) -> String {
+    let receipt_id = paykit_lib::ReceiptId::new(receipt_id).unwrap();
+    receipt_access_raw_with_location(
+        event_id,
+        receipt_id.as_str(),
+        reference,
+        &paykit_lib::ReceiptAccess::location_for(&receipt_id),
+    )
+}
+
+fn receipt_access_raw_with_location(
+    event_id: &str,
+    receipt_id: &str,
+    reference: &str,
+    location: &str,
+) -> String {
+    let key = paykit_lib::ReceiptDecryptionKey::generate();
+    format!(
+        r#"{{"version":1,"kind":"paykit.receipt_access","event_id":"{event_id}","receipt_id":"{receipt_id}","payment_reference":"{reference}","location":"{location}","key":"{}"}}"#,
+        key.as_str()
+    )
+}
+
+#[tokio::test]
+async fn test_persist_private_stream_batch_stores_messages_and_checkpoint() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty,
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: None,
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let link_state = EncryptedLinkStateRecord {
+        counterparty: counterparty.clone(),
+        link_snapshot: Some(vec![1, 2, 3]),
+        handshake_snapshot: None,
+        handshake_role: None,
+        generation: 1,
+        checkpointed_at: timestamp(),
+    };
+    let messages = vec![
+        private_message(r#"{"version":1,"kind":"paykit.unknown","body":{}}"#),
+        private_message(&payment_request_raw("invoice-2026-0001")),
+    ];
+
+    let report = persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        messages,
+        Some(link_state.clone()),
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    assert_eq!(report.receive_batch_id, 0);
+    assert_eq!(report.stream_item_ids, vec![0, 1]);
+    assert_eq!(snapshot.private_stream_items.len(), 2);
+    assert_eq!(
+        snapshot.private_stream_items[0].parse_status,
+        PrivateStreamParseStatus::UnknownKind
+    );
+    assert_eq!(
+        snapshot.private_stream_items[1].parse_status,
+        PrivateStreamParseStatus::Valid
+    );
+    assert_eq!(snapshot.encrypted_link_states[&counterparty], link_state);
+    assert_eq!(snapshot.event_dedup_records.len(), 1);
+    let peer = snapshot.linked_peers.get(&counterparty).unwrap();
+    assert_eq!(peer.last_private_receive_at, Some(timestamp()));
+    assert_eq!(peer.last_sync_at, Some(timestamp()));
+}
+
+#[tokio::test]
+async fn test_persist_private_stream_batch_empty_checkpoint_updates_sync_time() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty,
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: None,
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let link_state = EncryptedLinkStateRecord {
+        counterparty: counterparty.clone(),
+        link_snapshot: Some(vec![1, 2, 3]),
+        handshake_snapshot: None,
+        handshake_role: None,
+        generation: 1,
+        checkpointed_at: timestamp(),
+    };
+
+    let report = persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        Vec::new(),
+        Some(link_state),
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    let peer = snapshot.linked_peers.get(&counterparty).unwrap();
+    assert!(report.stream_item_ids.is_empty());
+    assert_eq!(peer.last_private_receive_at, None);
+    assert_eq!(peer.last_sync_at, Some(timestamp()));
+}
+
+#[tokio::test]
+async fn test_persist_private_stream_batch_indexes_receipt_access() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let event_id = "650e8400-e29b-41d4-a716-446655440000";
+    let receipt_id = "550e8400-e29b-41d4-a716-446655440000";
+    let raw = receipt_access_raw(event_id, receipt_id, "invoice-2026-0001");
+
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![private_message(&raw)],
+        None,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let records = crate::receipts::receipt_access_records(&storage, &counterparty)
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].stream_item_id, 0);
+    assert_eq!(records[0].receive_batch_id, 0);
+    assert_eq!(records[0].event_id, event_id);
+    assert_eq!(records[0].receipt_id, receipt_id);
+    assert_eq!(records[0].payment_reference, "invoice-2026-0001");
+    assert!(records[0].payment_request_id.is_none());
+    assert!(records[0].billing_period.is_none());
+    assert!(records[0].location.ends_with(receipt_id));
+    let debug = format!("{:?}", records[0]);
+    assert!(debug.contains("<redacted>"));
+    assert!(!debug.contains(&records[0].key));
+
+    let indexed =
+        crate::receipts::receipt_access_record_by_receipt_id(&storage, &counterparty, receipt_id)
+            .await
+            .unwrap()
+            .unwrap();
+    assert_eq!(indexed.event_id, event_id);
+}
+
+#[tokio::test]
+async fn test_persist_private_stream_batch_dedupes_receipt_access_index() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let event_id = "650e8400-e29b-41d4-a716-446655440000";
+    let receipt_id = "550e8400-e29b-41d4-a716-446655440000";
+    let duplicate_raw = receipt_access_raw(event_id, receipt_id, "invoice-2026-0001");
+    let conflicting_raw = receipt_access_raw(
+        event_id,
+        "750e8400-e29b-41d4-a716-446655440000",
+        "invoice-2026-0002",
+    );
+
+    let report = persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![
+            private_message(&duplicate_raw),
+            private_message(&duplicate_raw),
+            private_message(&conflicting_raw),
+        ],
+        None,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let records = crate::receipts::receipt_access_records(&storage, &counterparty)
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].stream_item_id, 0);
+    assert_eq!(records[0].receipt_id, receipt_id);
+    assert_eq!(report.event_conflicts.len(), 1);
+    assert_eq!(report.event_conflicts[0].conflicting_stream_item_id, 2);
+    let snapshot = storage.snapshot().unwrap();
+    let dedupe = snapshot
+        .event_dedup_records
+        .get(&(counterparty, event_id.into()))
+        .unwrap();
+    assert_eq!(dedupe.duplicate_stream_item_ids, vec![1]);
+    assert_eq!(dedupe.conflicting_stream_item_ids, vec![2]);
+}
+
+#[tokio::test]
+async fn test_persist_private_stream_batch_skips_malformed_receipt_access_index() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let raw = receipt_access_raw_with_location(
+        "650e8400-e29b-41d4-a716-446655440000",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "invoice-2026-0001",
+        "/pub/paykit/v0/private/receipts/not-the-receipt-id",
+    );
+
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![private_message(&raw)],
+        None,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    assert_eq!(
+        snapshot.private_stream_items[0].parse_status,
+        PrivateStreamParseStatus::MalformedRecognized
+    );
+    let records = crate::receipts::receipt_access_records(&storage, &counterparty)
+        .await
+        .unwrap();
+    assert!(records.is_empty());
+}
+
+#[tokio::test]
+async fn test_persist_private_stream_batch_marks_event_id_conflicts() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let messages = vec![
+        private_message(&payment_request_raw("invoice-2026-0001")),
+        private_message(&payment_request_raw("invoice-2026-0002")),
+    ];
+
+    let report =
+        persist_private_stream_batch(&storage, counterparty.clone(), messages, None, timestamp())
+            .await
+            .unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    let record = snapshot
+        .event_dedup_records
+        .get(&(counterparty, "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101".into()))
+        .unwrap();
+    assert_eq!(report.event_conflicts.len(), 1);
+    assert_eq!(record.first_stream_item_id, 0);
+    assert_eq!(record.conflicting_stream_item_ids, vec![1]);
+}
+
+#[tokio::test]
+async fn test_persist_private_stream_batch_scopes_event_dedupe_by_counterparty() {
+    let storage = InMemoryStorage::new();
+    let first_counterparty = counterparty();
+    let second_counterparty = counterparty();
+
+    let first_report = persist_private_stream_batch(
+        &storage,
+        first_counterparty,
+        vec![private_message(&payment_request_raw("invoice-2026-0001"))],
+        None,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+    let second_report = persist_private_stream_batch(
+        &storage,
+        second_counterparty,
+        vec![private_message(&payment_request_raw("invoice-2026-0002"))],
+        None,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    assert!(first_report.event_conflicts.is_empty());
+    assert!(second_report.event_conflicts.is_empty());
+    assert_eq!(snapshot.event_dedup_records.len(), 2);
+}
+
+#[tokio::test]
+async fn test_persist_private_stream_batch_keeps_malformed_recognized_messages() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let malformed = r#"{"version":1,"kind":"paykit.payment_request","event_id":"8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101","payment_request_id":"b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33","request":{"amount":{"value":"ten","asset":"btc"},"payment_reference":"invoice-2026-0001","proposal_expires_at":null,"recurrence":null,"accepted_payment_endpoint_identifiers":["btc-lightning-bolt11"],"metadata":{}}}"#;
+
+    persist_private_stream_batch(
+        &storage,
+        counterparty,
+        vec![private_message(malformed)],
+        None,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    let item = &snapshot.private_stream_items[0];
+    assert_eq!(
+        item.parse_status,
+        PrivateStreamParseStatus::MalformedRecognized
+    );
+    assert!(item
+        .parse_error
+        .as_ref()
+        .is_some_and(|error| error.contains("amount.value")));
+    assert_eq!(snapshot.event_dedup_records.len(), 1);
+}
+
+#[tokio::test]
+async fn test_persist_private_stream_batch_keeps_invalid_json_payloads() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let raw_json = "not json";
+
+    let report = persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![PrivateApplicationMessage {
+            version: None,
+            kind: None,
+            raw_json: raw_json.into(),
+        }],
+        None,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    let item = &snapshot.private_stream_items[0];
+    assert_eq!(report.stream_item_ids, vec![0]);
+    assert_eq!(item.counterparty, counterparty);
+    assert_eq!(item.raw_json, raw_json);
+    assert_eq!(item.parse_status, PrivateStreamParseStatus::InvalidJson);
+}
+
+#[tokio::test]
+async fn test_persist_private_stream_batch_records_invalid_utf8_marker_error() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let raw_json = "paykit.invalid_utf8_private_message:_w";
+
+    persist_private_stream_batch(
+        &storage,
+        counterparty,
+        vec![PrivateApplicationMessage {
+            version: None,
+            kind: None,
+            raw_json: raw_json.into(),
+        }],
+        None,
+        timestamp(),
+    )
+    .await
+    .unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    let item = &snapshot.private_stream_items[0];
+    assert_eq!(item.parse_status, PrivateStreamParseStatus::InvalidJson);
+    assert!(item
+        .parse_error
+        .as_ref()
+        .is_some_and(|error| error.contains("valid UTF-8")));
+}
+
+#[tokio::test]
+async fn test_persist_private_stream_batch_rolls_back_with_stale_lease() {
+    let storage = InMemoryStorage::new();
+    let counterparty = counterparty();
+    let first_lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp(),
+                    timestamp() + chrono::Duration::seconds(10),
+                ))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.claim_peer_link_operation(
+                    &counterparty,
+                    timestamp() + chrono::Duration::seconds(11),
+                    timestamp() + chrono::Duration::seconds(71),
+                );
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let link_state = EncryptedLinkStateRecord {
+        counterparty: counterparty.clone(),
+        link_snapshot: Some(vec![1, 2, 3]),
+        handshake_snapshot: None,
+        handshake_role: None,
+        generation: 1,
+        checkpointed_at: timestamp() + chrono::Duration::seconds(12),
+    };
+
+    let result = persist_private_stream_batch_with_link_lease(
+        &storage,
+        counterparty,
+        vec![private_message(r#"{"version":1,"kind":"paykit.unknown"}"#)],
+        Some(link_state),
+        Some(first_lease),
+        timestamp() + chrono::Duration::seconds(12),
+    )
+    .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    let snapshot = storage.snapshot().unwrap();
+    assert!(snapshot.private_stream_items.is_empty());
+    assert!(snapshot.encrypted_link_states.is_empty());
+    assert_eq!(snapshot.next_private_stream_item_id, 0);
+}

--- a/paykit-sdk/src/receipts.rs
+++ b/paykit-sdk/src/receipts.rs
@@ -937,3 +937,6 @@ fn is_not_found(err: &PubkyError) -> bool {
             if *status == StatusCode::NOT_FOUND || *status == StatusCode::GONE
     )
 }
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/receipts/tests.rs
+++ b/paykit-sdk/src/receipts/tests.rs
@@ -1,0 +1,310 @@
+use chrono::{TimeZone, Utc};
+
+use super::*;
+
+fn timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+}
+
+fn public_key() -> paykit_lib::PublicKey {
+    pubky::Keypair::random().public_key()
+}
+
+fn receipt_access_record(
+    receipt_id: &paykit_lib::ReceiptId,
+    key: &ReceiptDecryptionKey,
+    payment_reference: &str,
+) -> ReceiptAccessRecord {
+    ReceiptAccessRecord {
+        counterparty: PubkyPublicKey::from_public_key(&public_key()),
+        stream_item_id: 0,
+        receive_batch_id: 0,
+        event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+        receipt_id: receipt_id.as_str().into(),
+        payment_reference: payment_reference.into(),
+        payment_request_id: None,
+        billing_period: None,
+        location: paykit_lib::ReceiptAccess::location_for(receipt_id),
+        key: key.as_str().into(),
+        retrieval_status: ReceiptRetrievalStatus::Pending,
+        retrieval_attempted_at: None,
+        retrieved_at: None,
+        last_retrieval_error: None,
+        received_at: timestamp(),
+    }
+}
+
+fn receipt(
+    receipt_id: paykit_lib::ReceiptId,
+    payment_reference: &str,
+    recipient_public_key: paykit_lib::PublicKey,
+) -> Receipt {
+    Receipt {
+        receipt_id,
+        payment_reference: paykit_lib::PaymentReference::new(payment_reference).unwrap(),
+        payment_request_id: None,
+        billing_period: None,
+        recipient_public_key,
+        payment_endpoint_identifier: Some(
+            paykit_lib::PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap(),
+        ),
+        amount: Some(paykit_lib::PaymentAmount::new("0.001", "btc").unwrap()),
+        metadata: serde_json::json!({"settlement_id": "abc-123"})
+            .as_object()
+            .cloned()
+            .unwrap(),
+    }
+}
+
+#[test]
+fn test_receipt_draft_builder_creates_retry_safe_draft() {
+    let draft = ReceiptDraftBuilder::new("invoice-2026-0001")
+        .unwrap()
+        .with_new_receipt_id()
+        .with_payment_endpoint_identifier_text("btc-lightning-bolt11")
+        .unwrap()
+        .with_amount_text("0.001", "btc")
+        .unwrap()
+        .with_metadata(
+            serde_json::json!({"settlement_id": "abc-123"})
+                .as_object()
+                .cloned()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    assert!(draft.receipt_id.is_some());
+    assert_eq!(draft.payment_reference.as_str(), "invoice-2026-0001");
+    assert_eq!(
+        draft.payment_endpoint_identifier.unwrap().as_str(),
+        "btc-lightning-bolt11"
+    );
+    assert_eq!(draft.amount.unwrap().asset, "btc");
+    assert_eq!(draft.metadata["settlement_id"], "abc-123");
+}
+
+#[test]
+fn test_receipt_draft_builder_requires_request_id_for_billing_period() {
+    let result = ReceiptDraftBuilder::new("invoice-2026-0001")
+        .unwrap()
+        .with_billing_period(paykit_lib::BillingPeriod {
+            starts_at: "2026-06-01T00:00:00Z".into(),
+            ends_at: "2026-07-01T00:00:00Z".into(),
+        })
+        .build();
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[test]
+fn test_receipt_draft_builder_debug_redacts_sensitive_fields() {
+    let builder = ReceiptDraftBuilder::new("invoice-2026-0001")
+        .unwrap()
+        .with_amount_text("0.001", "btc")
+        .unwrap()
+        .with_metadata(
+            serde_json::json!({"settlement_id": "abc-123"})
+                .as_object()
+                .cloned()
+                .unwrap(),
+        );
+
+    let debug = format!("{builder:?}");
+
+    assert!(!debug.contains("invoice-2026-0001"));
+    assert!(!debug.contains("0.001"));
+    assert!(!debug.contains("abc-123"));
+}
+
+#[test]
+fn test_receipt_issuance_record_redacts_sensitive_fields() {
+    let counterparty_key = public_key();
+    let counterparty = PubkyPublicKey::from_public_key(&counterparty_key);
+    let prepared = paykit_lib::prepare_receipt_for_recipient(
+        counterparty_key,
+        paykit_lib::ReceiptDraft {
+            receipt_id: Some(
+                paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+            ),
+            payment_reference: paykit_lib::PaymentReference::new("invoice-2026-0001").unwrap(),
+            payment_request_id: None,
+            billing_period: None,
+            payment_endpoint_identifier: Some(
+                paykit_lib::PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap(),
+            ),
+            amount: Some(paykit_lib::PaymentAmount::new("0.001", "btc").unwrap()),
+            metadata: serde_json::Map::new(),
+        },
+    )
+    .unwrap();
+    let key = prepared.access.key.as_str().to_owned();
+    let encrypted_receipt = prepared.encrypted_receipt.clone();
+    let access_json = paykit_lib::serialize_receipt_access_json(&prepared.access).unwrap();
+    let record = ReceiptIssuanceRecord::from_prepared(counterparty, prepared, timestamp()).unwrap();
+
+    let debug = format!("{record:?}");
+
+    assert!(!debug.contains("invoice-2026-0001"));
+    assert!(!debug.contains(&key));
+    assert!(!debug.contains(&encrypted_receipt));
+    assert!(!debug.contains(&access_json));
+}
+
+#[test]
+fn test_decrypt_receipt_record_from_access_validates_and_redacts() {
+    let receipt_id = paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let key = ReceiptDecryptionKey::generate();
+    let recipient_public_key = public_key();
+    let expected_recipient = PubkyPublicKey::from_public_key(&recipient_public_key);
+    let receipt = receipt(
+        receipt_id.clone(),
+        "invoice-2026-0001",
+        recipient_public_key,
+    );
+    let encrypted = receipt.encrypt(&key).unwrap();
+    let access = receipt_access_record(&receipt_id, &key, "invoice-2026-0001");
+
+    let record =
+        decrypt_receipt_record_from_access(&access, &encrypted, timestamp(), &expected_recipient)
+            .unwrap();
+
+    assert_eq!(record.receipt_id, receipt_id.as_str());
+    assert!(receipt_record_matches_access(&record, &access));
+    assert_eq!(record.payment_reference, "invoice-2026-0001");
+    assert_eq!(record.receipt_access_event_id, access.event_id);
+    assert_eq!(record.amount.as_ref().unwrap().asset, "btc");
+    assert_eq!(record.metadata["settlement_id"], "abc-123");
+    let debug = format!("{record:?}");
+    assert!(debug.contains("<redacted:1 fields>"));
+    assert!(!debug.contains("abc-123"));
+    assert!(!debug.contains("invoice-2026-0001"));
+    assert!(!debug.contains(&access.location));
+}
+
+#[test]
+fn test_receipt_record_matches_access_requires_decrypting_key() {
+    let receipt_id = paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let key = ReceiptDecryptionKey::generate();
+    let recipient_public_key = public_key();
+    let expected_recipient = PubkyPublicKey::from_public_key(&recipient_public_key);
+    let receipt = receipt(
+        receipt_id.clone(),
+        "invoice-2026-0001",
+        recipient_public_key,
+    );
+    let encrypted = receipt.encrypt(&key).unwrap();
+    let access = receipt_access_record(&receipt_id, &key, "invoice-2026-0001");
+    let record =
+        decrypt_receipt_record_from_access(&access, &encrypted, timestamp(), &expected_recipient)
+            .unwrap();
+    let wrong_key_access = receipt_access_record(
+        &receipt_id,
+        &ReceiptDecryptionKey::generate(),
+        "invoice-2026-0001",
+    );
+
+    assert!(!receipt_record_matches_access(&record, &wrong_key_access));
+}
+
+#[test]
+fn test_receipt_access_record_deserializes_pending_retrieval_defaults() {
+    let counterparty = PubkyPublicKey::from_public_key(&public_key());
+    let value = serde_json::json!({
+        "counterparty": counterparty.as_str(),
+        "stream_item_id": 0,
+        "receive_batch_id": 0,
+        "event_id": "650e8400-e29b-41d4-a716-446655440000",
+        "receipt_id": "550e8400-e29b-41d4-a716-446655440000",
+        "payment_reference": "invoice-2026-0001",
+        "payment_request_id": null,
+        "billing_period": null,
+        "location": "/pub/paykit/v0/private/receipts/550e8400-e29b-41d4-a716-446655440000",
+        "key": "receipt-secret",
+        "received_at": timestamp(),
+    });
+
+    let record: ReceiptAccessRecord = serde_json::from_value(value).unwrap();
+
+    assert_eq!(record.retrieval_status, ReceiptRetrievalStatus::Pending);
+    assert!(record.retrieval_attempted_at.is_none());
+    assert!(record.retrieved_at.is_none());
+    assert!(record.last_retrieval_error.is_none());
+}
+
+#[test]
+fn test_receipt_access_record_error_clears_success_timestamp() {
+    let receipt_id = paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let key = ReceiptDecryptionKey::generate();
+    let record =
+        receipt_access_record(&receipt_id, &key, "invoice-2026-0001").mark_retrieved(timestamp());
+
+    let failed = record.mark_retrieval_error(
+        ReceiptRetrievalStatus::Failed,
+        timestamp() + chrono::Duration::seconds(1),
+        "decryption failed".into(),
+    );
+
+    assert_eq!(failed.retrieval_status, ReceiptRetrievalStatus::Failed);
+    assert!(failed.retrieved_at.is_none());
+    assert_eq!(
+        failed.last_retrieval_error.as_deref(),
+        Some("decryption failed")
+    );
+    let debug = format!("{failed:?}");
+    assert!(!debug.contains("decryption failed"));
+}
+
+#[test]
+fn test_receipt_access_view_hides_storage_only_fields() {
+    let receipt_id = paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let key = ReceiptDecryptionKey::generate();
+    let access = receipt_access_record(&receipt_id, &key, "invoice-2026-0001");
+
+    let view = ReceiptAccessView::from(&access);
+    let json = serde_json::to_string(&view).unwrap();
+
+    assert_eq!(view.payment_reference, "invoice-2026-0001");
+    assert!(!json.contains(key.as_str()));
+    assert!(!json.contains("/pub/paykit/v0/private/receipts"));
+    assert!(!format!("{view:?}").contains("invoice-2026-0001"));
+}
+
+#[test]
+fn test_decrypt_receipt_record_from_access_rejects_mismatch() {
+    let receipt_id = paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let key = ReceiptDecryptionKey::generate();
+    let recipient_public_key = public_key();
+    let expected_recipient = PubkyPublicKey::from_public_key(&recipient_public_key);
+    let receipt = receipt(
+        receipt_id.clone(),
+        "invoice-2026-0002",
+        recipient_public_key,
+    );
+    let encrypted = receipt.encrypt(&key).unwrap();
+    let access = receipt_access_record(&receipt_id, &key, "invoice-2026-0001");
+
+    let err =
+        decrypt_receipt_record_from_access(&access, &encrypted, timestamp(), &expected_recipient)
+            .unwrap_err();
+
+    assert!(
+        matches!(err, PaykitSdkError::Protocol(message) if message.contains("Payment Reference"))
+    );
+}
+
+#[test]
+fn test_decrypt_receipt_record_from_access_rejects_wrong_recipient() {
+    let receipt_id = paykit_lib::ReceiptId::new("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let key = ReceiptDecryptionKey::generate();
+    let receipt = receipt(receipt_id.clone(), "invoice-2026-0001", public_key());
+    let encrypted = receipt.encrypt(&key).unwrap();
+    let access = receipt_access_record(&receipt_id, &key, "invoice-2026-0001");
+    let expected_recipient = PubkyPublicKey::from_public_key(&public_key());
+
+    let err =
+        decrypt_receipt_record_from_access(&access, &encrypted, timestamp(), &expected_recipient)
+            .unwrap_err();
+
+    assert!(matches!(err, PaykitSdkError::Protocol(message) if message.contains("recipient")));
+}


### PR DESCRIPTION
## Summary

Replacement stack PR 3/5 for the Paykit SDK split.

Adds domain/helper/storage tests for the SDK modules:

- backup validation and restore reconciliation tests
- contact/profile parsing and validation tests
- endpoint reservation tests
- linked peer and lease tests
- outbound queue tests
- Payment Request derivation tests
- private stream persistence/dedupe tests
- receipt record and decryption tests
- storage transaction/queue tests

Runtime workflow tests are kept in the next PR so this one stays focused on module behavior.

## Stack

Base: `codex/sdk-review-02-runtime`

The final stack branch was verified to match draft reference PR #55 exactly.

## Verification

- `cargo fmt --check`
- `cargo test -p paykit-sdk --all-targets` passed with the tests present at this stack layer
