### PR TITLE
Add paykit-lib support hooks for SDK runtime

### DIFF
--- a/paykit-lib/src/encrypted_link/link.rs
+++ b/paykit-lib/src/encrypted_link/link.rs
@@ -106,7 +106,7 @@ impl EncryptedLink {
         &self.recipient
     }
 
-    async fn send_private_application_message(
+    async fn send_private_application_message_with_context(
         &mut self,
         plaintext: &[u8],
         context: &'static str,
@@ -124,17 +124,17 @@ impl EncryptedLink {
         &mut self,
         plaintext: &[u8],
     ) -> Result<()> {
-        self.send_private_application_message(plaintext, "Private Payment List")
+        self.send_private_application_message_with_context(plaintext, "Private Payment List")
             .await
     }
 
     pub(crate) async fn send_receipt_access_message(&mut self, plaintext: &[u8]) -> Result<()> {
-        self.send_private_application_message(plaintext, "Receipt Access")
+        self.send_private_application_message_with_context(plaintext, "Receipt Access")
             .await
     }
 
     pub(crate) async fn send_payment_request_message(&mut self, plaintext: &[u8]) -> Result<()> {
-        self.send_private_application_message(plaintext, "Payment Request")
+        self.send_private_application_message_with_context(plaintext, "Payment Request")
             .await
     }
 
@@ -142,7 +142,7 @@ impl EncryptedLink {
         &mut self,
         plaintext: &[u8],
     ) -> Result<()> {
-        self.send_private_application_message(plaintext, "Payment Request Acceptance")
+        self.send_private_application_message_with_context(plaintext, "Payment Request Acceptance")
             .await
     }
 
@@ -150,7 +150,7 @@ impl EncryptedLink {
         &mut self,
         plaintext: &[u8],
     ) -> Result<()> {
-        self.send_private_application_message(plaintext, "Payment Request Rejection")
+        self.send_private_application_message_with_context(plaintext, "Payment Request Rejection")
             .await
     }
 
@@ -158,13 +158,36 @@ impl EncryptedLink {
         &mut self,
         plaintext: &[u8],
     ) -> Result<()> {
-        self.send_private_application_message(plaintext, "Payment Request Cancellation")
-            .await
+        self.send_private_application_message_with_context(
+            plaintext,
+            "Payment Request Cancellation",
+        )
+        .await
     }
 
     pub(crate) async fn send_payment_proof_message(&mut self, plaintext: &[u8]) -> Result<()> {
-        self.send_private_application_message(plaintext, "Payment Proof")
+        self.send_private_application_message_with_context(plaintext, "Payment Proof")
             .await
+    }
+
+    /// Send one raw JSON Private Application Message.
+    ///
+    /// This is the low-level send counterpart to
+    /// [`receive_private_application_messages`](Self::receive_private_application_messages).
+    /// It validates only the generic `version` and `kind` envelope fields; it
+    /// does not require a known Paykit kind or validate known Paykit message
+    /// bodies. Use the typed serializers or SDK queue for protocol-managed
+    /// Paykit messages.
+    ///
+    /// Higher-level callers should persist the exact JSON before sending when
+    /// retrying the same message matters.
+    pub async fn send_private_application_message_json(&mut self, raw_json: &str) -> Result<()> {
+        validate_private_application_message_json(raw_json)?;
+        self.send_private_application_message_with_context(
+            raw_json.as_bytes(),
+            "Private Application Message",
+        )
+        .await
     }
 
     #[cfg(test)]
@@ -172,11 +195,14 @@ impl EncryptedLink {
         &mut self,
         plaintext: &[u8],
     ) -> Result<()> {
-        self.send_private_application_message(plaintext, "raw test Private Application Message")
-            .await
+        self.send_private_application_message_with_context(
+            plaintext,
+            "raw test Private Application Message",
+        )
+        .await
     }
 
-    /// Receive currently available Private Application Messages in stream order.
+    /// Receive available Private Application Messages in stream order.
     ///
     /// The Noise read checkpoint advances past the returned messages. Callers
     /// that need crash-safe Event Message handling should persist returned
@@ -187,6 +213,26 @@ impl EncryptedLink {
     ) -> Result<Vec<PrivateApplicationMessage>> {
         private_application_message::receive_private_application_messages(&mut self.encryptor).await
     }
+}
+
+fn validate_private_application_message_json(raw_json: &str) -> Result<()> {
+    let value: serde_json::Value =
+        serde_json::from_str(raw_json).map_err(|err| PaykitError::Validation(err.to_string()))?;
+    if value
+        .get("version")
+        .and_then(serde_json::Value::as_u64)
+        .is_none_or(|version| u8::try_from(version).is_err())
+    {
+        return Err(PaykitError::Validation(
+            "Private Application Message version must be a u8 integer".into(),
+        ));
+    }
+    if !value.get("kind").is_some_and(serde_json::Value::is_string) {
+        return Err(PaykitError::Validation(
+            "Private Application Message kind must be a string".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Default maximum number of automatic Private Application Message
@@ -300,4 +346,19 @@ async fn restore_encrypted_link_inner(
         remote_pubkey.clone(),
         config,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_private_application_message_json_requires_header() {
+        assert!(validate_private_application_message_json(
+            r#"{"version":1,"kind":"paykit.private_payment_list"}"#
+        )
+        .is_ok());
+        assert!(validate_private_application_message_json(r#"{"version":1}"#).is_err());
+        assert!(validate_private_application_message_json(r#"{"kind":"paykit.test"}"#).is_err());
+    }
 }

--- a/paykit-lib/src/encrypted_link/private_application_message.rs
+++ b/paykit-lib/src/encrypted_link/private_application_message.rs
@@ -6,6 +6,10 @@ use crate::{
     PaykitError, Result,
 };
 
+// Local marker used when decrypted private plaintext is not valid UTF-8.
+// This is not a protocol message. It lets receive callers persist the malformed
+// stream item, advance their local link checkpoint, and avoid wedging on the
+// same encrypted slot forever.
 const INVALID_UTF8_PRIVATE_MESSAGE_PREFIX: &str = "paykit.invalid_utf8_private_message:";
 
 /// Private Message Kind values understood by Paykit.
@@ -77,8 +81,9 @@ impl std::fmt::Display for PrivateMessageKind {
 ///
 /// This is the low-level receive item for the Private Application Message stream.
 /// It keeps the raw plaintext payload so callers can route and persist messages
-/// themselves. If decrypted bytes are not UTF-8, `raw_json` contains an
-/// invalid-JSON marker with the bytes encoded as base64url.
+/// themselves. If decrypted bytes are not UTF-8, `raw_json` contains a local
+/// invalid-JSON marker with the bytes encoded as base64url. Higher layers should
+/// treat that marker as malformed input, not as a Private Application Message.
 #[derive(Clone, PartialEq, Eq)]
 pub struct PrivateApplicationMessage {
     /// Private Application Message version from the JSON `version` field, when
@@ -137,7 +142,11 @@ impl PrivateApplicationMessage {
             })
     }
 
-    /// Return a parse error when this item represents non-UTF-8 plaintext bytes.
+    /// Return a parse error for the local invalid-UTF-8 receive marker.
+    ///
+    /// SDK/runtime callers use this to persist an audit/error record for a
+    /// malformed stream item while still advancing the local Encrypted Link
+    /// checkpoint. This is not expected on valid protocol messages.
     pub fn invalid_utf8_error(&self) -> Option<&'static str> {
         self.raw_json
             .starts_with(INVALID_UTF8_PRIVATE_MESSAGE_PREFIX)

--- a/paykit-lib/src/encrypted_link/private_application_message.rs
+++ b/paykit-lib/src/encrypted_link/private_application_message.rs
@@ -1,6 +1,12 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use tracing::{debug, warn};
 
-use crate::{PaykitError, Result};
+use crate::{
+    error::{NonRetryablePrivateReceiveError, NonRetryablePrivateSendError},
+    PaykitError, Result,
+};
+
+const INVALID_UTF8_PRIVATE_MESSAGE_PREFIX: &str = "paykit.invalid_utf8_private_message:";
 
 /// Private Message Kind values understood by Paykit.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -70,7 +76,9 @@ impl std::fmt::Display for PrivateMessageKind {
 /// One Private Application Message received from an Encrypted Link.
 ///
 /// This is the low-level receive item for the Private Application Message stream.
-/// It keeps the raw JSON so callers can route and persist messages themselves.
+/// It keeps the raw plaintext payload so callers can route and persist messages
+/// themselves. If decrypted bytes are not UTF-8, `raw_json` contains an
+/// invalid-JSON marker with the bytes encoded as base64url.
 #[derive(Clone, PartialEq, Eq)]
 pub struct PrivateApplicationMessage {
     /// Private Application Message version from the JSON `version` field, when
@@ -79,7 +87,7 @@ pub struct PrivateApplicationMessage {
     /// Message kind string from the JSON `kind` field, when the field is a
     /// string.
     pub kind: Option<String>,
-    /// Raw JSON plaintext received over the Encrypted Link.
+    /// Raw plaintext received over the Encrypted Link.
     pub raw_json: String,
 }
 
@@ -97,29 +105,27 @@ impl std::fmt::Debug for PrivateApplicationMessage {
 }
 
 impl PrivateApplicationMessage {
-    pub(super) fn from_plaintext(plaintext: String) -> Result<Self> {
-        let value: serde_json::Value =
-            serde_json::from_str(&plaintext).map_err(|err| PaykitError::InvalidData {
-                context: format!("failed to parse Private Application Message JSON: {err}"),
-                source: Some(err.into()),
-            })?;
+    pub(super) fn from_plaintext(plaintext: String) -> Self {
+        let value = serde_json::from_str::<serde_json::Value>(&plaintext).ok();
         let version = value
-            .get("version")
+            .as_ref()
+            .and_then(|value| value.get("version"))
             .and_then(serde_json::Value::as_u64)
             .and_then(|version| u8::try_from(version).ok());
         let kind = value
-            .get("kind")
+            .as_ref()
+            .and_then(|value| value.get("kind"))
             .and_then(serde_json::Value::as_str)
             .map(str::to_owned);
-        Ok(Self {
+        Self {
             version,
             kind,
             raw_json: plaintext,
-        })
+        }
     }
 
-    /// Return the known Paykit kind from the raw JSON payload, if this library
-    /// version recognizes it.
+    /// Return the known Paykit kind from the raw payload, if this library can
+    /// parse and recognize it.
     pub fn known_kind(&self) -> Option<PrivateMessageKind> {
         serde_json::from_str::<serde_json::Value>(&self.raw_json)
             .ok()
@@ -130,6 +136,13 @@ impl PrivateApplicationMessage {
                     .and_then(PrivateMessageKind::parse)
             })
     }
+
+    /// Return a parse error when this item represents non-UTF-8 plaintext bytes.
+    pub fn invalid_utf8_error(&self) -> Option<&'static str> {
+        self.raw_json
+            .starts_with(INVALID_UTF8_PRIVATE_MESSAGE_PREFIX)
+            .then_some("Private Application Message plaintext is not valid UTF-8")
+    }
 }
 
 fn decode_private_application_message(
@@ -139,56 +152,42 @@ fn decode_private_application_message(
     // Paykit application messages are JSON, so trailing NUL bytes are not valid
     // payload content.
     let end = raw.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
-    let plaintext = std::str::from_utf8(&raw[..end]).map_err(|err| PaykitError::InvalidData {
-        context: format!("Private Application Message plaintext is not valid UTF-8: {err}"),
-        source: Some(err.into()),
-    })?;
+    let plaintext = match std::str::from_utf8(&raw[..end]) {
+        Ok(plaintext) => plaintext.to_owned(),
+        Err(_) => format!(
+            "{INVALID_UTF8_PRIVATE_MESSAGE_PREFIX}{}",
+            URL_SAFE_NO_PAD.encode(&raw[..end])
+        ),
+    };
 
-    PrivateApplicationMessage::from_plaintext(plaintext.to_owned())
+    Ok(PrivateApplicationMessage::from_plaintext(plaintext))
 }
 
 pub(super) async fn receive_private_application_messages(
     encryptor: &mut pubky_noise::PubkyNoiseEncryptor,
 ) -> Result<Vec<PrivateApplicationMessage>> {
-    let mut received = 0usize;
-    let mut malformed = 0usize;
     let mut messages = Vec::new();
 
     loop {
-        let batch = encryptor
-            .receive_message()
-            .await
-            .map_err(|err| PaykitError::Transport {
-                context: format!("failed to receive Private Application Messages: {err:?}"),
-                source: anyhow::anyhow!("pubky-noise receive_message failed: {err:?}"),
-            })?;
+        let batch = encryptor.receive_message().await.map_err(|err| {
+            let context = format!("failed to receive Private Application Messages: {err:?}");
+            let source = if is_retryable_private_receive_error(&err) {
+                anyhow::anyhow!("pubky-noise receive_message failed: {err:?}")
+            } else {
+                anyhow::Error::new(NonRetryablePrivateReceiveError(err))
+            };
+            PaykitError::Transport { context, source }
+        })?;
 
         if batch.is_empty() {
             break;
         }
 
-        received += batch.len();
         for raw in batch {
-            match decode_private_application_message(&raw) {
-                Ok(message) => messages.push(message),
-                Err(err) => {
-                    malformed += 1;
-                    warn!(
-                        error = ?err,
-                        "dropping malformed Private Application Message"
-                    );
-                }
-            }
+            messages.push(decode_private_application_message(&raw)?);
         }
     }
 
-    if malformed > 0 {
-        warn!(
-            received,
-            malformed,
-            "ignored malformed Private Application Messages while preserving later messages"
-        );
-    }
     Ok(messages)
 }
 
@@ -198,6 +197,10 @@ fn send_attempts_from_retries(max_send_retries: u32) -> u32 {
 
 fn is_retryable_private_send_error(err: &pubky_noise::PubkyNoiseError) -> bool {
     matches!(err, pubky_noise::PubkyNoiseError::HomeserverWriteError)
+}
+
+fn is_retryable_private_receive_error(err: &pubky_noise::PubkyNoiseError) -> bool {
+    matches!(err, pubky_noise::PubkyNoiseError::HomeserverResponseError)
 }
 
 fn validate_private_application_message_size(
@@ -244,11 +247,10 @@ pub(super) async fn send_private_application_message(
                 }
             }
             Err(err) => {
+                let context = format!("failed to send {context}: {err:?}");
                 return Err(PaykitError::Transport {
-                    context: format!("failed to send {context}: {err:?}"),
-                    source: anyhow::anyhow!(
-                        "pubky-noise send_message failed with non-retryable error: {err:?}"
-                    ),
+                    context,
+                    source: anyhow::Error::new(NonRetryablePrivateSendError(err)),
                 });
             }
         }
@@ -295,6 +297,50 @@ mod tests {
     }
 
     #[test]
+    fn test_non_retryable_private_send_error_is_classified() {
+        let err = PaykitError::Transport {
+            context: "failed to send Private Application Message".into(),
+            source: anyhow::Error::new(NonRetryablePrivateSendError(
+                pubky_noise::PubkyNoiseError::EncryptionError,
+            )),
+        };
+
+        assert!(err.is_non_retryable_private_send_error());
+    }
+
+    #[test]
+    fn test_private_receive_retry_classification() {
+        assert!(is_retryable_private_receive_error(
+            &pubky_noise::PubkyNoiseError::HomeserverResponseError,
+        ));
+
+        for err in [
+            pubky_noise::PubkyNoiseError::BadLengthCiphertext,
+            pubky_noise::PubkyNoiseError::IsHandshake,
+            pubky_noise::PubkyNoiseError::DecryptionError,
+            pubky_noise::PubkyNoiseError::CounterOverflow,
+            pubky_noise::PubkyNoiseError::NonceOverflow,
+        ] {
+            assert!(
+                !is_retryable_private_receive_error(&err),
+                "{err:?} should not be retried"
+            );
+        }
+    }
+
+    #[test]
+    fn test_non_retryable_private_receive_error_is_classified() {
+        let err = PaykitError::Transport {
+            context: "failed to receive Private Application Messages".into(),
+            source: anyhow::Error::new(NonRetryablePrivateReceiveError(
+                pubky_noise::PubkyNoiseError::DecryptionError,
+            )),
+        };
+
+        assert!(err.is_non_retryable_private_receive_error());
+    }
+
+    #[test]
     fn test_private_application_message_size_validation_rejects_oversized_payload() {
         let payload = vec![b'x'; pubky_noise::snow_crypto::PUBKY_NOISE_MSG_LEN + 1];
         let err =
@@ -308,7 +354,7 @@ mod tests {
     #[test]
     fn test_private_application_message_keeps_malformed_header() {
         let raw = r#"{"version":"bad","kind":"paykit.payment_request","event_id":"not-a-uuid"}"#;
-        let message = PrivateApplicationMessage::from_plaintext(raw.to_string()).unwrap();
+        let message = PrivateApplicationMessage::from_plaintext(raw.to_string());
 
         assert_eq!(message.version, None);
         assert_eq!(
@@ -321,7 +367,7 @@ mod tests {
     #[test]
     fn test_private_application_message_keeps_json_without_kind() {
         let raw = r#"{"version":1,"payload":"unknown"}"#;
-        let message = PrivateApplicationMessage::from_plaintext(raw.to_string()).unwrap();
+        let message = PrivateApplicationMessage::from_plaintext(raw.to_string());
 
         assert_eq!(message.version, Some(1));
         assert_eq!(message.kind, None);
@@ -347,10 +393,40 @@ mod tests {
     #[test]
     fn test_private_application_message_debug_redacts_raw_json() {
         let raw = r#"{"version":1,"kind":"paykit.receipt_access","key":"secret"}"#;
-        let message = PrivateApplicationMessage::from_plaintext(raw.to_string()).unwrap();
+        let message = PrivateApplicationMessage::from_plaintext(raw.to_string());
         let debug = format!("{message:?}");
 
         assert!(!debug.contains("secret"));
         assert!(debug.contains("<redacted:"));
+    }
+
+    #[test]
+    fn test_private_application_message_keeps_invalid_json() {
+        let raw = "not json";
+        let message = PrivateApplicationMessage::from_plaintext(raw.to_string());
+
+        assert_eq!(message.version, None);
+        assert_eq!(message.kind, None);
+        assert_eq!(message.known_kind(), None);
+        assert_eq!(message.raw_json, raw);
+    }
+
+    #[test]
+    fn test_decode_private_application_message_retains_invalid_utf8_marker() {
+        let mut raw = [0u8; pubky_noise::snow_crypto::PUBKY_NOISE_MSG_LEN];
+        raw[0] = 0xff;
+
+        let message = decode_private_application_message(&raw).unwrap();
+
+        assert_eq!(message.version, None);
+        assert_eq!(message.kind, None);
+        assert_eq!(message.known_kind(), None);
+        assert_eq!(
+            message.invalid_utf8_error(),
+            Some("Private Application Message plaintext is not valid UTF-8")
+        );
+        assert!(message
+            .raw_json
+            .starts_with(INVALID_UTF8_PRIVATE_MESSAGE_PREFIX));
     }
 }

--- a/paykit-lib/src/encrypted_link_recovery.rs
+++ b/paykit-lib/src/encrypted_link_recovery.rs
@@ -1,4 +1,20 @@
-//! Stateless Encrypted Link recovery marker helpers.
+//! Stateless Encrypted Link Recovery Marker helpers.
+//!
+//! Recovery markers are public Pubky records used when a runtime decides an
+//! Encrypted Link with one counterparty can no longer be used safely. They are
+//! not sent over the broken link. Instead, each peer derives a pairwise marker
+//! path from its local secret key and the counterparty public key, writes a
+//! minimal marker to its own homeserver, and polls the counterparty's derived
+//! marker path.
+//!
+//! Marker payloads intentionally contain only `version`, `kind`, `attempt_id`,
+//! and `created_at`. They do not contain payment data, endpoint data, message
+//! counters, peer labels, or recovery transcripts.
+//!
+//! This module only provides the wire shape and Pubky publish/fetch/remove
+//! helpers. A higher-level runtime or SDK decides when a link is
+//! recovery-required, whether public markers are allowed by policy, and how to
+//! relink after observing a marker.
 
 use pubky::{
     errors::RequestError, Error as PubkyError, PubkySession, PublicKey, PublicStorage, StatusCode,

--- a/paykit-lib/src/encrypted_link_recovery.rs
+++ b/paykit-lib/src/encrypted_link_recovery.rs
@@ -1,0 +1,255 @@
+//! Stateless Encrypted Link recovery marker helpers.
+
+use pubky::{
+    errors::RequestError, Error as PubkyError, PubkySession, PublicKey, PublicStorage, StatusCode,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    validation::{invalid_data, invalid_wire, parse_utc_timestamp, validate_uuid_v4},
+    PaykitError, Result, PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX,
+};
+
+const RECOVERY_MARKER_KIND: &str = "paykit.encrypted_link_recovery";
+const RECOVERY_MARKER_PATH_DOMAIN: &[u8] = b"paykit-link-recovery-v0";
+
+/// Minimal public marker that asks a counterparty to relink an Encrypted Link.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EncryptedLinkRecoveryMarker {
+    attempt_id: String,
+    created_at: String,
+}
+
+impl EncryptedLinkRecoveryMarker {
+    /// Create a marker from a UUID-v4 attempt id and RFC3339 UTC timestamp.
+    pub fn new(attempt_id: impl Into<String>, created_at: impl Into<String>) -> Result<Self> {
+        let attempt_id = validate_uuid_v4(attempt_id.into(), "Encrypted Link recovery attempt ID")?;
+        let created_at = created_at.into();
+        parse_utc_timestamp(&created_at, "Encrypted Link recovery marker created_at")?;
+        Ok(Self {
+            attempt_id,
+            created_at,
+        })
+    }
+
+    /// Generate a marker with a fresh UUID-v4 attempt id.
+    pub fn new_v4(created_at: impl Into<String>) -> Result<Self> {
+        Self::new(uuid::Uuid::new_v4().to_string(), created_at)
+    }
+
+    /// Stable recovery attempt id.
+    pub fn attempt_id(&self) -> &str {
+        &self.attempt_id
+    }
+
+    /// Marker creation time as an RFC3339 UTC timestamp.
+    pub fn created_at(&self) -> &str {
+        &self.created_at
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RecoveryMarkerWire {
+    version: u8,
+    kind: String,
+    attempt_id: String,
+    created_at: String,
+}
+
+impl From<&EncryptedLinkRecoveryMarker> for RecoveryMarkerWire {
+    fn from(marker: &EncryptedLinkRecoveryMarker) -> Self {
+        Self {
+            version: 1,
+            kind: RECOVERY_MARKER_KIND.into(),
+            attempt_id: marker.attempt_id.clone(),
+            created_at: marker.created_at.clone(),
+        }
+    }
+}
+
+impl TryFrom<RecoveryMarkerWire> for EncryptedLinkRecoveryMarker {
+    type Error = PaykitError;
+
+    fn try_from(wire: RecoveryMarkerWire) -> Result<Self> {
+        if wire.version != 1 || wire.kind != RECOVERY_MARKER_KIND {
+            return Err(invalid_data(
+                format!(
+                    "unsupported Encrypted Link recovery marker version/kind: {}/{}",
+                    wire.version, wire.kind
+                ),
+                None,
+            ));
+        }
+        Self::new(wire.attempt_id, wire.created_at)
+            .map_err(|err| invalid_wire(err, "Encrypted Link recovery marker"))
+    }
+}
+
+/// Serialize an Encrypted Link Recovery Marker to canonical JSON.
+pub fn serialize_encrypted_link_recovery_marker(
+    marker: &EncryptedLinkRecoveryMarker,
+) -> Result<String> {
+    serde_json::to_string(&RecoveryMarkerWire::from(marker)).map_err(|err| {
+        PaykitError::Validation(format!(
+            "failed to serialize Encrypted Link recovery marker: {err}"
+        ))
+    })
+}
+
+/// Parse an Encrypted Link Recovery Marker JSON payload.
+pub fn parse_encrypted_link_recovery_marker_json(
+    raw_json: &str,
+) -> Result<EncryptedLinkRecoveryMarker> {
+    let wire = serde_json::from_str::<RecoveryMarkerWire>(raw_json).map_err(|err| {
+        invalid_data(
+            format!("Encrypted Link recovery marker JSON is invalid: {err}"),
+            Some(err.into()),
+        )
+    })?;
+    wire.try_into()
+}
+
+/// Compute local write and remote read paths for recovery markers.
+pub fn encrypted_link_recovery_marker_paths(
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+) -> (String, String) {
+    pubky_noise::path_derivation::derive_asymmetric_paths(
+        local_secret_key,
+        remote_pubkey,
+        RECOVERY_MARKER_PATH_DOMAIN,
+        PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX,
+    )
+}
+
+/// Publish a local recovery marker and return the path written.
+pub async fn publish_encrypted_link_recovery_marker(
+    session: &PubkySession,
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+    marker: &EncryptedLinkRecoveryMarker,
+) -> Result<String> {
+    let (write_path, _) = encrypted_link_recovery_marker_paths(local_secret_key, remote_pubkey);
+    let payload = serialize_encrypted_link_recovery_marker(marker)?;
+    session
+        .storage()
+        .put(write_path.clone(), payload)
+        .await
+        .map_err(|err| PaykitError::Transport {
+            context: "publish Encrypted Link recovery marker".into(),
+            source: err.into(),
+        })?;
+    Ok(write_path)
+}
+
+/// Remove the local recovery marker for a counterparty.
+pub async fn remove_encrypted_link_recovery_marker(
+    session: &PubkySession,
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+) -> Result<String> {
+    let (write_path, _) = encrypted_link_recovery_marker_paths(local_secret_key, remote_pubkey);
+    match session.storage().delete(write_path.clone()).await {
+        Ok(_) => Ok(write_path),
+        Err(err) if is_not_found(&err) => Ok(write_path),
+        Err(err) => Err(PaykitError::Transport {
+            context: "remove Encrypted Link recovery marker".into(),
+            source: err.into(),
+        }),
+    }
+}
+
+/// Fetch a counterparty's recovery marker, if one is present.
+pub async fn fetch_encrypted_link_recovery_marker(
+    storage: &PublicStorage,
+    local_secret_key: &[u8; 32],
+    remote_pubkey: &PublicKey,
+) -> Result<Option<EncryptedLinkRecoveryMarker>> {
+    let (_, read_path) = encrypted_link_recovery_marker_paths(local_secret_key, remote_pubkey);
+    let addr = format!("{remote_pubkey}{read_path}");
+    match storage.get(&addr).await {
+        Ok(resp) => {
+            let bytes = resp.bytes().await.map_err(|err| PaykitError::Transport {
+                context: "fetch Encrypted Link recovery marker".into(),
+                source: err.into(),
+            })?;
+            if bytes.is_empty() {
+                return Ok(None);
+            }
+            let raw_json = String::from_utf8(bytes.to_vec()).map_err(|err| {
+                let pos = err.utf8_error().valid_up_to();
+                invalid_data(
+                    format!("Encrypted Link recovery marker is invalid UTF-8 at byte {pos}"),
+                    Some(err.into()),
+                )
+            })?;
+            parse_encrypted_link_recovery_marker_json(&raw_json).map(Some)
+        }
+        Err(err) if is_not_found(&err) => Ok(None),
+        Err(err) => Err(PaykitError::Transport {
+            context: "fetch Encrypted Link recovery marker".into(),
+            source: err.into(),
+        }),
+    }
+}
+
+fn is_not_found(err: &PubkyError) -> bool {
+    matches!(
+        err,
+        PubkyError::Request(RequestError::Server { status, .. })
+            if *status == StatusCode::NOT_FOUND || *status == StatusCode::GONE
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use pubky::Keypair;
+
+    use super::*;
+
+    fn secret_pair() -> ([u8; 32], PublicKey) {
+        let keypair = Keypair::random();
+        (keypair.secret_key(), keypair.public_key())
+    }
+
+    #[test]
+    fn test_recovery_marker_json_round_trips() {
+        let marker = EncryptedLinkRecoveryMarker::new(
+            "650e8400-e29b-41d4-a716-446655440000",
+            "2026-06-03T12:00:00Z",
+        )
+        .unwrap();
+
+        let raw = serialize_encrypted_link_recovery_marker(&marker).unwrap();
+        let parsed = parse_encrypted_link_recovery_marker_json(&raw).unwrap();
+
+        assert_eq!(parsed, marker);
+        assert!(raw.contains("\"kind\":\"paykit.encrypted_link_recovery\""));
+    }
+
+    #[test]
+    fn test_recovery_marker_rejects_extra_fields() {
+        let raw = r#"{"version":1,"kind":"paykit.encrypted_link_recovery","attempt_id":"650e8400-e29b-41d4-a716-446655440000","created_at":"2026-06-03T12:00:00Z","peer":"extra"}"#;
+
+        let result = parse_encrypted_link_recovery_marker_json(raw);
+
+        assert!(matches!(result, Err(PaykitError::InvalidData { .. })));
+    }
+
+    #[test]
+    fn test_recovery_marker_paths_are_pairwise_symmetric() {
+        let (alice_secret, alice_public) = secret_pair();
+        let (bob_secret, bob_public) = secret_pair();
+
+        let (alice_write, alice_read) =
+            encrypted_link_recovery_marker_paths(&alice_secret, &bob_public);
+        let (bob_write, bob_read) =
+            encrypted_link_recovery_marker_paths(&bob_secret, &alice_public);
+
+        assert_eq!(alice_write, bob_read);
+        assert_eq!(alice_read, bob_write);
+        assert!(alice_write.starts_with(PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX));
+        assert_ne!(alice_write, alice_read);
+    }
+}

--- a/paykit-lib/src/error.rs
+++ b/paykit-lib/src/error.rs
@@ -53,6 +53,42 @@ pub enum PaykitError {
     Validation(String),
 }
 
+#[derive(Debug, Error)]
+#[error("pubky-noise send_message failed with non-retryable error: {0:?}")]
+pub(crate) struct NonRetryablePrivateSendError(pub(crate) pubky_noise::PubkyNoiseError);
+
+#[derive(Debug, Error)]
+#[error("pubky-noise receive_message failed with non-retryable error: {0:?}")]
+pub(crate) struct NonRetryablePrivateReceiveError(pub(crate) pubky_noise::PubkyNoiseError);
+
+impl PaykitError {
+    /// Returns true when this error came from a deterministic Encrypted Link
+    /// private-message send failure that should trigger link recovery instead
+    /// of ordinary transport retry.
+    pub fn is_non_retryable_private_send_error(&self) -> bool {
+        matches!(
+            self,
+            Self::Transport { source, .. }
+                if source
+                    .downcast_ref::<NonRetryablePrivateSendError>()
+                    .is_some()
+        )
+    }
+
+    /// Returns true when this error came from a deterministic Encrypted Link
+    /// private-message receive failure that should trigger link recovery
+    /// instead of ordinary transport retry.
+    pub fn is_non_retryable_private_receive_error(&self) -> bool {
+        matches!(
+            self,
+            Self::Transport { source, .. }
+                if source
+                    .downcast_ref::<NonRetryablePrivateReceiveError>()
+                    .is_some()
+        )
+    }
+}
+
 pub(crate) fn map_error(label: &'static str, err: PaykitError) -> PaykitError {
     match err {
         PaykitError::Transport { context, source } => PaykitError::Transport {

--- a/paykit-lib/src/lib.rs
+++ b/paykit-lib/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 mod encrypted_link;
+mod encrypted_link_recovery;
 mod error;
 mod event;
 mod payment_amount;
@@ -22,6 +23,13 @@ pub use encrypted_link::{
     EncryptedLinkHandshakeSnapshot, EncryptedLinkSnapshot, HandshakeProgress,
     PrivateApplicationMessage, PrivateMessageKind, DEFAULT_MAX_RECOVERY_ATTEMPTS,
     DEFAULT_MAX_SEND_RETRIES,
+};
+#[doc(inline)]
+pub use encrypted_link_recovery::{
+    encrypted_link_recovery_marker_paths, fetch_encrypted_link_recovery_marker,
+    parse_encrypted_link_recovery_marker_json, publish_encrypted_link_recovery_marker,
+    remove_encrypted_link_recovery_marker, serialize_encrypted_link_recovery_marker,
+    EncryptedLinkRecoveryMarker,
 };
 #[doc(inline)]
 pub use error::PaykitError;
@@ -47,18 +55,22 @@ pub use payment_request::{
 };
 #[doc(inline)]
 pub use private_payment_list::{
-    parse_private_payment_list_json, set_private_payment_list, PrivatePaymentList,
+    parse_private_payment_list_json, serialize_private_payment_list_json, set_private_payment_list,
+    PrivatePaymentList,
 };
 #[doc(inline)]
 pub use pubky::PublicKey;
 pub use pubky_noise;
 #[doc(inline)]
-pub use pubky_routing::{PAYKIT_PATH_PREFIX, PAYKIT_PRIVATE_PATH_PREFIX};
+pub use pubky_routing::{
+    PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX, PAYKIT_PATH_PREFIX, PAYKIT_PRIVATE_PATH_PREFIX,
+};
 #[doc(inline)]
 pub use receipt::{
     decrypt_receipt, parse_receipt_access_event_message, parse_receipt_access_json,
-    prepare_receipt, send_receipt_access, store_prepared_receipt, PreparedReceipt, Receipt,
-    ReceiptAccess, ReceiptAccessEventMessage, ReceiptDecryptionKey, ReceiptDraft, ReceiptId,
+    prepare_receipt, prepare_receipt_for_recipient, send_receipt_access,
+    serialize_receipt_access_json, store_prepared_receipt, PreparedReceipt, Receipt, ReceiptAccess,
+    ReceiptAccessEventMessage, ReceiptDecryptionKey, ReceiptDraft, ReceiptId,
 };
 
 /// Common result alias for Paykit operations.

--- a/paykit-lib/src/payment_endpoint.rs
+++ b/paykit-lib/src/payment_endpoint.rs
@@ -18,7 +18,7 @@ use crate::{error::map_error, pubky_routing, PaykitError, PublicKey, Result};
 /// # Limits
 /// - Must not be empty.
 /// - Must not exceed 64 characters.
-/// - Must not be the reserved value `"private"`.
+/// - Must not be a reserved Paykit storage value.
 ///
 /// # Examples
 /// ```
@@ -36,6 +36,8 @@ pub struct PaymentEndpointIdentifier(String);
 const PAYMENT_ENDPOINT_IDENTIFIER_MAX_LEN: usize = 64;
 /// Reserved [`PaymentEndpointIdentifier`] value used by private Paykit storage.
 const PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE: &str = "private";
+/// Reserved [`PaymentEndpointIdentifier`] value used by recovery marker storage.
+const PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_RECOVERY: &str = "encrypted-link-recovery";
 
 impl PaymentEndpointIdentifier {
     /// Create a new `PaymentEndpointIdentifier` after validating the identifier.
@@ -59,9 +61,11 @@ impl PaymentEndpointIdentifier {
             )));
         }
 
-        if id == PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE {
+        if id == PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE
+            || id == PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_RECOVERY
+        {
             return Err(PaykitError::Validation(format!(
-                "PaymentEndpointIdentifier '{PAYMENT_ENDPOINT_IDENTIFIER_RESERVED_PRIVATE}' is reserved for Private Payment Lists"
+                "PaymentEndpointIdentifier '{id}' is reserved for Paykit storage"
             )));
         }
 
@@ -398,9 +402,11 @@ mod validation_tests {
     }
 
     #[test]
-    fn test_payment_endpoint_identifier_reject_reserved_private() {
-        let err = PaymentEndpointIdentifier::new("private").unwrap_err();
-        assert!(matches!(err, PaykitError::Validation(msg) if msg.contains("reserved")));
+    fn test_payment_endpoint_identifier_reject_reserved_values() {
+        for reserved in ["private", "encrypted-link-recovery"] {
+            let err = PaymentEndpointIdentifier::new(reserved).unwrap_err();
+            assert!(matches!(err, PaykitError::Validation(msg) if msg.contains("reserved")));
+        }
     }
 
     // ── PaymentEndpointPayload: basic accessors ───────────────────────────────────

--- a/paykit-lib/src/payment_reference.rs
+++ b/paykit-lib/src/payment_reference.rs
@@ -1,7 +1,7 @@
 use crate::{PaykitError, Result};
 
 /// Payee-visible correlation reference used to connect payments with Paykit artifacts.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PaymentReference(String);
 
 /// Maximum Payment Reference length in Unicode scalar values.
@@ -44,6 +44,12 @@ impl std::fmt::Display for PaymentReference {
     }
 }
 
+impl std::fmt::Debug for PaymentReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("PaymentReference(<redacted>)")
+    }
+}
+
 impl AsRef<str> for PaymentReference {
     fn as_ref(&self) -> &str {
         &self.0
@@ -60,6 +66,7 @@ mod tests {
         let reference = PaymentReference::new("invoice 2026/0001").unwrap();
         assert_eq!(reference.as_str(), "invoice 2026/0001");
         assert_eq!(format!("{reference}"), "invoice 2026/0001");
+        assert_eq!(format!("{reference:?}"), "PaymentReference(<redacted>)");
     }
 
     #[test]

--- a/paykit-lib/src/payment_request/types.rs
+++ b/paykit-lib/src/payment_request/types.rs
@@ -122,7 +122,7 @@ impl fmt::Debug for PaymentRequestTerms {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PaymentRequestTerms")
             .field("amount", &"<redacted>")
-            .field("payment_reference", &self.payment_reference)
+            .field("payment_reference", &"<redacted>")
             .field("proposal_expires_at", &self.proposal_expires_at)
             .field("recurrence", &self.recurrence)
             .field(
@@ -307,7 +307,7 @@ impl fmt::Debug for PaymentProof {
             .field("kind", &self.kind)
             .field("event_id", &self.event_id)
             .field("payment_request_id", &self.payment_request_id)
-            .field("payment_reference", &self.payment_reference)
+            .field("payment_reference", &"<redacted>")
             .field("billing_period", &self.billing_period)
             .field(
                 "payment_endpoint_identifier",
@@ -659,6 +659,8 @@ mod tests {
             event: Ok(PaymentRequestEvent::Proof(proof.clone())),
         };
 
+        assert!(!format!("{request:?}").contains("invoice-2026-0001"));
+        assert!(!format!("{proof:?}").contains("invoice-2026-0001"));
         assert!(!format!("{request:?}").contains("private request note"));
         assert!(!format!("{proof:?}").contains("private proof secret"));
         let debug = format!("{message:?}");

--- a/paykit-lib/src/private_payment_list.rs
+++ b/paykit-lib/src/private_payment_list.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt};
 
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Serialize};
 use tracing::{debug, instrument};
 
 use crate::{
@@ -76,6 +76,7 @@ impl PrivatePaymentList {
 struct PrivatePaymentListWire {
     version: u8,
     kind: String,
+    #[serde(deserialize_with = "deserialize_payment_endpoints")]
     payment_endpoints: HashMap<String, String>,
 }
 
@@ -84,6 +85,42 @@ struct PrivatePaymentListWireRef<'a> {
     version: u8,
     kind: &'static str,
     payment_endpoints: HashMap<&'a str, &'a str>,
+}
+
+fn deserialize_payment_endpoints<'de, D>(
+    deserializer: D,
+) -> std::result::Result<HashMap<String, String>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    struct PaymentEndpointsVisitor;
+
+    impl<'de> de::Visitor<'de> for PaymentEndpointsVisitor {
+        type Value = HashMap<String, String>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a Payment Endpoint map without duplicate identifiers")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut payment_endpoints = HashMap::new();
+
+            while let Some((key, value)) = map.next_entry::<String, String>()? {
+                if payment_endpoints.insert(key.clone(), value).is_some() {
+                    return Err(de::Error::custom(format!(
+                        "duplicate Payment Endpoint identifier '{key}'"
+                    )));
+                }
+            }
+
+            Ok(payment_endpoints)
+        }
+    }
+
+    deserializer.deserialize_map(PaymentEndpointsVisitor)
 }
 
 /// Parse a versioned Private Payment List JSON message.
@@ -124,8 +161,8 @@ pub fn parse_private_payment_list_json(json: &str) -> Result<PrivatePaymentList>
     Ok(PrivatePaymentList::new(payment_endpoints))
 }
 
-/// Serializes a Private Payment List into its JSON wire representation.
-fn serialize_private_payment_list_json(list: &PrivatePaymentList) -> Result<String> {
+/// Serialize a Private Payment List into its JSON wire representation.
+pub fn serialize_private_payment_list_json(list: &PrivatePaymentList) -> Result<String> {
     let payment_endpoints = list
         .payment_endpoints
         .iter()
@@ -232,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_private_payment_list_json_rejects_removed_reference_field() {
+    fn test_parse_private_payment_list_json_rejects_reference_field() {
         let err = parse_private_payment_list_json(
             r#"{"version":1,"kind":"paykit.private_payment_list","reference":"invoice-2026-0001","payment_endpoints":{}}"#,
         )
@@ -301,6 +338,18 @@ mod tests {
         assert!(
             matches!(err, PaykitError::InvalidData { ref context, .. } if context.contains("failed to parse")),
             "expected InvalidData for non-string values, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_private_payment_list_json_rejects_duplicate_identifiers() {
+        let err = parse_private_payment_list_json(
+            r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{"lightning":"ln-one","lightning":"ln-two"}}"#,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, PaykitError::InvalidData { ref context, .. } if context.contains("duplicate Payment Endpoint identifier")),
+            "expected InvalidData for duplicate identifiers, got: {err}"
         );
     }
 

--- a/paykit-lib/src/pubky_routing.rs
+++ b/paykit-lib/src/pubky_routing.rs
@@ -29,6 +29,15 @@ pub const PAYKIT_PATH_PREFIX: &str = "/pub/paykit/v0/";
 /// individual file slots within the derived folders using a counter-based scheme.
 pub const PAYKIT_PRIVATE_PATH_PREFIX: &str = "/pub/paykit/v0/private";
 
+/// Conventional prefix for Encrypted Link recovery markers.
+///
+/// Marker paths are derived per-counterparty pair before being appended below
+/// this prefix, so the prefix itself does not identify the counterparty pair.
+pub const PAYKIT_ENCRYPTED_LINK_RECOVERY_PATH_PREFIX: &str =
+    "/pub/paykit/v0/encrypted-link-recovery";
+
+const LIST_PAGE_LIMIT: u16 = 100;
+
 /// Writes or updates a payment endpoint document in the authenticated Pubky session.
 #[instrument(skip(session, payload), fields(identifier = %identifier))]
 pub async fn upsert_payment_endpoint(
@@ -61,13 +70,19 @@ pub async fn delete_payment_endpoint(
 ) -> Result<()> {
     let path = payment_endpoint_path(identifier);
     debug!(path = %path, "deleting payment endpoint from Pubky storage");
-    session.storage().delete(path).await.map_err(|err| {
-        error!(error = %err, "failed to delete payment endpoint");
-        PaykitError::Transport {
-            context: "delete endpoint".into(),
-            source: err.into(),
+    match session.storage().delete(path).await {
+        Ok(_) => {}
+        Err(err) if is_not_found(&err) => {
+            debug!("payment endpoint already absent");
         }
-    })?;
+        Err(err) => {
+            error!(error = %err, "failed to delete payment endpoint");
+            return Err(PaykitError::Transport {
+                context: "delete endpoint".into(),
+                source: err.into(),
+            });
+        }
+    }
     debug!("payment endpoint removed successfully");
     Ok(())
 }
@@ -207,38 +222,61 @@ async fn list_resources(
     label: &str,
 ) -> Result<Vec<PubkyResource>> {
     trace!("listing directory resources");
-    let builder = match storage.list(&addr) {
-        Ok(builder) => builder,
-        Err(err) if is_not_found(&err) => {
-            debug!("directory not found, returning empty list");
-            return Ok(Vec::new());
-        }
-        Err(err) => {
-            error!(error = %err, "failed to create list builder");
-            return Err(PaykitError::Transport {
-                context: label.to_string(),
-                source: err.into(),
-            });
-        }
-    };
+    let mut resources = Vec::new();
+    let mut cursor = None::<String>;
 
-    match builder.shallow(true).send().await {
-        Ok(resources) => {
-            debug!(count = resources.len(), "directory resources listed");
-            Ok(resources)
+    loop {
+        let mut builder = match storage.list(&addr) {
+            Ok(builder) => builder.shallow(true).limit(LIST_PAGE_LIMIT),
+            Err(err) if is_not_found(&err) => {
+                debug!("directory not found, returning listed resources");
+                return Ok(resources);
+            }
+            Err(err) => {
+                error!(error = %err, "failed to create list builder");
+                return Err(PaykitError::Transport {
+                    context: label.to_string(),
+                    source: err.into(),
+                });
+            }
+        };
+
+        if let Some(cursor) = cursor.as_deref() {
+            builder = builder.cursor(cursor);
         }
-        Err(err) if is_not_found(&err) => {
-            debug!("directory not found during send, returning empty list");
-            Ok(Vec::new())
+
+        let page = match builder.send().await {
+            Ok(page) => page,
+            Err(err) if is_not_found(&err) => {
+                debug!("directory not found during send, returning listed resources");
+                return Ok(resources);
+            }
+            Err(err) => {
+                error!(error = %err, "list send failed");
+                return Err(PaykitError::Transport {
+                    context: format!("{label} send failed"),
+                    source: err.into(),
+                });
+            }
+        };
+
+        if page.is_empty() {
+            break;
         }
-        Err(err) => {
-            error!(error = %err, "list send failed");
-            Err(PaykitError::Transport {
-                context: format!("{label} send failed"),
-                source: err.into(),
-            })
+
+        let page_len = page.len();
+        cursor = page
+            .last()
+            .map(|resource| format!("{}{}", resource.owner.z32(), resource.path.as_str()));
+        resources.extend(page);
+
+        if page_len < LIST_PAGE_LIMIT as usize {
+            break;
         }
     }
+
+    debug!(count = resources.len(), "directory resources listed");
+    Ok(resources)
 }
 
 fn is_not_found(err: &PubkyError) -> bool {

--- a/paykit-lib/src/receipt.rs
+++ b/paykit-lib/src/receipt.rs
@@ -3,14 +3,18 @@ mod crypto;
 mod types;
 mod wire;
 
-pub use access::{prepare_receipt, send_receipt_access, store_prepared_receipt};
+pub use access::{
+    prepare_receipt, prepare_receipt_for_recipient, send_receipt_access, store_prepared_receipt,
+};
 pub use crypto::decrypt_receipt;
 pub(crate) use types::RECEIPT_ENCRYPTION_ALGORITHM;
 pub use types::{
     PreparedReceipt, Receipt, ReceiptAccess, ReceiptAccessEventMessage, ReceiptDecryptionKey,
     ReceiptDraft, ReceiptId,
 };
-pub use wire::{parse_receipt_access_event_message, parse_receipt_access_json};
+pub use wire::{
+    parse_receipt_access_event_message, parse_receipt_access_json, serialize_receipt_access_json,
+};
 
 #[cfg(test)]
 use wire::{EncryptedReceiptWire, ReceiptWire};

--- a/paykit-lib/src/receipt/access.rs
+++ b/paykit-lib/src/receipt/access.rs
@@ -1,7 +1,7 @@
 use tracing::{debug, instrument};
 
 use crate::{
-    error::map_error, EncryptedLink, PaykitError, PrivateMessageKind, Result,
+    error::map_error, EncryptedLink, PaykitError, PrivateMessageKind, PublicKey, Result,
     PAYKIT_PRIVATE_PATH_PREFIX,
 };
 
@@ -71,6 +71,19 @@ impl ReceiptAccess {
 /// must be handled as sensitive data.
 #[instrument(skip(link, draft))]
 pub fn prepare_receipt(link: &EncryptedLink, draft: ReceiptDraft) -> Result<PreparedReceipt> {
+    prepare_receipt_for_recipient(link.recipient().clone(), draft)
+}
+
+/// Prepare a plaintext Receipt, Encrypted Receipt, and Receipt Access
+/// descriptor for an explicit recipient public key.
+///
+/// This is useful for stateful runtimes that queue Receipt Access delivery
+/// separately from receipt preparation.
+#[instrument(skip(recipient_public_key, draft))]
+pub fn prepare_receipt_for_recipient(
+    recipient_public_key: PublicKey,
+    draft: ReceiptDraft,
+) -> Result<PreparedReceipt> {
     debug!("preparing encrypted receipt");
     draft.validate_request_context()?;
     let receipt_id = draft.receipt_id.unwrap_or_else(ReceiptId::new_v4);
@@ -87,7 +100,7 @@ pub fn prepare_receipt(link: &EncryptedLink, draft: ReceiptDraft) -> Result<Prep
         payment_reference: payment_reference.clone(),
         payment_request_id: payment_request_id.clone(),
         billing_period: billing_period.clone(),
-        recipient_public_key: link.recipient().clone(),
+        recipient_public_key,
         payment_endpoint_identifier: draft.payment_endpoint_identifier,
         amount: draft.amount,
         metadata: draft.metadata,

--- a/paykit-lib/src/receipt/types.rs
+++ b/paykit-lib/src/receipt/types.rs
@@ -71,7 +71,7 @@ impl fmt::Debug for ReceiptDraft {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ReceiptDraft")
             .field("receipt_id", &self.receipt_id)
-            .field("payment_reference", &self.payment_reference)
+            .field("payment_reference", &"<redacted>")
             .field("payment_request_id", &self.payment_request_id)
             .field("billing_period", &self.billing_period)
             .field(
@@ -112,7 +112,7 @@ impl fmt::Debug for Receipt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Receipt")
             .field("receipt_id", &self.receipt_id)
-            .field("payment_reference", &self.payment_reference)
+            .field("payment_reference", &"<redacted>")
             .field("payment_request_id", &self.payment_request_id)
             .field("billing_period", &self.billing_period)
             .field("recipient_public_key", &self.recipient_public_key)
@@ -231,7 +231,7 @@ impl fmt::Debug for PreparedReceipt {
 }
 
 /// Receipt Access descriptor sent over the existing Noise channel.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ReceiptAccess {
     /// Receipt Access message version. Currently always `1`.
     pub version: u8,
@@ -251,6 +251,22 @@ pub struct ReceiptAccess {
     pub location: String,
     /// Symmetric key needed to decrypt the Receipt.
     pub key: ReceiptDecryptionKey,
+}
+
+impl fmt::Debug for ReceiptAccess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiptAccess")
+            .field("version", &self.version)
+            .field("kind", &self.kind)
+            .field("event_id", &self.event_id)
+            .field("receipt_id", &self.receipt_id)
+            .field("payment_reference", &"<redacted>")
+            .field("payment_request_id", &self.payment_request_id)
+            .field("billing_period", &self.billing_period)
+            .field("location", &"<redacted>")
+            .field("key", &"<redacted>")
+            .finish()
+    }
 }
 
 /// A recognized Receipt Access Event Message plus the raw JSON payload received
@@ -367,5 +383,72 @@ impl ReceiptAccess {
             self.billing_period.as_ref(),
             "Receipt Access",
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receipt_debug_redacts_payment_reference() {
+        let payment_reference = PaymentReference::new("invoice-secret-123").unwrap();
+        let draft = ReceiptDraft {
+            receipt_id: Some(ReceiptId::new_v4()),
+            payment_reference: payment_reference.clone(),
+            payment_request_id: Some(PaymentRequestId::new_v4()),
+            billing_period: None,
+            payment_endpoint_identifier: Some(
+                PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap(),
+            ),
+            amount: Some(PaymentAmount {
+                value: "0.001".to_string(),
+                asset: "btc".to_string(),
+            }),
+            metadata: JsonMap::from_iter([(
+                "note".to_string(),
+                JsonValue::String("private receipt note".to_string()),
+            )]),
+        };
+        let receipt = Receipt {
+            receipt_id: draft.receipt_id.clone().unwrap(),
+            payment_reference,
+            payment_request_id: draft.payment_request_id.clone(),
+            billing_period: None,
+            recipient_public_key: pubky::Keypair::random().public_key().clone(),
+            payment_endpoint_identifier: draft.payment_endpoint_identifier.clone(),
+            amount: draft.amount.clone(),
+            metadata: draft.metadata.clone(),
+        };
+
+        let access = ReceiptAccess {
+            version: 1,
+            kind: PrivateMessageKind::ReceiptAccess,
+            event_id: EventId::new_v4(),
+            receipt_id: receipt.receipt_id.clone(),
+            payment_reference: receipt.payment_reference.clone(),
+            payment_request_id: receipt.payment_request_id.clone(),
+            billing_period: None,
+            location: ReceiptAccess::location_for(&receipt.receipt_id),
+            key: ReceiptDecryptionKey::generate(),
+        };
+        let prepared = PreparedReceipt {
+            receipt: receipt.clone(),
+            encrypted_receipt: "encrypted-secret".into(),
+            access: access.clone(),
+        };
+
+        for debug in [
+            format!("{draft:?}"),
+            format!("{receipt:?}"),
+            format!("{access:?}"),
+            format!("{prepared:?}"),
+        ] {
+            assert!(!debug.contains("invoice-secret-123"));
+            assert!(!debug.contains("private receipt note"));
+            assert!(!debug.contains("encrypted-secret"));
+            assert!(!debug.contains(access.key.as_str()));
+            assert!(!debug.contains(&access.location));
+        }
     }
 }

--- a/paykit-lib/src/receipt/wire.rs
+++ b/paykit-lib/src/receipt/wire.rs
@@ -246,7 +246,7 @@ impl TryFrom<ReceiptAccessWire> for ReceiptAccess {
     }
 }
 
-pub(super) fn serialize_receipt_access_json(access: &ReceiptAccess) -> Result<String> {
+pub fn serialize_receipt_access_json(access: &ReceiptAccess) -> Result<String> {
     serde_json::to_string(&ReceiptAccessWire::from(access)).map_err(|err| {
         invalid_data(
             format!("failed to serialize Receipt Access JSON: {err}"),

--- a/paykit-lib/src/tests/payment_endpoint.rs
+++ b/paykit-lib/src/tests/payment_endpoint.rs
@@ -104,13 +104,35 @@ async fn list_reflects_additions_and_removals() {
 }
 
 #[tokio::test]
-async fn removing_missing_endpoint_is_error() {
+async fn list_fetches_multiple_pages() {
+    let setup = TestSetup::new().await;
+    let mut expected = HashMap::new();
+
+    for index in 0..105 {
+        let identifier = PaymentEndpointIdentifier::new(format!("endpoint-{index:03}")).unwrap();
+        let payload = PaymentEndpointPayload::new(format!("payload-{index:03}"));
+        set_payment_endpoint(&setup.session, identifier.clone(), payload.clone())
+            .await
+            .unwrap();
+        expected.insert(identifier, payload);
+    }
+
+    let list = get_payment_list(&setup.public_storage, &setup.public_key)
+        .await
+        .unwrap();
+    assert_eq!(list.payment_endpoints, expected);
+
+    setup.raw_session.signout().await.unwrap();
+}
+
+#[tokio::test]
+async fn removing_missing_endpoint_is_idempotent() {
     let setup = TestSetup::new().await;
     let method = PaymentEndpointIdentifier::new("unused").unwrap();
 
     remove_payment_endpoint(&setup.session, method)
         .await
-        .expect_err("removing non-existent endpoint should fail");
+        .expect("removing non-existent endpoint should be idempotent");
 
     setup.raw_session.signout().await.unwrap();
 }


### PR DESCRIPTION
Stack PR 1/6 replacing the earlier SDK review stack. This isolates the low-level paykit-lib support needed by the SDK: Encrypted Link Recovery Marker helpers, private receive retry classification, paginated Payment Endpoint reads, and small protocol/doc refinements. Final stack remains byte-for-byte equivalent to draft PR #55.