### PR TITLE
Add Paykit SDK runtime workflow tests

### DIFF
--- a/paykit-sdk/src/runtime.rs
+++ b/paykit-sdk/src/runtime.rs
@@ -554,3 +554,6 @@ fn is_pubky_not_found(err: &PubkyError) -> bool {
             if *status == StatusCode::NOT_FOUND || *status == StatusCode::GONE
     )
 }
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/runtime/tests.rs
+++ b/paykit-sdk/src/runtime/tests.rs
@@ -1,0 +1,668 @@
+use async_trait::async_trait;
+use chrono::{TimeZone, Utc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use super::*;
+use super::{
+    payment_resolution::{payable_from_batch, PrivateRecoveryOutcome},
+    recovery::{local_recovery_marker_belongs_to_current_episode, RecoveryRequiredUpdate},
+};
+use crate::{
+    adapters::{
+        PaymentEndpointCandidate, PaymentEndpointReservation,
+        PaymentEndpointReservationCancellation, PaymentEndpointSelectionRequest, PaymentTarget,
+        ReceivingDetail, ReceivingDetailScope,
+    },
+    endpoint_reservations::queue_private_payment_list_with_reservations,
+    private_stream::persist_private_stream_batch,
+    storage::{
+        EncryptedLinkStateRecord, EventDedupRecord, InMemoryStorage, LinkedPeerRecord,
+        NewOutboundPrivateMessage, PublicEndpointRecord,
+    },
+    OutboundPrivateMessageStatus, PubkySessionAccess,
+};
+use paykit_lib::PrivateApplicationMessage;
+
+#[derive(Clone)]
+struct FixedClock;
+
+impl Clock for FixedClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap()
+    }
+}
+
+struct TestPubkySessionProvider {
+    session: Option<PubkySessionAccess>,
+}
+
+#[async_trait]
+impl PubkySessionProvider for TestPubkySessionProvider {
+    async fn load_session_access(&self) -> Result<Option<PubkySessionAccess>> {
+        Ok(self.session.clone())
+    }
+
+    async fn load_public_storage(&self) -> Result<Option<pubky::PublicStorage>> {
+        Ok(self
+            .session
+            .as_ref()
+            .map(|session_access| session_access.outbox_client.public_storage()))
+    }
+
+    async fn clear_session_access(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+struct FailingClearSessionProvider;
+
+#[async_trait]
+impl PubkySessionProvider for FailingClearSessionProvider {
+    async fn load_session_access(&self) -> Result<Option<PubkySessionAccess>> {
+        Ok(None)
+    }
+
+    async fn load_public_storage(&self) -> Result<Option<pubky::PublicStorage>> {
+        Ok(None)
+    }
+
+    async fn clear_session_access(&self) -> Result<()> {
+        Err(PaykitSdkError::Identity {
+            context: "failed to clear Pubky session access".into(),
+            source: None,
+        })
+    }
+}
+
+struct TestPaymentAdapter;
+
+#[async_trait]
+impl PaymentAdapter for TestPaymentAdapter {
+    async fn current_receiving_details(
+        &self,
+        _scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>> {
+        Ok(Vec::new())
+    }
+
+    async fn cancel_receiving_detail_reservation(
+        &self,
+        _release: &PaymentEndpointReservationCancellation,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn select_payment_endpoints(
+        &self,
+        request: &PaymentEndpointSelectionRequest,
+    ) -> Result<Vec<PaymentEndpointCandidate>> {
+        Ok(request.candidates.clone())
+    }
+
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget> {
+        Ok(PaymentTarget {
+            payload: endpoint.payload.clone(),
+        })
+    }
+}
+
+struct PrivateListPaymentAdapter;
+
+#[async_trait]
+impl PaymentAdapter for PrivateListPaymentAdapter {
+    async fn current_receiving_details(
+        &self,
+        scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>> {
+        assert!(matches!(scope, ReceivingDetailScope::Private { .. }));
+        Ok(vec![ReceivingDetail {
+            identifier: "btc-lightning-bolt11".into(),
+            payload: "ln-private".into(),
+        }])
+    }
+
+    async fn cancel_receiving_detail_reservation(
+        &self,
+        _release: &PaymentEndpointReservationCancellation,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn select_payment_endpoints(
+        &self,
+        _request: &PaymentEndpointSelectionRequest,
+    ) -> Result<Vec<PaymentEndpointCandidate>> {
+        Ok(Vec::new())
+    }
+
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget> {
+        Ok(PaymentTarget {
+            payload: endpoint.payload.clone(),
+        })
+    }
+}
+
+struct ReservedPrivateListPaymentAdapter;
+
+#[async_trait]
+impl PaymentAdapter for ReservedPrivateListPaymentAdapter {
+    async fn current_receiving_details(
+        &self,
+        _scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>> {
+        panic!("reservation-capable adapter should not use fallback details");
+    }
+
+    async fn reserve_receiving_details(
+        &self,
+        counterparty: &PubkyPublicKey,
+    ) -> Result<Option<Vec<PaymentEndpointReservation>>> {
+        assert!(!counterparty.as_str().is_empty());
+        Ok(Some(vec![PaymentEndpointReservation {
+            reservation_id: "reservation-1".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "ln-reserved".into(),
+            },
+            expires_at: None,
+            attribution: HashMap::from([("contact".into(), "alice".into())]),
+        }]))
+    }
+
+    async fn cancel_receiving_detail_reservation(
+        &self,
+        _release: &PaymentEndpointReservationCancellation,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn select_payment_endpoints(
+        &self,
+        request: &PaymentEndpointSelectionRequest,
+    ) -> Result<Vec<PaymentEndpointCandidate>> {
+        Ok(request.candidates.clone())
+    }
+
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget> {
+        Ok(PaymentTarget {
+            payload: endpoint.payload.clone(),
+        })
+    }
+}
+
+struct InvalidReservedPrivateListPaymentAdapter {
+    canceled: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl PaymentAdapter for InvalidReservedPrivateListPaymentAdapter {
+    async fn current_receiving_details(
+        &self,
+        _scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>> {
+        panic!("reservation-capable adapter should not use fallback details");
+    }
+
+    async fn reserve_receiving_details(
+        &self,
+        _counterparty: &PubkyPublicKey,
+    ) -> Result<Option<Vec<PaymentEndpointReservation>>> {
+        Ok(Some(vec![
+            PaymentEndpointReservation {
+                reservation_id: "reservation-1".into(),
+                receiving_detail: ReceivingDetail {
+                    identifier: "btc-lightning-bolt11".into(),
+                    payload: "one".into(),
+                },
+                expires_at: None,
+                attribution: HashMap::new(),
+            },
+            PaymentEndpointReservation {
+                reservation_id: "reservation-2".into(),
+                receiving_detail: ReceivingDetail {
+                    identifier: "btc-lightning-bolt11".into(),
+                    payload: "two".into(),
+                },
+                expires_at: None,
+                attribution: HashMap::new(),
+            },
+        ]))
+    }
+
+    async fn cancel_receiving_detail_reservation(
+        &self,
+        cancellation: &PaymentEndpointReservationCancellation,
+    ) -> Result<()> {
+        self.canceled
+            .lock()
+            .unwrap()
+            .push(cancellation.reservation_id.clone());
+        Ok(())
+    }
+
+    async fn select_payment_endpoints(
+        &self,
+        _request: &PaymentEndpointSelectionRequest,
+    ) -> Result<Vec<PaymentEndpointCandidate>> {
+        Ok(Vec::new())
+    }
+
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget> {
+        Ok(PaymentTarget {
+            payload: endpoint.payload.clone(),
+        })
+    }
+}
+
+struct FailingCancellationPaymentAdapter;
+
+#[async_trait]
+impl PaymentAdapter for FailingCancellationPaymentAdapter {
+    async fn current_receiving_details(
+        &self,
+        _scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>> {
+        Ok(Vec::new())
+    }
+
+    async fn reserve_receiving_details(
+        &self,
+        _counterparty: &PubkyPublicKey,
+    ) -> Result<Option<Vec<PaymentEndpointReservation>>> {
+        Ok(None)
+    }
+
+    async fn cancel_receiving_detail_reservation(
+        &self,
+        _release: &PaymentEndpointReservationCancellation,
+    ) -> Result<()> {
+        Err(PaykitSdkError::PaymentAdapter {
+            context: "cancellation failed".into(),
+            source: None,
+        })
+    }
+
+    async fn select_payment_endpoints(
+        &self,
+        _request: &PaymentEndpointSelectionRequest,
+    ) -> Result<Vec<PaymentEndpointCandidate>> {
+        Ok(Vec::new())
+    }
+
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget> {
+        Ok(PaymentTarget {
+            payload: endpoint.payload.clone(),
+        })
+    }
+}
+
+struct LeaseChangingCancellationPaymentAdapter {
+    storage: InMemoryStorage,
+    counterparty: PubkyPublicKey,
+    canceled: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl PaymentAdapter for LeaseChangingCancellationPaymentAdapter {
+    async fn current_receiving_details(
+        &self,
+        _scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>> {
+        Ok(Vec::new())
+    }
+
+    async fn reserve_receiving_details(
+        &self,
+        _counterparty: &PubkyPublicKey,
+    ) -> Result<Option<Vec<PaymentEndpointReservation>>> {
+        Ok(None)
+    }
+
+    async fn cancel_receiving_detail_reservation(
+        &self,
+        cancellation: &PaymentEndpointReservationCancellation,
+    ) -> Result<()> {
+        self.storage
+            .transaction({
+                let counterparty = self.counterparty.clone();
+                move |tx| {
+                    let _ = tx.claim_peer_link_operation(
+                        &counterparty,
+                        FixedClock.now() + ChronoDuration::seconds(11),
+                        FixedClock.now() + ChronoDuration::seconds(71),
+                    );
+                    Ok(())
+                }
+            })
+            .await?;
+        self.canceled
+            .lock()
+            .unwrap()
+            .push(cancellation.reservation_id.clone());
+        Ok(())
+    }
+
+    async fn select_payment_endpoints(
+        &self,
+        _request: &PaymentEndpointSelectionRequest,
+    ) -> Result<Vec<PaymentEndpointCandidate>> {
+        Ok(Vec::new())
+    }
+
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget> {
+        Ok(PaymentTarget {
+            payload: endpoint.payload.clone(),
+        })
+    }
+}
+
+struct LeaseChangingInvalidReservedPrivateListPaymentAdapter {
+    storage: InMemoryStorage,
+    counterparty: PubkyPublicKey,
+    canceled: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl PaymentAdapter for LeaseChangingInvalidReservedPrivateListPaymentAdapter {
+    async fn current_receiving_details(
+        &self,
+        _scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>> {
+        panic!("reservation-capable adapter should not use fallback details");
+    }
+
+    async fn reserve_receiving_details(
+        &self,
+        _counterparty: &PubkyPublicKey,
+    ) -> Result<Option<Vec<PaymentEndpointReservation>>> {
+        self.storage
+            .transaction({
+                let counterparty = self.counterparty.clone();
+                move |tx| {
+                    let _ = tx.claim_peer_link_operation(
+                        &counterparty,
+                        FixedClock.now() + ChronoDuration::seconds(61),
+                        FixedClock.now() + ChronoDuration::seconds(121),
+                    );
+                    Ok(())
+                }
+            })
+            .await?;
+        Ok(Some(vec![
+            PaymentEndpointReservation {
+                reservation_id: "reservation-1".into(),
+                receiving_detail: ReceivingDetail {
+                    identifier: "btc-lightning-bolt11".into(),
+                    payload: "one".into(),
+                },
+                expires_at: None,
+                attribution: HashMap::new(),
+            },
+            PaymentEndpointReservation {
+                reservation_id: "reservation-2".into(),
+                receiving_detail: ReceivingDetail {
+                    identifier: "btc-onchain-address".into(),
+                    payload: "two".into(),
+                },
+                expires_at: None,
+                attribution: HashMap::new(),
+            },
+        ]))
+    }
+
+    async fn cancel_receiving_detail_reservation(
+        &self,
+        cancellation: &PaymentEndpointReservationCancellation,
+    ) -> Result<()> {
+        self.canceled
+            .lock()
+            .unwrap()
+            .push(cancellation.reservation_id.clone());
+        Ok(())
+    }
+
+    async fn select_payment_endpoints(
+        &self,
+        _request: &PaymentEndpointSelectionRequest,
+    ) -> Result<Vec<PaymentEndpointCandidate>> {
+        Ok(Vec::new())
+    }
+
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget> {
+        Ok(PaymentTarget {
+            payload: endpoint.payload.clone(),
+        })
+    }
+}
+
+struct MixedExistingReservedPrivateListPaymentAdapter {
+    canceled: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl PaymentAdapter for MixedExistingReservedPrivateListPaymentAdapter {
+    async fn current_receiving_details(
+        &self,
+        _scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>> {
+        panic!("reservation-capable adapter should not use fallback details");
+    }
+
+    async fn reserve_receiving_details(
+        &self,
+        _counterparty: &PubkyPublicKey,
+    ) -> Result<Option<Vec<PaymentEndpointReservation>>> {
+        Ok(Some(vec![
+            PaymentEndpointReservation {
+                reservation_id: "existing-reservation".into(),
+                receiving_detail: ReceivingDetail {
+                    identifier: "btc-lightning-bolt11".into(),
+                    payload: "existing".into(),
+                },
+                expires_at: None,
+                attribution: HashMap::new(),
+            },
+            PaymentEndpointReservation {
+                reservation_id: "conflicting-reservation".into(),
+                receiving_detail: ReceivingDetail {
+                    identifier: "btc-lightning-bolt11".into(),
+                    payload: "conflict".into(),
+                },
+                expires_at: None,
+                attribution: HashMap::new(),
+            },
+        ]))
+    }
+
+    async fn cancel_receiving_detail_reservation(
+        &self,
+        cancellation: &PaymentEndpointReservationCancellation,
+    ) -> Result<()> {
+        self.canceled
+            .lock()
+            .unwrap()
+            .push(cancellation.reservation_id.clone());
+        Ok(())
+    }
+
+    async fn select_payment_endpoints(
+        &self,
+        _request: &PaymentEndpointSelectionRequest,
+    ) -> Result<Vec<PaymentEndpointCandidate>> {
+        Ok(Vec::new())
+    }
+
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget> {
+        Ok(PaymentTarget {
+            payload: endpoint.payload.clone(),
+        })
+    }
+}
+
+fn private_list_message(payload: &str) -> PrivateApplicationMessage {
+    PrivateApplicationMessage {
+        version: Some(1),
+        kind: Some("paykit.private_payment_list".into()),
+        raw_json: format!(
+            r#"{{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{{"btc-lightning-bolt11":"{payload}"}}}}"#
+        ),
+    }
+}
+
+fn private_list_json() -> String {
+    r#"{"version":1,"kind":"paykit.private_payment_list","payment_endpoints":{}}"#.into()
+}
+
+fn receipt_access_record(counterparty: PubkyPublicKey, receipt_id: &str) -> ReceiptAccessRecord {
+    ReceiptAccessRecord {
+        counterparty,
+        stream_item_id: 1,
+        receive_batch_id: 1,
+        event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+        receipt_id: receipt_id.into(),
+        payment_reference: "invoice-2026-0001".into(),
+        payment_request_id: None,
+        billing_period: None,
+        location: format!("/pub/paykit/v0/private/receipts/{receipt_id}"),
+        key: "receipt-secret-key".into(),
+        retrieval_status: ReceiptRetrievalStatus::Pending,
+        retrieval_attempted_at: None,
+        retrieved_at: None,
+        last_retrieval_error: None,
+        received_at: FixedClock.now(),
+    }
+}
+
+fn receipt_record(
+    issuer: PubkyPublicKey,
+    receipt_id: &str,
+    recipient_public_key: PubkyPublicKey,
+) -> ReceiptRecord {
+    ReceiptRecord {
+        issuer,
+        receipt_access_event_id: "650e8400-e29b-41d4-a716-446655440000".into(),
+        receipt_access_key_hash: "receipt-access-key-hash".into(),
+        receipt_id: receipt_id.into(),
+        payment_reference: "invoice-2026-0001".into(),
+        payment_request_id: None,
+        billing_period: None,
+        recipient_public_key,
+        payment_endpoint_identifier: None,
+        amount: None,
+        metadata: JsonMap::new(),
+        location: format!("/pub/paykit/v0/private/receipts/{receipt_id}"),
+        retrieved_at: FixedClock.now(),
+    }
+}
+
+fn conflicted_event_dedup_record(access: &ReceiptAccessRecord) -> EventDedupRecord {
+    EventDedupRecord {
+        counterparty: access.counterparty.clone(),
+        event_id: access.event_id.clone(),
+        event_kind: "paykit.receipt_access".into(),
+        payload_hash: "sha256:first".into(),
+        first_stream_item_id: access.stream_item_id,
+        duplicate_stream_item_ids: Vec::new(),
+        conflicting_stream_item_ids: vec![access.stream_item_id + 1],
+    }
+}
+
+fn endpoint_candidate(payload: &str) -> PaymentEndpointCandidate {
+    PaymentEndpointCandidate {
+        counterparty: PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key()),
+        source: PaymentEndpointSource::PrivatePaymentList,
+        identifier: "btc-lightning-bolt11".into(),
+        payload: payload.into(),
+    }
+}
+
+fn payment_request_message(
+    event_id: &str,
+    request_id: &str,
+    expires_at: Option<&str>,
+) -> PrivateApplicationMessage {
+    let expiry = expires_at
+        .map(|value| format!(r#""{value}""#))
+        .unwrap_or_else(|| "null".into());
+    PrivateApplicationMessage {
+        version: Some(1),
+        kind: Some("paykit.payment_request".into()),
+        raw_json: format!(
+            r#"{{"version":1,"kind":"paykit.payment_request","event_id":"{event_id}","payment_request_id":"{request_id}","request":{{"amount":{{"value":"0.001","asset":"btc"}},"payment_reference":"invoice-2026-0001","proposal_expires_at":{expiry},"recurrence":null,"accepted_payment_endpoint_identifiers":["btc-lightning-bolt11"],"metadata":{{}}}}}}"#
+        ),
+    }
+}
+
+async fn seed_private_capable_identity_and_link(
+    storage: &InMemoryStorage,
+    counterparty: PubkyPublicKey,
+) {
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(PubkyPublicKey::from_public_key(
+                &pubky::Keypair::random().public_key(),
+            )),
+            capability: PubkyIdentityCapability::PrivateLinkCapable,
+            local_secret_available: true,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    storage
+        .transaction(move |tx| {
+            tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                counterparty,
+                link_snapshot: Some(vec![1, 2, 3]),
+                handshake_snapshot: None,
+                handshake_role: None,
+                generation: 0,
+                checkpointed_at: FixedClock.now(),
+            });
+            Ok(())
+        })
+        .await
+        .unwrap();
+}
+
+mod backup;
+mod contacts;
+mod encrypted_links;
+mod identity;
+mod linked_peers;
+mod outbound_private;
+mod payment_requests;
+mod payment_resolution;
+mod private_lists;
+mod private_stream;
+mod public_endpoints;
+mod receipts;
+mod recovery;

--- a/paykit-sdk/src/runtime/tests/backup.rs
+++ b/paykit-sdk/src/runtime/tests/backup.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+fn empty_backup_state() -> SdkBackupState {
+    SdkBackupState {
+        version: crate::SDK_BACKUP_VERSION,
+        identity_state: None,
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    }
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_requires_active_identity() {
+    let storage = InMemoryStorage::new();
+    let existing_public_key =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(existing_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 7,
+        })
+        .await
+        .unwrap();
+    let backup_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let backup = SdkBackupState {
+        version: crate::SDK_BACKUP_VERSION,
+        identity_state: Some(IdentityState {
+            public_key: Some(backup_public_key),
+            capability: PubkyIdentityCapability::PrivateLinkCapable,
+            local_secret_available: true,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        }),
+        linked_peers: Vec::new(),
+        contact_records: Vec::new(),
+        public_endpoint_records: Vec::new(),
+        payment_endpoint_reservations: Vec::new(),
+        encrypted_link_states: Vec::new(),
+        outbound_private_messages: Vec::new(),
+        private_stream_items: Vec::new(),
+        event_dedup_records: Vec::new(),
+        receipt_access_records: Vec::new(),
+        receipt_records: Vec::new(),
+        receipt_issuance_records: Vec::new(),
+        next_outbound_private_message_id: 0,
+        next_receive_batch_id: 0,
+        next_private_stream_item_id: 0,
+    };
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.restore_backup_state(backup).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    let identity = storage.snapshot().unwrap().identity_state.unwrap();
+    assert_eq!(identity.sign_out_generation, 7);
+    assert_eq!(identity.capability, PubkyIdentityCapability::PublicOnly);
+}
+
+#[tokio::test]
+async fn test_restore_backup_state_rejects_concurrent_identity_operation() {
+    let storage = InMemoryStorage::new();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let _guard = sdk.claim_identity_operation("test operation").unwrap();
+
+    let result = sdk.restore_backup_state(empty_backup_state()).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+}

--- a/paykit-sdk/src/runtime/tests/contacts.rs
+++ b/paykit-sdk/src/runtime/tests/contacts.rs
@@ -1,0 +1,535 @@
+use super::*;
+
+#[tokio::test]
+async fn test_contact_records_save_list_and_remove_locally() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let contact_public_key =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let saved = sdk
+        .save_contact(ContactUpdate {
+            public_key: contact_public_key.clone(),
+            label: Some("Alice".into()),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(saved.label.as_deref(), Some("Alice"));
+    assert_eq!(sdk.contact_records().await.unwrap(), vec![saved.clone()]);
+    assert_eq!(
+        sdk.contact_record(&contact_public_key).await.unwrap(),
+        Some(saved.clone())
+    );
+    assert_eq!(
+        sdk.remove_contact(&contact_public_key).await.unwrap(),
+        Some(saved)
+    );
+    assert!(sdk
+        .contact_record(&contact_public_key)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn test_save_contact_empty_label_clears_existing_label() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let contact_public_key =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    sdk.save_contact(ContactUpdate {
+        public_key: contact_public_key.clone(),
+        label: Some("Alice".into()),
+    })
+    .await
+    .unwrap();
+    let updated = sdk
+        .save_contact(ContactUpdate {
+            public_key: contact_public_key,
+            label: Some(String::new()),
+        })
+        .await
+        .unwrap();
+
+    assert!(updated.label.is_none());
+}
+
+#[tokio::test]
+async fn test_publish_paykit_blob_requires_session() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .publish_paykit_blob("avatar.jpg".into(), vec![1, 2, 3])
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+#[tokio::test]
+async fn test_delete_paykit_blob_requires_initialized_session() {
+    let sdk = PaykitSdk::with_clock(
+        InMemoryStorage::new(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.delete_paykit_blob("/pub/paykit/blobs/avatar.jpg").await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+#[tokio::test]
+async fn test_fetch_pubky_file_requires_public_storage() {
+    let sdk = PaykitSdk::with_clock(
+        InMemoryStorage::new(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .fetch_pubky_file("pubky://invalid/pub/paykit/blobs/avatar.jpg")
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+#[tokio::test]
+async fn test_remove_contact_blocks_when_public_marker_may_exist() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let contact_public_key =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    storage
+        .transaction({
+            let contact_public_key = contact_public_key.clone();
+            move |tx| {
+                tx.save_contact_record(ContactRecord {
+                    public_key: contact_public_key,
+                    label: None,
+                    profile: None,
+                    profile_fetched_at: None,
+                    created_at: FixedClock.now(),
+                    updated_at: FixedClock.now(),
+                    public_contact_marker_status: crate::PublicationStatus::Published,
+                    public_contact_published_at: Some(FixedClock.now()),
+                    public_contact_removed_at: None,
+                    public_contact_last_error: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.remove_contact(&contact_public_key).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+}
+
+#[tokio::test]
+async fn test_publish_public_contact_does_not_mark_pending_without_session() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let contact_public_key =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    storage
+        .transaction({
+            let contact_public_key = contact_public_key.clone();
+            move |tx| {
+                tx.save_contact_record(ContactRecord {
+                    public_key: contact_public_key,
+                    label: None,
+                    profile: None,
+                    profile_fetched_at: None,
+                    created_at: FixedClock.now(),
+                    updated_at: FixedClock.now(),
+                    public_contact_marker_status: crate::PublicationStatus::NotPublished,
+                    public_contact_published_at: None,
+                    public_contact_removed_at: None,
+                    public_contact_last_error: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig {
+            public_contact_sharing: PublicContactSharingPolicy::ConfiguredPublicNamespace,
+            ..PaykitSdkConfig::default()
+        },
+        FixedClock,
+    );
+
+    let result = sdk.publish_public_contact(contact_public_key.clone()).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    let record = storage
+        .snapshot()
+        .unwrap()
+        .contact_records
+        .get(&contact_public_key)
+        .unwrap()
+        .clone();
+    assert_eq!(
+        record.public_contact_marker_status,
+        crate::PublicationStatus::NotPublished
+    );
+}
+
+#[tokio::test]
+async fn test_remove_public_contact_cleanup_is_allowed_when_sharing_disabled() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let contact_public_key =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    storage
+        .transaction({
+            let contact_public_key = contact_public_key.clone();
+            move |tx| {
+                tx.save_contact_record(ContactRecord {
+                    public_key: contact_public_key,
+                    label: None,
+                    profile: None,
+                    profile_fetched_at: None,
+                    created_at: FixedClock.now(),
+                    updated_at: FixedClock.now(),
+                    public_contact_marker_status: crate::PublicationStatus::Published,
+                    public_contact_published_at: Some(FixedClock.now()),
+                    public_contact_removed_at: None,
+                    public_contact_last_error: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.remove_public_contact(contact_public_key.clone()).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    let record = storage
+        .snapshot()
+        .unwrap()
+        .contact_records
+        .get(&contact_public_key)
+        .unwrap()
+        .clone();
+    assert_eq!(
+        record.public_contact_marker_status,
+        crate::PublicationStatus::Published
+    );
+}
+
+#[tokio::test]
+async fn test_remove_public_contact_without_local_record_still_requires_session() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let contact_public_key =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.remove_public_contact(contact_public_key).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+#[tokio::test]
+async fn test_sync_public_contact_markers_returns_empty_without_pending_markers() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let records = sdk.sync_public_contact_markers().await.unwrap();
+
+    assert!(records.is_empty());
+}
+
+#[tokio::test]
+async fn test_sync_public_contact_markers_preserves_pending_without_session() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let contact_public_key =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    storage
+        .transaction({
+            let contact_public_key = contact_public_key.clone();
+            move |tx| {
+                tx.save_contact_record(ContactRecord {
+                    public_key: contact_public_key,
+                    label: None,
+                    profile: None,
+                    profile_fetched_at: None,
+                    created_at: FixedClock.now(),
+                    updated_at: FixedClock.now(),
+                    public_contact_marker_status: crate::PublicationStatus::PendingPublication,
+                    public_contact_published_at: None,
+                    public_contact_removed_at: None,
+                    public_contact_last_error: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig {
+            public_contact_sharing: PublicContactSharingPolicy::ConfiguredPublicNamespace,
+            ..PaykitSdkConfig::default()
+        },
+        FixedClock,
+    );
+
+    let result = sdk.sync_public_contact_markers().await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    let record = storage
+        .snapshot()
+        .unwrap()
+        .contact_records
+        .get(&contact_public_key)
+        .unwrap()
+        .clone();
+    assert_eq!(
+        record.public_contact_marker_status,
+        crate::PublicationStatus::PendingPublication
+    );
+}
+
+#[tokio::test]
+async fn test_sync_public_contact_markers_fails_pending_publication_when_sharing_disabled() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let contact_public_key =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    storage
+        .transaction({
+            let contact_public_key = contact_public_key.clone();
+            move |tx| {
+                tx.save_contact_record(ContactRecord {
+                    public_key: contact_public_key,
+                    label: None,
+                    profile: None,
+                    profile_fetched_at: None,
+                    created_at: FixedClock.now(),
+                    updated_at: FixedClock.now(),
+                    public_contact_marker_status: crate::PublicationStatus::PendingPublication,
+                    public_contact_published_at: None,
+                    public_contact_removed_at: None,
+                    public_contact_last_error: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let records = sdk.sync_public_contact_markers().await.unwrap();
+
+    assert!(records.is_empty());
+    let record = storage
+        .snapshot()
+        .unwrap()
+        .contact_records
+        .get(&contact_public_key)
+        .unwrap()
+        .clone();
+    assert_eq!(
+        record.public_contact_marker_status,
+        crate::PublicationStatus::Failed
+    );
+    assert_eq!(
+        record.public_contact_last_error.as_deref(),
+        Some("public contact sharing is disabled")
+    );
+}
+
+#[tokio::test]
+async fn test_save_contact_requires_initialized_identity() {
+    let storage = InMemoryStorage::new();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let contact_public_key =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+
+    let result = sdk
+        .save_contact(ContactUpdate {
+            public_key: contact_public_key,
+            label: None,
+        })
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}

--- a/paykit-sdk/src/runtime/tests/encrypted_links.rs
+++ b/paykit-sdk/src/runtime/tests/encrypted_links.rs
@@ -1,0 +1,278 @@
+use super::*;
+
+#[tokio::test]
+async fn test_initiate_link_with_peer_requires_pubky_session() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.initiate_link_with_peer(counterparty).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+#[tokio::test]
+async fn test_initiate_link_with_peer_requires_session_before_using_stored_link() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    seed_private_capable_identity_and_link(&storage, counterparty.clone()).await;
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.initiate_link_with_peer(counterparty).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    let snapshot = storage.snapshot().unwrap();
+    assert_eq!(snapshot.encrypted_link_states.len(), 1);
+}
+
+#[tokio::test]
+async fn test_initiate_link_with_peer_preserves_untrusted_linking_state_without_session() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    crate::linked_peers::save_link_handshake_state(
+        &storage,
+        counterparty.clone(),
+        EncryptedLinkHandshakeRole::Initiator,
+        vec![1, 2, 3],
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.initiate_link_with_peer(counterparty.clone()).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    assert!(crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_recovery_required_peer_allows_relink_attempt() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    crate::linked_peers::save_linked_peer_state(
+        &storage,
+        counterparty.clone(),
+        LinkedPeerState::RecoveryRequired,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                Ok(tx
+                    .claim_peer_link_operation(
+                        &counterparty,
+                        FixedClock.now(),
+                        FixedClock.now() + chrono::Duration::seconds(60),
+                    )
+                    .unwrap())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .start_link_handshake_with_claim(counterparty, EncryptedLinkHandshakeRole::Initiator, lease)
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+#[tokio::test]
+async fn test_advance_link_handshake_rejects_recovery_required_peer() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::RecoveryRequired,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 1,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: Some(vec![1, 2, 3]),
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 4,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.advance_link_handshake(counterparty.clone()).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::RecoveryRequired(_))));
+    assert_eq!(
+        crate::load_encrypted_link_state(&storage, &counterparty)
+            .await
+            .unwrap()
+            .unwrap()
+            .generation,
+        4
+    );
+}
+
+#[tokio::test]
+async fn test_advance_link_handshake_preserves_unusable_link_state_without_session() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: None,
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 0,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.advance_link_handshake(counterparty.clone()).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    assert!(crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_advance_link_handshake_preserves_unusable_handshake_snapshot_without_session() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: None,
+                    handshake_snapshot: Some(vec![1, 2, 3]),
+                    handshake_role: Some(EncryptedLinkHandshakeRole::Initiator),
+                    generation: 0,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.advance_link_handshake(counterparty.clone()).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    assert!(crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_advance_link_handshake_preserves_unusable_handshake_metadata_without_session() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: None,
+                    handshake_snapshot: Some(vec![1, 2, 3]),
+                    handshake_role: None,
+                    generation: 0,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.advance_link_handshake(counterparty.clone()).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    assert!(crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .is_some());
+}

--- a/paykit-sdk/src/runtime/tests/identity.rs
+++ b/paykit-sdk/src/runtime/tests/identity.rs
@@ -1,0 +1,292 @@
+use super::*;
+
+#[tokio::test]
+async fn test_initialize_persists_signed_out_identity() {
+    let storage = InMemoryStorage::new();
+    let pubky = TestPubkySessionProvider { session: None };
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        pubky,
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let report = sdk.initialize().await.unwrap();
+
+    assert!(!report.live_session_available);
+    assert!(!report.identity.live_session_available);
+    assert!(!report.identity.private_link_capable);
+    let stored = storage.snapshot().unwrap().identity_state.unwrap();
+    assert!(stored.public_key.is_none());
+    assert_eq!(stored.capability, PubkyIdentityCapability::SignedOut);
+    assert!(!stored.local_secret_available);
+    assert_eq!(stored.initialized_at, FixedClock.now());
+}
+
+#[tokio::test]
+async fn test_initialize_without_live_session_preserves_identity_scoped_state() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(counterparty.clone()),
+                    capability: PubkyIdentityCapability::PrivateLinkCapable,
+                    local_secret_available: true,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 3,
+                });
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_public_endpoint_record(PublicEndpointRecord {
+                    identifier: "btc-lightning-bolt11".into(),
+                    payload: Some("payload".into()),
+                    status: PublicationStatus::Published,
+                    updated_at: FixedClock.now(),
+                    last_error: None,
+                });
+                tx.save_contact_record(ContactRecord {
+                    public_key: counterparty.clone(),
+                    label: Some("Alice".into()),
+                    profile: None,
+                    profile_fetched_at: None,
+                    created_at: FixedClock.now(),
+                    updated_at: FixedClock.now(),
+                    public_contact_marker_status: crate::PublicationStatus::NotPublished,
+                    public_contact_published_at: None,
+                    public_contact_removed_at: None,
+                    public_contact_last_error: None,
+                });
+                tx.insert_outbound_private_message(crate::storage::NewOutboundPrivateMessage::new(
+                    counterparty,
+                    "paykit.private_payment_list".into(),
+                    private_list_json(),
+                    FixedClock.now(),
+                ));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let report = sdk.initialize().await.unwrap();
+
+    let snapshot = storage.snapshot().unwrap();
+    let identity = snapshot.identity_state.unwrap();
+    assert!(!report.live_session_available);
+    assert!(!report.identity.live_session_available);
+    assert!(!report.identity.private_link_capable);
+    assert_eq!(identity.public_key.as_ref(), Some(&counterparty));
+    assert_eq!(
+        identity.capability,
+        PubkyIdentityCapability::PrivateLinkCapable
+    );
+    assert_eq!(identity.sign_out_generation, 3);
+    assert_eq!(snapshot.linked_peers.len(), 1);
+    assert_eq!(snapshot.contact_records.len(), 1);
+    assert_eq!(snapshot.public_endpoint_records.len(), 1);
+    assert_eq!(snapshot.outbound_private_messages.len(), 1);
+}
+
+#[tokio::test]
+async fn test_identity_status_cached_capability_requires_live_session() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PrivateLinkCapable,
+            local_secret_available: true,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let status = sdk.identity_status().await.unwrap().unwrap();
+
+    assert_eq!(
+        status.capability,
+        PubkyIdentityCapability::PrivateLinkCapable
+    );
+    assert!(!status.live_session_available);
+    assert!(!status.private_link_capable);
+}
+
+#[tokio::test]
+async fn test_sign_out_clears_identity_scoped_state() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(counterparty.clone()),
+                    capability: PubkyIdentityCapability::PrivateLinkCapable,
+                    local_secret_available: true,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 3,
+                });
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_public_endpoint_record(PublicEndpointRecord {
+                    identifier: "btc-lightning-bolt11".into(),
+                    payload: Some("payload".into()),
+                    status: PublicationStatus::Published,
+                    updated_at: FixedClock.now(),
+                    last_error: None,
+                });
+                tx.save_contact_record(ContactRecord {
+                    public_key: counterparty.clone(),
+                    label: Some("Alice".into()),
+                    profile: None,
+                    profile_fetched_at: None,
+                    created_at: FixedClock.now(),
+                    updated_at: FixedClock.now(),
+                    public_contact_marker_status: crate::PublicationStatus::NotPublished,
+                    public_contact_published_at: None,
+                    public_contact_removed_at: None,
+                    public_contact_last_error: None,
+                });
+                tx.insert_outbound_private_message(crate::storage::NewOutboundPrivateMessage::new(
+                    counterparty,
+                    "paykit.private_payment_list".into(),
+                    private_list_json(),
+                    FixedClock.now(),
+                ));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let status = sdk.sign_out().await.unwrap();
+
+    assert_eq!(status.capability, PubkyIdentityCapability::SignedOut);
+    assert!(!status.live_session_available);
+    assert!(!status.private_link_capable);
+    let snapshot = storage.snapshot().unwrap();
+    let identity = snapshot.identity_state.unwrap();
+    assert_eq!(identity.sign_out_generation, 4);
+    assert!(identity.public_key.is_none());
+    assert_eq!(identity.capability, PubkyIdentityCapability::SignedOut);
+    assert!(snapshot.linked_peers.is_empty());
+    assert!(snapshot.contact_records.is_empty());
+    assert!(snapshot.public_endpoint_records.is_empty());
+    assert!(snapshot.outbound_private_messages.is_empty());
+}
+
+#[tokio::test]
+async fn test_sign_out_rejects_concurrent_identity_operation() {
+    let storage = InMemoryStorage::new();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let _guard = sdk.claim_identity_operation("test operation").unwrap();
+
+    let result = sdk.sign_out().await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+}
+
+#[tokio::test]
+async fn test_sign_out_provider_failure_preserves_identity_scoped_state() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(counterparty.clone()),
+                    capability: PubkyIdentityCapability::PrivateLinkCapable,
+                    local_secret_available: true,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 3,
+                });
+                tx.save_contact_record(ContactRecord {
+                    public_key: counterparty,
+                    label: Some("Alice".into()),
+                    profile: None,
+                    profile_fetched_at: None,
+                    created_at: FixedClock.now(),
+                    updated_at: FixedClock.now(),
+                    public_contact_marker_status: crate::PublicationStatus::NotPublished,
+                    public_contact_published_at: None,
+                    public_contact_removed_at: None,
+                    public_contact_last_error: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        FailingClearSessionProvider,
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.sign_out().await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    let snapshot = storage.snapshot().unwrap();
+    let identity = snapshot.identity_state.unwrap();
+    assert_eq!(identity.sign_out_generation, 3);
+    assert_eq!(
+        identity.capability,
+        PubkyIdentityCapability::PrivateLinkCapable
+    );
+    assert_eq!(snapshot.contact_records.len(), 1);
+}

--- a/paykit-sdk/src/runtime/tests/linked_peers.rs
+++ b/paykit-sdk/src/runtime/tests/linked_peers.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+#[tokio::test]
+async fn test_linked_peers_lists_tracked_peers() {
+    let storage = InMemoryStorage::new();
+    let first = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let second = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let first = first.clone();
+            let second = second.clone();
+            move |tx| {
+                for counterparty in [second, first] {
+                    tx.save_linked_peer(LinkedPeerRecord {
+                        counterparty,
+                        state: LinkedPeerState::Linked,
+                        last_sync_at: Some(FixedClock.now()),
+                        last_private_receive_at: None,
+                        failure_count: 0,
+                        local_recovery_attempt_id: None,
+                        local_recovery_marker_created_at: None,
+                        local_recovery_marker_last_error: None,
+                        remote_recovery_attempt_id: None,
+                        remote_recovery_marker_observed_at: None,
+                    });
+                }
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let peers = sdk.linked_peers().await.unwrap();
+
+    assert_eq!(peers.len(), 2);
+    assert!(peers[0].counterparty.as_str() <= peers[1].counterparty.as_str());
+}

--- a/paykit-sdk/src/runtime/tests/outbound_private.rs
+++ b/paykit-sdk/src/runtime/tests/outbound_private.rs
@@ -1,0 +1,597 @@
+use super::*;
+
+#[tokio::test]
+async fn test_pending_outbound_private_counterparties_dedupes_work() {
+    let storage = InMemoryStorage::new();
+    let first = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let second = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let first = first.clone();
+            let second = second.clone();
+            move |tx| {
+                tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                    first.clone(),
+                    "paykit.private_payment_list".into(),
+                    private_list_json(),
+                    FixedClock.now(),
+                ));
+                let mut sent = tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                    second,
+                    "paykit.private_payment_list".into(),
+                    private_list_json(),
+                    FixedClock.now(),
+                ));
+                sent.status = OutboundPrivateMessageStatus::Sent;
+                tx.save_outbound_private_message(sent)?;
+                tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                    first,
+                    "paykit.private_payment_list".into(),
+                    private_list_json(),
+                    FixedClock.now(),
+                ));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let counterparties = sdk.pending_outbound_private_counterparties().await.unwrap();
+
+    assert_eq!(counterparties, vec![first]);
+}
+
+#[tokio::test]
+async fn test_pending_outbound_private_counterparties_waits_for_stale_sending() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut sending =
+                    tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                        counterparty,
+                        "paykit.private_payment_list".into(),
+                        private_list_json(),
+                        FixedClock.now(),
+                    ));
+                sending.status = OutboundPrivateMessageStatus::Sending;
+                sending.last_attempt_at = Some(FixedClock.now());
+                tx.save_outbound_private_message(sending)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    assert!(sdk
+        .pending_outbound_private_counterparties()
+        .await
+        .unwrap()
+        .is_empty());
+
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut sending = tx.outbound_private_messages(&counterparty)[0].clone();
+                sending.last_attempt_at = Some(FixedClock.now() - ChronoDuration::seconds(120));
+                tx.save_outbound_private_message(sending)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        sdk.pending_outbound_private_counterparties().await.unwrap(),
+        vec![counterparty]
+    );
+}
+
+#[tokio::test]
+async fn test_pending_outbound_private_counterparties_skips_recovery_required_peer() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::RecoveryRequired,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 1,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                    counterparty,
+                    "paykit.private_payment_list".into(),
+                    private_list_json(),
+                    FixedClock.now(),
+                ));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    assert!(sdk
+        .pending_outbound_private_counterparties()
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn test_pending_outbound_private_counterparties_skips_linking_peer() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linking,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                    counterparty,
+                    "paykit.private_payment_list".into(),
+                    private_list_json(),
+                    FixedClock.now(),
+                ));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    assert!(sdk
+        .pending_outbound_private_counterparties()
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn test_pending_outbound_private_counterparties_waits_for_failed_backoff() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut failed =
+                    tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                        counterparty,
+                        "paykit.private_payment_list".into(),
+                        private_list_json(),
+                        FixedClock.now(),
+                    ));
+                failed.status = OutboundPrivateMessageStatus::Failed;
+                failed.last_attempt_at = Some(FixedClock.now());
+                tx.save_outbound_private_message(failed)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig {
+            outbound_private_retry_backoff: Duration::from_secs(30),
+            ..PaykitSdkConfig::default()
+        },
+        FixedClock,
+    );
+
+    assert!(sdk
+        .pending_outbound_private_counterparties()
+        .await
+        .unwrap()
+        .is_empty());
+
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut failed = tx.outbound_private_messages(&counterparty)[0].clone();
+                failed.last_attempt_at = Some(FixedClock.now() - ChronoDuration::seconds(31));
+                tx.save_outbound_private_message(failed)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        sdk.pending_outbound_private_counterparties().await.unwrap(),
+        vec![counterparty]
+    );
+}
+
+#[tokio::test]
+async fn test_pending_outbound_private_counterparties_respects_queue_head() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut failed_head =
+                    tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                        counterparty.clone(),
+                        "paykit.payment_request".into(),
+                        payment_request_message(
+                            "650e8400-e29b-41d4-a716-446655440000",
+                            "550e8400-e29b-41d4-a716-446655440000",
+                            None,
+                        )
+                        .raw_json,
+                        FixedClock.now(),
+                    ));
+                failed_head.status = OutboundPrivateMessageStatus::Failed;
+                failed_head.last_attempt_at = Some(FixedClock.now());
+                tx.save_outbound_private_message(failed_head)?;
+                tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                    counterparty,
+                    "paykit.payment_request".into(),
+                    payment_request_message(
+                        "650e8400-e29b-41d4-a716-446655440001",
+                        "550e8400-e29b-41d4-a716-446655440001",
+                        None,
+                    )
+                    .raw_json,
+                    FixedClock.now(),
+                ));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig {
+            outbound_private_retry_backoff: Duration::from_secs(30),
+            ..PaykitSdkConfig::default()
+        },
+        FixedClock,
+    );
+
+    assert!(sdk
+        .pending_outbound_private_counterparties()
+        .await
+        .unwrap()
+        .is_empty());
+
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut failed_head = tx.outbound_private_messages(&counterparty)[0].clone();
+                failed_head.last_attempt_at = Some(FixedClock.now() - ChronoDuration::seconds(31));
+                tx.save_outbound_private_message(failed_head)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        sdk.pending_outbound_private_counterparties().await.unwrap(),
+        vec![counterparty]
+    );
+}
+
+#[tokio::test]
+async fn test_process_pending_private_messages_reports_counterparty_errors() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.insert_outbound_private_message(NewOutboundPrivateMessage::new(
+                    counterparty,
+                    "paykit.private_payment_list".into(),
+                    private_list_json(),
+                    FixedClock.now(),
+                ));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let reports = sdk.process_pending_private_messages().await.unwrap();
+
+    assert_eq!(reports.len(), 1);
+    assert_eq!(reports[0].counterparty, counterparty);
+    assert!(reports[0].report.is_none());
+    assert!(reports[0].error.is_some());
+}
+
+#[tokio::test]
+async fn test_process_outbound_private_messages_preserves_superseded_reservations_without_session()
+{
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "reservation-1".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "one".into(),
+            },
+            expires_at: None,
+            attribution: HashMap::new(),
+        }],
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let latest = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "reservation-2".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "two".into(),
+            },
+            expires_at: None,
+            attribution: HashMap::new(),
+        }],
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut sent = tx
+                    .outbound_private_messages(&counterparty)
+                    .into_iter()
+                    .find(|message| message.outbound_message_id == latest.outbound_message_id)
+                    .unwrap();
+                sent.status = crate::OutboundPrivateMessageStatus::Sent;
+                tx.save_outbound_private_message(sent)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let canceled = Arc::new(Mutex::new(Vec::new()));
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        InvalidReservedPrivateListPaymentAdapter {
+            canceled: canceled.clone(),
+        },
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .process_outbound_private_messages(counterparty.clone())
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    assert!(canceled.lock().unwrap().is_empty());
+    assert_eq!(
+        storage
+            .snapshot()
+            .unwrap()
+            .payment_endpoint_reservations
+            .len(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_keeps_existing_reservation_on_error() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "existing-reservation".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "existing".into(),
+            },
+            expires_at: None,
+            attribution: HashMap::new(),
+        }],
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let canceled = Arc::new(Mutex::new(Vec::new()));
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        MixedExistingReservedPrivateListPaymentAdapter {
+            canceled: canceled.clone(),
+        },
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .enqueue_private_payment_list_from_receiving_details(counterparty)
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    assert_eq!(
+        *canceled.lock().unwrap(),
+        vec!["conflicting-reservation".to_string()]
+    );
+    assert_eq!(
+        storage
+            .snapshot()
+            .unwrap()
+            .payment_endpoint_reservations
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn test_enqueue_payment_request_event_requires_private_capable_identity() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let event = PaymentRequestAcceptance::new(
+        paykit_lib::EventId::new("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102").unwrap(),
+        paykit_lib::PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap(),
+    );
+
+    let result = sdk
+        .enqueue_raw_payment_request_acceptance(counterparty, &event)
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+#[tokio::test]
+async fn test_process_outbound_private_messages_preserves_untrusted_queue_without_session() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    crate::outbound_private::enqueue_private_message(
+        &storage,
+        counterparty.clone(),
+        private_list_json(),
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .process_outbound_private_messages(counterparty.clone())
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    let queued = crate::outbound_private::queued_outbound_private_messages(&storage, &counterparty)
+        .await
+        .unwrap();
+    assert_eq!(queued.len(), 1);
+    assert!(storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+        })
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn test_process_outbound_private_messages_blocks_recovery_required_peer() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    crate::linked_peers::save_linked_peer_state(
+        &storage,
+        counterparty.clone(),
+        LinkedPeerState::RecoveryRequired,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    crate::outbound_private::enqueue_private_message(
+        &storage,
+        counterparty.clone(),
+        private_list_json(),
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .process_outbound_private_messages(counterparty.clone())
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::RecoveryRequired(_))));
+    let queued = crate::outbound_private::queued_outbound_private_messages(&storage, &counterparty)
+        .await
+        .unwrap();
+    assert_eq!(queued.len(), 1);
+}

--- a/paykit-sdk/src/runtime/tests/outbound_private.rs
+++ b/paykit-sdk/src/runtime/tests/outbound_private.rs
@@ -49,6 +49,56 @@ async fn test_pending_outbound_private_counterparties_dedupes_work() {
 }
 
 #[tokio::test]
+async fn test_pending_outbound_private_counterparties_includes_cleanup_only_work() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let queued = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "reservation-1".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "one".into(),
+            },
+            expires_at: None,
+            attribution: HashMap::new(),
+        }],
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut invalid = tx
+                    .outbound_private_messages(&counterparty)
+                    .into_iter()
+                    .find(|message| message.outbound_message_id == queued.outbound_message_id)
+                    .unwrap();
+                invalid.status = OutboundPrivateMessageStatus::Invalid;
+                tx.save_outbound_private_message(invalid)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    assert_eq!(
+        sdk.pending_outbound_private_counterparties().await.unwrap(),
+        vec![counterparty]
+    );
+}
+
+#[tokio::test]
 async fn test_pending_outbound_private_counterparties_waits_for_stale_sending() {
     let storage = InMemoryStorage::new();
     let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());

--- a/paykit-sdk/src/runtime/tests/payment_requests.rs
+++ b/paykit-sdk/src/runtime/tests/payment_requests.rs
@@ -1,0 +1,515 @@
+use super::*;
+
+#[tokio::test]
+async fn test_payment_requests_with_allows_public_only_identity() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let local_public_key = local_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![payment_request_message(
+            "650e8400-e29b-41d4-a716-446655440000",
+            "550e8400-e29b-41d4-a716-446655440000",
+            None,
+        )],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let records = sdk.payment_requests_with(&counterparty).await.unwrap();
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].state, PaymentRequestLifecycleState::Proposed);
+}
+
+#[tokio::test]
+async fn test_payment_requests_with_marks_recovery_required_peer_state() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let local_public_key = local_public_key.clone();
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty,
+                    state: LinkedPeerState::RecoveryRequired,
+                    last_sync_at: None,
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![payment_request_message(
+            "650e8400-e29b-41d4-a716-446655440000",
+            "550e8400-e29b-41d4-a716-446655440000",
+            None,
+        )],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let records = sdk.payment_requests_with(&counterparty).await.unwrap();
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(
+        records[0].state,
+        PaymentRequestLifecycleState::RecoveryRequired
+    );
+}
+
+#[tokio::test]
+async fn test_list_payment_requests_filters_across_counterparties() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let first = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let second = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let blocked = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let local_public_key = local_public_key.clone();
+            let blocked = blocked.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: blocked,
+                    state: LinkedPeerState::Blocked,
+                    last_sync_at: None,
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    persist_private_stream_batch(
+        &storage,
+        first.clone(),
+        vec![payment_request_message(
+            "650e8400-e29b-41d4-a716-446655440000",
+            "550e8400-e29b-41d4-a716-446655440000",
+            None,
+        )],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    persist_private_stream_batch(
+        &storage,
+        second.clone(),
+        vec![payment_request_message(
+            "650e8400-e29b-41d4-a716-446655440001",
+            "550e8400-e29b-41d4-a716-446655440001",
+            Some("2026-06-03T11:59:59Z"),
+        )],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    persist_private_stream_batch(
+        &storage,
+        blocked,
+        vec![payment_request_message(
+            "650e8400-e29b-41d4-a716-446655440002",
+            "550e8400-e29b-41d4-a716-446655440002",
+            None,
+        )],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let all = sdk.payment_requests().await.unwrap();
+    let expired = sdk
+        .list_payment_requests(PaymentRequestFilter {
+            states: vec![PaymentRequestLifecycleState::ProposalExpired],
+            ..PaymentRequestFilter::default()
+        })
+        .await
+        .unwrap();
+    let received = sdk.actionable_received_payment_requests().await.unwrap();
+
+    assert_eq!(all.len(), 2);
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].counterparty, second);
+    assert_eq!(received.len(), 2);
+    assert!(received
+        .iter()
+        .all(|record| record.local_role == Some(PaymentRequestLocalRole::Payer)));
+}
+
+#[tokio::test]
+async fn test_active_recurring_payment_requests_filters_accepted_recurring_requests() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let recurring_peer = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let one_time_peer = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    queue_recurring_request_with_inbound_acceptance(
+        &storage,
+        recurring_peer.clone(),
+        "650e8400-e29b-41d4-a716-446655440010",
+        "650e8400-e29b-41d4-a716-446655440011",
+        "550e8400-e29b-41d4-a716-446655440010",
+    )
+    .await;
+    queue_one_time_request_with_inbound_acceptance(
+        &storage,
+        one_time_peer,
+        "650e8400-e29b-41d4-a716-446655440012",
+        "650e8400-e29b-41d4-a716-446655440013",
+        "550e8400-e29b-41d4-a716-446655440011",
+    )
+    .await;
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let active = sdk.active_recurring_payment_requests().await.unwrap();
+
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].counterparty, recurring_peer);
+    assert_eq!(
+        active[0].state,
+        PaymentRequestLifecycleState::ActiveRecurring
+    );
+    assert!(active[0]
+        .terms
+        .as_ref()
+        .and_then(|terms| terms.recurrence.as_ref())
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_enqueue_payment_request_event_requires_private_capable_identity() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let event = PaymentRequestAcceptance::new(
+        paykit_lib::EventId::new("8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d102").unwrap(),
+        paykit_lib::PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap(),
+    );
+
+    let result = sdk
+        .enqueue_raw_payment_request_acceptance(counterparty, &event)
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+#[tokio::test]
+async fn test_accept_payment_request_rejects_expired_proposal_before_enqueue() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let request_id = PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap();
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![payment_request_message(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id.as_str(),
+            Some("2026-06-03T11:59:59Z"),
+        )],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.accept_payment_request(counterparty, &request_id).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    assert!(storage
+        .snapshot()
+        .unwrap()
+        .outbound_private_messages
+        .is_empty());
+}
+
+#[tokio::test]
+async fn test_reject_payment_request_allows_expired_proposal_before_readiness_check() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let request_id = PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap();
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![payment_request_message(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id.as_str(),
+            Some("2026-06-03T11:59:59Z"),
+        )],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .reject_payment_request(counterparty, &request_id, None)
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    assert!(storage
+        .snapshot()
+        .unwrap()
+        .outbound_private_messages
+        .is_empty());
+}
+
+#[tokio::test]
+async fn test_accept_payment_request_does_not_queue_without_private_send_readiness() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let request_id = PaymentRequestId::new("b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33").unwrap();
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![payment_request_message(
+            "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            request_id.as_str(),
+            None,
+        )],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.accept_payment_request(counterparty, &request_id).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    assert!(storage
+        .snapshot()
+        .unwrap()
+        .outbound_private_messages
+        .is_empty());
+}
+
+async fn queue_recurring_request_with_inbound_acceptance(
+    storage: &InMemoryStorage,
+    counterparty: PubkyPublicKey,
+    request_event_id: &str,
+    acceptance_event_id: &str,
+    request_id: &str,
+) {
+    queue_request_with_inbound_acceptance(
+        storage,
+        counterparty,
+        request_event_id,
+        acceptance_event_id,
+        request_id,
+        Some(
+            r#"{"every":1,"unit":"month","starts_at":"2026-06-03T12:00:00Z","anchor":"2026-06-03T12:00:00Z","ends_at":null}"#,
+        ),
+    )
+    .await;
+}
+
+async fn queue_one_time_request_with_inbound_acceptance(
+    storage: &InMemoryStorage,
+    counterparty: PubkyPublicKey,
+    request_event_id: &str,
+    acceptance_event_id: &str,
+    request_id: &str,
+) {
+    queue_request_with_inbound_acceptance(
+        storage,
+        counterparty,
+        request_event_id,
+        acceptance_event_id,
+        request_id,
+        None,
+    )
+    .await;
+}
+
+async fn queue_request_with_inbound_acceptance(
+    storage: &InMemoryStorage,
+    counterparty: PubkyPublicKey,
+    request_event_id: &str,
+    acceptance_event_id: &str,
+    request_id: &str,
+    recurrence: Option<&str>,
+) {
+    let request_event = parsed_payment_request_event(payment_request_raw(
+        request_event_id,
+        request_id,
+        recurrence,
+    ));
+    crate::payment_requests::enqueue_payment_request_event(
+        storage,
+        counterparty.clone(),
+        &request_event,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    persist_private_stream_batch(
+        storage,
+        counterparty,
+        vec![payment_request_acceptance_message(
+            acceptance_event_id,
+            request_id,
+        )],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+}
+
+fn parsed_payment_request_event(raw_json: String) -> PaymentRequestEvent {
+    paykit_lib::parse_payment_request_event_message(&private_application_message(raw_json))
+        .unwrap()
+        .parsed_event()
+        .unwrap()
+        .clone()
+}
+
+fn private_application_message(raw_json: String) -> PrivateApplicationMessage {
+    let value = serde_json::from_str::<serde_json::Value>(&raw_json).unwrap();
+    PrivateApplicationMessage {
+        version: value
+            .get("version")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|version| u8::try_from(version).ok()),
+        kind: value
+            .get("kind")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned),
+        raw_json,
+    }
+}
+
+fn payment_request_raw(event_id: &str, request_id: &str, recurrence: Option<&str>) -> String {
+    let recurrence = recurrence.unwrap_or("null");
+    format!(
+        r#"{{"version":1,"kind":"paykit.payment_request","event_id":"{event_id}","payment_request_id":"{request_id}","request":{{"amount":{{"value":"0.001","asset":"btc"}},"payment_reference":"invoice-2026-0001","proposal_expires_at":null,"recurrence":{recurrence},"accepted_payment_endpoint_identifiers":["btc-lightning-bolt11"],"metadata":{{}}}}}}"#
+    )
+}
+
+fn payment_request_acceptance_message(
+    event_id: &str,
+    request_id: &str,
+) -> PrivateApplicationMessage {
+    private_application_message(format!(
+        r#"{{"version":1,"kind":"paykit.payment_request_acceptance","event_id":"{event_id}","payment_request_id":"{request_id}"}}"#
+    ))
+}

--- a/paykit-sdk/src/runtime/tests/payment_resolution.rs
+++ b/paykit-sdk/src/runtime/tests/payment_resolution.rs
@@ -1,0 +1,329 @@
+use super::*;
+
+#[test]
+fn test_payable_from_batch_rejects_foreign_candidates() {
+    let candidate = endpoint_candidate("ln-private");
+    let foreign = endpoint_candidate("ln-foreign");
+
+    let result = payable_from_batch(&[foreign], &[candidate]);
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[test]
+fn test_payable_from_batch_rejects_duplicate_candidates() {
+    let candidate = endpoint_candidate("ln-private");
+
+    let result = payable_from_batch(&[candidate.clone(), candidate.clone()], &[candidate]);
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[test]
+fn test_payable_from_batch_preserves_adapter_order_for_private_and_public() {
+    let private = endpoint_candidate("ln-private");
+    let mut public = private.clone();
+    public.source = PaymentEndpointSource::PublicPaymentEndpoint;
+    public.payload = "ln-public".into();
+    let candidates = vec![private.clone(), public.clone()];
+
+    let result = payable_from_batch(&[public.clone(), private.clone()], &candidates).unwrap();
+
+    assert_eq!(result, vec![public, private]);
+}
+
+#[tokio::test]
+async fn test_resolve_candidate_batch_preserves_private_state() {
+    let storage = InMemoryStorage::new();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let endpoint = endpoint_candidate("ln-public");
+    let result = sdk
+        .resolve_candidate_batch(
+            endpoint.counterparty.clone(),
+            None,
+            vec![endpoint],
+            ContactPaymentResolutionPrivateState::RecoveryPending,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.status, ContactPaymentResolutionStatus::Payable);
+    assert_eq!(
+        result.private_state,
+        ContactPaymentResolutionPrivateState::RecoveryPending
+    );
+    assert_eq!(result.payable_endpoints.len(), 1);
+}
+
+#[tokio::test]
+async fn test_resolve_candidate_batch_returns_ordered_payable_endpoints() {
+    let storage = InMemoryStorage::new();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let private = endpoint_candidate("ln-private");
+    let mut public = private.clone();
+    public.source = PaymentEndpointSource::PublicPaymentEndpoint;
+    public.payload = "ln-public".into();
+
+    let result = sdk
+        .resolve_candidate_batch(
+            private.counterparty.clone(),
+            Some(crate::PaymentAmountContext {
+                value: "10.00".into(),
+                asset: "usd".into(),
+            }),
+            vec![private.clone(), public.clone()],
+            ContactPaymentResolutionPrivateState::Available,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.status, ContactPaymentResolutionStatus::Payable);
+    assert_eq!(
+        result.private_state,
+        ContactPaymentResolutionPrivateState::Available
+    );
+    assert_eq!(result.payable_endpoints.len(), 2);
+    assert_eq!(result.payable_endpoints[0].endpoint, private);
+    assert_eq!(result.payable_endpoints[0].target.payload, "ln-private");
+    assert_eq!(result.payable_endpoints[1].endpoint, public);
+    assert_eq!(result.payable_endpoints[1].target.payload, "ln-public");
+}
+
+#[tokio::test]
+async fn test_resolve_contact_payment_hides_cached_private_list_without_identity() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![private_list_message("ln-private")],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let pubky = TestPubkySessionProvider { session: None };
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        pubky,
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .resolve_contact_payment(ContactPaymentResolutionRequest {
+            counterparty: counterparty.clone(),
+            amount: Some(crate::PaymentAmountContext {
+                value: "10.00".into(),
+                asset: "usd".into(),
+            }),
+            include_public_endpoints: false,
+        })
+        .await;
+
+    let result = result.unwrap();
+    assert_eq!(result.status, ContactPaymentResolutionStatus::NoEndpoint);
+    assert_eq!(
+        result.private_state,
+        ContactPaymentResolutionPrivateState::PublicOnlySession
+    );
+    assert!(result.payable_endpoints.is_empty());
+    assert!(sdk
+        .current_private_payment_list(&counterparty)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn test_resolve_contact_payment_uses_cached_private_list_for_public_only_identity() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction(|tx| {
+            tx.save_identity_state(IdentityState {
+                public_key: Some(PubkyPublicKey::from_public_key(
+                    &pubky::Keypair::random().public_key(),
+                )),
+                capability: PubkyIdentityCapability::PublicOnly,
+                local_secret_available: false,
+                initialized_at: FixedClock.now(),
+                sign_out_generation: 0,
+            });
+            Ok(())
+        })
+        .await
+        .unwrap();
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![private_list_message("ln-private")],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .resolve_contact_payment(ContactPaymentResolutionRequest {
+            counterparty,
+            amount: Some(crate::PaymentAmountContext {
+                value: "10.00".into(),
+                asset: "usd".into(),
+            }),
+            include_public_endpoints: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.status, ContactPaymentResolutionStatus::Payable);
+    assert_eq!(
+        result.private_state,
+        ContactPaymentResolutionPrivateState::Available
+    );
+    assert_eq!(
+        result.payable_endpoints[0].endpoint.source,
+        PaymentEndpointSource::PrivatePaymentList
+    );
+}
+
+#[tokio::test]
+async fn test_resolve_contact_payment_does_not_use_cached_private_list_while_linking() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(PubkyPublicKey::from_public_key(
+                        &pubky::Keypair::random().public_key(),
+                    )),
+                    capability: PubkyIdentityCapability::PrivateLinkCapable,
+                    local_secret_available: true,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty,
+                    state: LinkedPeerState::Linking,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![private_list_message("ln-private")],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .resolve_contact_payment(ContactPaymentResolutionRequest {
+            counterparty,
+            amount: Some(crate::PaymentAmountContext {
+                value: "10.00".into(),
+                asset: "usd".into(),
+            }),
+            include_public_endpoints: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.status, ContactPaymentResolutionStatus::NoEndpoint);
+    assert_eq!(
+        result.private_state,
+        ContactPaymentResolutionPrivateState::RecoveryPending
+    );
+    assert!(result.payable_endpoints.is_empty());
+}
+
+#[tokio::test]
+async fn test_recover_private_candidates_reports_pending_for_linking_peer() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(PubkyPublicKey::from_public_key(
+                        &pubky::Keypair::random().public_key(),
+                    )),
+                    capability: PubkyIdentityCapability::PrivateLinkCapable,
+                    local_secret_available: true,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty,
+                    state: LinkedPeerState::Linking,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let outcome = sdk
+        .recover_private_candidates_for_resolution(&counterparty)
+        .await
+        .unwrap();
+
+    assert!(matches!(outcome, PrivateRecoveryOutcome::Pending));
+}

--- a/paykit-sdk/src/runtime/tests/private_lists.rs
+++ b/paykit-sdk/src/runtime/tests/private_lists.rs
@@ -1,0 +1,799 @@
+use super::*;
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_requires_live_session_for_stored_link() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    seed_private_capable_identity_and_link(&storage, counterparty.clone()).await;
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        PrivateListPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.enqueue_private_payment_list(counterparty).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    let snapshot = storage.snapshot().unwrap();
+    assert_eq!(snapshot.encrypted_link_states.len(), 1);
+}
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_requires_private_capable_identity() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        PrivateListPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.enqueue_private_payment_list(counterparty).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_uses_fallback_details() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        PrivateListPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let outbound = sdk
+        .enqueue_private_payment_list_from_receiving_details(counterparty)
+        .await
+        .unwrap();
+
+    let list = paykit_lib::parse_private_payment_list_json(&outbound.raw_json).unwrap();
+    assert_eq!(
+        list.get(&PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap())
+            .unwrap()
+            .as_str(),
+        "ln-private"
+    );
+    assert!(storage
+        .snapshot()
+        .unwrap()
+        .payment_endpoint_reservations
+        .is_empty());
+}
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_waits_for_peer_operation_lease() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                assert!(tx
+                    .claim_peer_link_operation(
+                        &counterparty,
+                        FixedClock.now(),
+                        FixedClock.now() + ChronoDuration::seconds(60),
+                    )
+                    .is_some());
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        ReservedPrivateListPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .enqueue_private_payment_list_from_receiving_details(counterparty)
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+}
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_uses_reserved_details() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        ReservedPrivateListPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let outbound = sdk
+        .enqueue_private_payment_list_from_receiving_details(counterparty.clone())
+        .await
+        .unwrap();
+
+    let list = paykit_lib::parse_private_payment_list_json(&outbound.raw_json).unwrap();
+    assert_eq!(
+        list.get(&PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap())
+            .unwrap()
+            .as_str(),
+        "ln-reserved"
+    );
+    let reservations = storage
+        .snapshot()
+        .unwrap()
+        .payment_endpoint_reservations
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(reservations.len(), 1);
+    assert_eq!(
+        reservations[0].outbound_message_id,
+        outbound.outbound_message_id
+    );
+    assert_ne!(reservations[0].payload_hash, "ln-reserved");
+    assert!(!format!("{:?}", reservations[0]).contains("ln-reserved"));
+}
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_cancels_invalid_reservations() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let canceled = Arc::new(Mutex::new(Vec::new()));
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        InvalidReservedPrivateListPaymentAdapter {
+            canceled: canceled.clone(),
+        },
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .enqueue_private_payment_list_from_receiving_details(counterparty)
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    assert_eq!(
+        *canceled.lock().unwrap(),
+        vec!["reservation-1".to_string(), "reservation-2".to_string()]
+    );
+    let snapshot = storage.snapshot().unwrap();
+    assert!(snapshot.payment_endpoint_reservations.is_empty());
+    assert!(snapshot.outbound_private_messages.is_empty());
+}
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_cancels_unpersisted_reservations_after_lease_change() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let canceled = Arc::new(Mutex::new(Vec::new()));
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        LeaseChangingInvalidReservedPrivateListPaymentAdapter {
+            storage: storage.clone(),
+            counterparty: counterparty.clone(),
+            canceled: canceled.clone(),
+        },
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .enqueue_private_payment_list_from_receiving_details(counterparty)
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    assert_eq!(
+        *canceled.lock().unwrap(),
+        vec!["reservation-1".to_string(), "reservation-2".to_string()]
+    );
+    let snapshot = storage.snapshot().unwrap();
+    assert!(snapshot.payment_endpoint_reservations.is_empty());
+    assert!(snapshot.outbound_private_messages.is_empty());
+}
+
+#[tokio::test]
+async fn test_unattempted_superseded_reservation_cleanup_cancels_without_claimed_message() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "reservation-1".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "one".into(),
+            },
+            expires_at: None,
+            attribution: HashMap::new(),
+        }],
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let latest = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "reservation-2".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "two".into(),
+            },
+            expires_at: None,
+            attribution: HashMap::new(),
+        }],
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut sent = tx
+                    .outbound_private_messages(&counterparty)
+                    .into_iter()
+                    .find(|message| message.outbound_message_id == latest.outbound_message_id)
+                    .unwrap();
+                sent.status = crate::OutboundPrivateMessageStatus::Sent;
+                tx.save_outbound_private_message(sent)?;
+                let claimed = tx.claim_next_outbound_private_message(
+                    &counterparty,
+                    FixedClock.now(),
+                    FixedClock.now() - ChronoDuration::seconds(1),
+                    FixedClock.now() - ChronoDuration::seconds(1),
+                );
+                assert!(claimed.is_none());
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let canceled = Arc::new(Mutex::new(Vec::new()));
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        InvalidReservedPrivateListPaymentAdapter {
+            canceled: canceled.clone(),
+        },
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let failures = sdk
+        .cancel_unattempted_superseded_reservations(&counterparty, None)
+        .await;
+
+    assert!(failures.is_empty());
+    assert_eq!(*canceled.lock().unwrap(), vec!["reservation-1".to_string()]);
+    let reservations = storage
+        .snapshot()
+        .unwrap()
+        .payment_endpoint_reservations
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(reservations.len(), 1);
+    assert_eq!(reservations[0].reservation_id, "reservation-2");
+}
+
+#[tokio::test]
+async fn test_terminal_private_list_reservation_cleanup_cancels_invalid_message_reservations() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let queued = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "reservation-1".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "one".into(),
+            },
+            expires_at: Some(FixedClock.now() - ChronoDuration::seconds(1)),
+            attribution: HashMap::new(),
+        }],
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut invalid = tx
+                    .outbound_private_messages(&counterparty)
+                    .into_iter()
+                    .find(|message| message.outbound_message_id == queued.outbound_message_id)
+                    .unwrap();
+                invalid.status = crate::OutboundPrivateMessageStatus::Invalid;
+                invalid.last_error =
+                    Some("Payment Endpoint Reservation expired before private list send".into());
+                tx.save_outbound_private_message(invalid)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let canceled = Arc::new(Mutex::new(Vec::new()));
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        InvalidReservedPrivateListPaymentAdapter {
+            canceled: canceled.clone(),
+        },
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let failures = sdk
+        .cancel_terminal_private_list_reservations(&counterparty, None)
+        .await;
+
+    assert!(failures.is_empty());
+    assert_eq!(*canceled.lock().unwrap(), vec!["reservation-1".to_string()]);
+    assert!(storage
+        .snapshot()
+        .unwrap()
+        .payment_endpoint_reservations
+        .is_empty());
+}
+
+#[tokio::test]
+async fn test_reservation_cleanup_skips_reused_reservation_from_newer_outbound_message() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_payment_endpoint_reservation(
+                    crate::storage::PaymentEndpointReservationRecord {
+                        reservation_id: "reservation-1".into(),
+                        counterparty,
+                        identifier: "btc-lightning-bolt11".into(),
+                        payload_hash: reservation_payload_hash("one"),
+                        outbound_message_id: 2,
+                        attribution: HashMap::new(),
+                        expires_at: None,
+                        cancellation_started_at: None,
+                        created_at: FixedClock.now(),
+                    },
+                );
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let canceled = Arc::new(Mutex::new(Vec::new()));
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        InvalidReservedPrivateListPaymentAdapter {
+            canceled: canceled.clone(),
+        },
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let cancellation = PaymentEndpointReservationCancellationRecord {
+        outbound_message_id: 1,
+        cancellation: PaymentEndpointReservationCancellation {
+            reservation_id: "reservation-1".into(),
+            counterparty: counterparty.clone(),
+            identifier: "btc-lightning-bolt11".into(),
+            payload_hash: reservation_payload_hash("one"),
+            attribution: HashMap::new(),
+        },
+    };
+
+    let failures = sdk
+        .cancel_reservation_records(vec![cancellation], None)
+        .await;
+
+    assert!(failures.is_empty());
+    assert!(canceled.lock().unwrap().is_empty());
+    assert_eq!(
+        storage
+            .snapshot()
+            .unwrap()
+            .payment_endpoint_reservations
+            .get(&(counterparty, "reservation-1".into()))
+            .unwrap()
+            .outbound_message_id,
+        2
+    );
+}
+
+#[tokio::test]
+async fn test_reservation_cleanup_rejects_stale_peer_operation_lease_before_adapter_cancellation() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let stale_lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_payment_endpoint_reservation(
+                    crate::storage::PaymentEndpointReservationRecord {
+                        reservation_id: "reservation-1".into(),
+                        counterparty: counterparty.clone(),
+                        identifier: "btc-lightning-bolt11".into(),
+                        payload_hash: reservation_payload_hash("one"),
+                        outbound_message_id: 1,
+                        attribution: HashMap::new(),
+                        expires_at: None,
+                        cancellation_started_at: None,
+                        created_at: FixedClock.now(),
+                    },
+                );
+                Ok(tx
+                    .claim_peer_link_operation(
+                        &counterparty,
+                        FixedClock.now(),
+                        FixedClock.now() + ChronoDuration::seconds(10),
+                    )
+                    .unwrap())
+            }
+        })
+        .await
+        .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let _ = tx.claim_peer_link_operation(
+                    &counterparty,
+                    FixedClock.now() + ChronoDuration::seconds(11),
+                    FixedClock.now() + ChronoDuration::seconds(71),
+                );
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let canceled = Arc::new(Mutex::new(Vec::new()));
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        InvalidReservedPrivateListPaymentAdapter {
+            canceled: canceled.clone(),
+        },
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let cancellation = PaymentEndpointReservationCancellationRecord {
+        outbound_message_id: 1,
+        cancellation: PaymentEndpointReservationCancellation {
+            reservation_id: "reservation-1".into(),
+            counterparty: counterparty.clone(),
+            identifier: "btc-lightning-bolt11".into(),
+            payload_hash: reservation_payload_hash("one"),
+            attribution: HashMap::new(),
+        },
+    };
+
+    let failures = sdk
+        .cancel_reservation_records(vec![cancellation], Some(&stale_lease))
+        .await;
+
+    assert_eq!(failures.len(), 1);
+    assert!(canceled.lock().unwrap().is_empty());
+    assert!(storage
+        .snapshot()
+        .unwrap()
+        .payment_endpoint_reservations
+        .contains_key(&(counterparty, "reservation-1".into())));
+}
+
+#[tokio::test]
+async fn test_reservation_cleanup_failure_keeps_cancellation_claim() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_payment_endpoint_reservation(
+                    crate::storage::PaymentEndpointReservationRecord {
+                        reservation_id: "reservation-1".into(),
+                        counterparty: counterparty.clone(),
+                        identifier: "btc-lightning-bolt11".into(),
+                        payload_hash: reservation_payload_hash("one"),
+                        outbound_message_id: 1,
+                        attribution: HashMap::new(),
+                        expires_at: None,
+                        cancellation_started_at: None,
+                        created_at: FixedClock.now(),
+                    },
+                );
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        FailingCancellationPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let cancellation = PaymentEndpointReservationCancellationRecord {
+        outbound_message_id: 1,
+        cancellation: PaymentEndpointReservationCancellation {
+            reservation_id: "reservation-1".into(),
+            counterparty: counterparty.clone(),
+            identifier: "btc-lightning-bolt11".into(),
+            payload_hash: reservation_payload_hash("one"),
+            attribution: HashMap::new(),
+        },
+    };
+
+    let failures = sdk
+        .cancel_reservation_records(vec![cancellation], None)
+        .await;
+
+    assert_eq!(failures.len(), 1);
+    let record = storage
+        .snapshot()
+        .unwrap()
+        .payment_endpoint_reservations
+        .get(&(counterparty, "reservation-1".into()))
+        .unwrap()
+        .clone();
+    assert_eq!(record.cancellation_started_at, Some(FixedClock.now()));
+}
+
+#[tokio::test]
+async fn test_reservation_cleanup_removes_claimed_record_after_lease_changes() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let lease = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_payment_endpoint_reservation(
+                    crate::storage::PaymentEndpointReservationRecord {
+                        reservation_id: "reservation-1".into(),
+                        counterparty: counterparty.clone(),
+                        identifier: "btc-lightning-bolt11".into(),
+                        payload_hash: reservation_payload_hash("one"),
+                        outbound_message_id: 1,
+                        attribution: HashMap::new(),
+                        expires_at: None,
+                        cancellation_started_at: None,
+                        created_at: FixedClock.now(),
+                    },
+                );
+                Ok(tx
+                    .claim_peer_link_operation(
+                        &counterparty,
+                        FixedClock.now(),
+                        FixedClock.now() + ChronoDuration::seconds(10),
+                    )
+                    .unwrap())
+            }
+        })
+        .await
+        .unwrap();
+    let canceled = Arc::new(Mutex::new(Vec::new()));
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        LeaseChangingCancellationPaymentAdapter {
+            storage: storage.clone(),
+            counterparty: counterparty.clone(),
+            canceled: canceled.clone(),
+        },
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let cancellation = PaymentEndpointReservationCancellationRecord {
+        outbound_message_id: 1,
+        cancellation: PaymentEndpointReservationCancellation {
+            reservation_id: "reservation-1".into(),
+            counterparty: counterparty.clone(),
+            identifier: "btc-lightning-bolt11".into(),
+            payload_hash: reservation_payload_hash("one"),
+            attribution: HashMap::new(),
+        },
+    };
+
+    let failures = sdk
+        .cancel_reservation_records(vec![cancellation], Some(&lease))
+        .await;
+
+    assert!(failures.is_empty());
+    assert_eq!(*canceled.lock().unwrap(), vec!["reservation-1".to_string()]);
+    assert!(!storage
+        .snapshot()
+        .unwrap()
+        .payment_endpoint_reservations
+        .contains_key(&(counterparty, "reservation-1".into())));
+}
+
+#[tokio::test]
+async fn test_process_outbound_private_messages_preserves_superseded_reservations_without_session()
+{
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "reservation-1".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "one".into(),
+            },
+            expires_at: None,
+            attribution: HashMap::new(),
+        }],
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let latest = queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "reservation-2".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "two".into(),
+            },
+            expires_at: None,
+            attribution: HashMap::new(),
+        }],
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let mut sent = tx
+                    .outbound_private_messages(&counterparty)
+                    .into_iter()
+                    .find(|message| message.outbound_message_id == latest.outbound_message_id)
+                    .unwrap();
+                sent.status = crate::OutboundPrivateMessageStatus::Sent;
+                tx.save_outbound_private_message(sent)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let canceled = Arc::new(Mutex::new(Vec::new()));
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        InvalidReservedPrivateListPaymentAdapter {
+            canceled: canceled.clone(),
+        },
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .process_outbound_private_messages(counterparty.clone())
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    assert!(canceled.lock().unwrap().is_empty());
+    assert_eq!(
+        storage
+            .snapshot()
+            .unwrap()
+            .payment_endpoint_reservations
+            .len(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_keeps_existing_reservation_on_error() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    queue_private_payment_list_with_reservations(
+        &storage,
+        &counterparty,
+        vec![PaymentEndpointReservation {
+            reservation_id: "existing-reservation".into(),
+            receiving_detail: ReceivingDetail {
+                identifier: "btc-lightning-bolt11".into(),
+                payload: "existing".into(),
+            },
+            expires_at: None,
+            attribution: HashMap::new(),
+        }],
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let canceled = Arc::new(Mutex::new(Vec::new()));
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        MixedExistingReservedPrivateListPaymentAdapter {
+            canceled: canceled.clone(),
+        },
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .enqueue_private_payment_list_from_receiving_details(counterparty)
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    assert_eq!(
+        *canceled.lock().unwrap(),
+        vec!["conflicting-reservation".to_string()]
+    );
+    assert_eq!(
+        storage
+            .snapshot()
+            .unwrap()
+            .payment_endpoint_reservations
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn test_current_private_payment_list_reads_cached_view_for_public_only_identity() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction(|tx| {
+            tx.save_identity_state(IdentityState {
+                public_key: Some(PubkyPublicKey::from_public_key(
+                    &pubky::Keypair::random().public_key(),
+                )),
+                capability: PubkyIdentityCapability::PublicOnly,
+                local_secret_available: false,
+                initialized_at: FixedClock.now(),
+                sign_out_generation: 0,
+            });
+            Ok(())
+        })
+        .await
+        .unwrap();
+    persist_private_stream_batch(
+        &storage,
+        counterparty.clone(),
+        vec![private_list_message("ln-private")],
+        None,
+        FixedClock.now(),
+    )
+    .await
+    .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let view = sdk
+        .current_private_payment_list(&counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(view.payment_endpoints["btc-lightning-bolt11"], "ln-private");
+}

--- a/paykit-sdk/src/runtime/tests/private_stream.rs
+++ b/paykit-sdk/src/runtime/tests/private_stream.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+#[tokio::test]
+async fn test_receive_private_messages_requires_pubky_session() {
+    let storage = InMemoryStorage::new();
+    let pubky = TestPubkySessionProvider { session: None };
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        pubky,
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: Some(vec![1, 2, 3]),
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 1,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let result = sdk.receive_private_messages(counterparty.clone()).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    assert!(storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+        })
+        .await
+        .unwrap()
+        .is_none());
+}

--- a/paykit-sdk/src/runtime/tests/public_endpoints.rs
+++ b/paykit-sdk/src/runtime/tests/public_endpoints.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+#[tokio::test]
+async fn test_sync_public_endpoints_requires_pubky_session() {
+    let storage = InMemoryStorage::new();
+    let pubky = TestPubkySessionProvider { session: None };
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        pubky,
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.sync_public_endpoints().await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+#[tokio::test]
+async fn test_sync_public_endpoints_rejects_reentrant_call() {
+    let storage = InMemoryStorage::new();
+    let pubky = TestPubkySessionProvider { session: None };
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        pubky,
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let _guard = sdk.claim_identity_operation("test operation").unwrap();
+
+    let result = sdk.sync_public_endpoints().await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+}

--- a/paykit-sdk/src/runtime/tests/receipts.rs
+++ b/paykit-sdk/src/runtime/tests/receipts.rs
@@ -1,0 +1,768 @@
+use super::*;
+
+#[tokio::test]
+async fn test_prepare_receipt_issuance_persists_pending_record() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty_keypair = pubky::Keypair::random();
+    let counterparty = PubkyPublicKey::from_public_key(&counterparty_keypair.public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let record = sdk
+        .prepare_receipt_issuance(
+            counterparty.clone(),
+            receipt_draft("550e8400-e29b-41d4-a716-446655440000"),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(record.counterparty, counterparty);
+    assert_eq!(record.status, ReceiptIssuanceStatus::PendingStorage);
+    assert!(record.stored_at.is_none());
+    assert!(record.outbound_message_id.is_none());
+
+    let stored = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let receipt_id = record.receipt_id.clone();
+            move |tx| Ok(tx.receipt_issuance_record(&counterparty, &receipt_id))
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let access = paykit_lib::parse_receipt_access_json(&stored.access_json).unwrap();
+    let receipt =
+        paykit_lib::decrypt_receipt(&stored.encrypted_receipt, &access.key, &access.location)
+            .unwrap();
+    assert_eq!(receipt.receipt_id.as_str(), record.receipt_id);
+    assert_eq!(
+        receipt.recipient_public_key,
+        counterparty_keypair.public_key()
+    );
+
+    let records = sdk.receipt_issuance_records(&counterparty).await.unwrap();
+    assert_eq!(records, vec![record]);
+}
+
+#[tokio::test]
+async fn test_receipt_listing_helpers_match_record_views() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let local_public_key = local_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key.clone()),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                tx.save_receipt_access_record(receipt_access_record(
+                    counterparty.clone(),
+                    "550e8400-e29b-41d4-a716-446655440000",
+                ));
+                tx.save_receipt_record(receipt_record(
+                    counterparty,
+                    "550e8400-e29b-41d4-a716-446655440000",
+                    local_public_key,
+                ));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    assert_eq!(
+        sdk.receipt_access_from(&counterparty).await.unwrap(),
+        sdk.receipt_access_records(&counterparty).await.unwrap()
+    );
+    assert_eq!(
+        sdk.receipt_access().await.unwrap(),
+        sdk.receipt_access_from(&counterparty).await.unwrap()
+    );
+    assert_eq!(
+        sdk.receipts_from(&counterparty).await.unwrap(),
+        sdk.receipt_records(&counterparty).await.unwrap()
+    );
+    assert_eq!(
+        sdk.receipts().await.unwrap(),
+        sdk.receipts_from(&counterparty).await.unwrap()
+    );
+
+    let issuance = sdk
+        .prepare_receipt_issuance(
+            counterparty.clone(),
+            receipt_draft("650e8400-e29b-41d4-a716-446655440001"),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        sdk.issued_receipts_to(&counterparty).await.unwrap(),
+        sdk.receipt_issuance_records(&counterparty).await.unwrap()
+    );
+    assert_eq!(sdk.issued_receipts().await.unwrap(), vec![issuance]);
+}
+
+#[tokio::test]
+async fn test_prepare_receipt_issuance_rejects_conflicting_reused_receipt_id() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let receipt_id = "550e8400-e29b-41d4-a716-446655440000";
+    let first = sdk
+        .prepare_receipt_issuance(counterparty.clone(), receipt_draft(receipt_id))
+        .await
+        .unwrap();
+    let second = sdk
+        .prepare_receipt_issuance(counterparty.clone(), receipt_draft(receipt_id))
+        .await
+        .unwrap();
+    let mut conflicting = receipt_draft(receipt_id);
+    conflicting.payment_reference = paykit_lib::PaymentReference::new("invoice-2026-0002").unwrap();
+
+    let result = sdk
+        .prepare_receipt_issuance(counterparty, conflicting)
+        .await;
+
+    assert_eq!(first, second);
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_prepare_receipt_issuance_rejects_reused_receipt_id_for_other_counterparty() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let first_counterparty =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let second_counterparty =
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let receipt_id = "550e8400-e29b-41d4-a716-446655440000";
+    sdk.prepare_receipt_issuance(first_counterparty, receipt_draft(receipt_id))
+        .await
+        .unwrap();
+
+    let result = sdk
+        .prepare_receipt_issuance(second_counterparty, receipt_draft(receipt_id))
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_issue_receipt_requires_retry_safe_receipt_id() {
+    let sdk = PaykitSdk::with_clock(
+        InMemoryStorage::new(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let mut draft = receipt_draft("550e8400-e29b-41d4-a716-446655440000");
+    draft.receipt_id = None;
+
+    let result = sdk.issue_receipt(counterparty, draft).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_process_receipt_issuance_without_session_preserves_prepared_record() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PrivateLinkCapable,
+            local_secret_available: true,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+    let record = sdk
+        .prepare_receipt_issuance(
+            counterparty.clone(),
+            receipt_draft("550e8400-e29b-41d4-a716-446655440000"),
+        )
+        .await
+        .unwrap();
+
+    let result = sdk
+        .process_receipt_issuance(counterparty.clone(), &record.receipt_id)
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    let records = sdk.receipt_issuance_records(&counterparty).await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].status, ReceiptIssuanceStatus::PendingStorage);
+    let stored = storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let receipt_id = record.receipt_id.clone();
+            move |tx| Ok(tx.receipt_issuance_record(&counterparty, &receipt_id))
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(stored.last_error.is_none());
+}
+
+#[tokio::test]
+async fn test_receipt_access_records_require_initialized_identity() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_receipt_access_record(receipt_access_record(
+                    counterparty,
+                    "550e8400-e29b-41d4-a716-446655440000",
+                ));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let views = sdk.receipt_access_records(&counterparty).await.unwrap();
+
+    assert!(views.is_empty());
+}
+
+#[tokio::test]
+async fn test_receipt_access_records_allow_public_only_identity() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let local_public_key = local_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                tx.save_receipt_access_record(receipt_access_record(
+                    counterparty,
+                    "550e8400-e29b-41d4-a716-446655440000",
+                ));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let views = sdk.receipt_access_records(&counterparty).await.unwrap();
+
+    assert_eq!(views.len(), 1);
+}
+
+#[tokio::test]
+async fn test_receipt_access_records_hide_conflicted_event_ids() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let receipt_id = "550e8400-e29b-41d4-a716-446655440000";
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let local_public_key = local_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                let access = receipt_access_record(counterparty.clone(), receipt_id);
+                tx.save_event_dedup_record(conflicted_event_dedup_record(&access));
+                tx.save_receipt_access_record(access);
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let views = sdk.receipt_access_records(&counterparty).await.unwrap();
+
+    assert!(views.is_empty());
+}
+
+#[tokio::test]
+async fn test_retrieve_receipt_reports_conflicted_access_before_missing_public_storage() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let receipt_id = "receipt-1";
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let local_public_key = local_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                let access = receipt_access_record(counterparty.clone(), receipt_id);
+                tx.save_event_dedup_record(conflicted_event_dedup_record(&access));
+                tx.save_receipt_access_record(access);
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.retrieve_receipt(counterparty, receipt_id).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_retrieve_receipt_reports_missing_access_before_public_storage() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let receipt_id = "receipt-1";
+    storage
+        .save_identity_state(IdentityState {
+            public_key: Some(local_public_key),
+            capability: PubkyIdentityCapability::PublicOnly,
+            local_secret_available: false,
+            initialized_at: FixedClock.now(),
+            sign_out_generation: 0,
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.retrieve_receipt(counterparty, receipt_id).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::RecoveryRequired(_))));
+}
+
+#[tokio::test]
+async fn test_retrieve_receipt_returns_cached_record_for_public_only_identity() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let receipt_id = "receipt-1";
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let local_public_key = local_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key.clone()),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                tx.save_receipt_record(receipt_record(counterparty, receipt_id, local_public_key));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let record = sdk
+        .retrieve_receipt(counterparty, receipt_id)
+        .await
+        .unwrap();
+
+    assert_eq!(record.receipt_id, receipt_id);
+}
+
+#[tokio::test]
+async fn test_retrieve_receipt_rejects_clean_mismatched_access_for_cached_receipt() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let receipt_id = "receipt-1";
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let local_public_key = local_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key.clone()),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                let mut access = receipt_access_record(counterparty.clone(), receipt_id);
+                access.event_id = "750e8400-e29b-41d4-a716-446655440000".into();
+                access.stream_item_id = 2;
+                access.payment_reference = "other-invoice".into();
+                tx.save_receipt_access_record(access);
+                tx.save_receipt_record(receipt_record(counterparty, receipt_id, local_public_key));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.retrieve_receipt(counterparty.clone(), receipt_id).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+    let access = storage
+        .transaction(|tx| {
+            Ok(tx
+                .receipt_access_records(&counterparty)
+                .into_iter()
+                .find(|record| record.receipt_id == receipt_id)
+                .unwrap())
+        })
+        .await
+        .unwrap();
+    assert_eq!(access.retrieval_status, ReceiptRetrievalStatus::Failed);
+}
+
+#[tokio::test]
+async fn test_retrieve_receipt_rejects_conflicted_access_for_cached_receipt() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let receipt_id = "receipt-1";
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let local_public_key = local_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key.clone()),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                let access = receipt_access_record(counterparty.clone(), receipt_id);
+                tx.save_event_dedup_record(conflicted_event_dedup_record(&access));
+                tx.save_receipt_access_record(access);
+                tx.save_receipt_record(receipt_record(counterparty, receipt_id, local_public_key));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.retrieve_receipt(counterparty, receipt_id).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_retrieve_receipt_rejects_conflicted_cached_provenance_with_clean_access_present() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let receipt_id = "receipt-1";
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let local_public_key = local_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key.clone()),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                let conflicted_access = receipt_access_record(counterparty.clone(), receipt_id);
+                let mut clean_access = receipt_access_record(counterparty.clone(), receipt_id);
+                clean_access.event_id = "750e8400-e29b-41d4-a716-446655440000".into();
+                clean_access.stream_item_id = 2;
+                tx.save_event_dedup_record(conflicted_event_dedup_record(&conflicted_access));
+                tx.save_receipt_access_record(conflicted_access);
+                tx.save_receipt_access_record(clean_access);
+                tx.save_receipt_record(receipt_record(counterparty, receipt_id, local_public_key));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.retrieve_receipt(counterparty, receipt_id).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Protocol(_))));
+}
+
+#[tokio::test]
+async fn test_receipt_records_filter_recipient_identity() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let wrong_recipient = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let issuer = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let issuer = issuer.clone();
+            let local_public_key = local_public_key.clone();
+            let wrong_recipient = wrong_recipient.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key.clone()),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                tx.save_receipt_record(receipt_record(
+                    issuer.clone(),
+                    "receipt-1",
+                    local_public_key,
+                ));
+                tx.save_receipt_record(receipt_record(issuer, "receipt-2", wrong_recipient));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let records = sdk.receipt_records(&issuer).await.unwrap();
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].receipt_id, "receipt-1");
+}
+
+#[tokio::test]
+async fn test_receipt_records_hide_conflicted_receipt_access_provenance() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let issuer = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let issuer = issuer.clone();
+            let local_public_key = local_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key.clone()),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                let access = receipt_access_record(issuer.clone(), "receipt-1");
+                tx.save_event_dedup_record(conflicted_event_dedup_record(&access));
+                tx.save_receipt_record(receipt_record(issuer, "receipt-1", local_public_key));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let records = sdk.receipt_records(&issuer).await.unwrap();
+
+    assert!(records.is_empty());
+}
+
+#[tokio::test]
+async fn test_retrieve_receipt_requires_public_storage_when_uncached() {
+    let storage = InMemoryStorage::new();
+    let local_public_key = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let receipt_id = "receipt-1";
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            let local_public_key = local_public_key.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(local_public_key),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                tx.save_receipt_access_record(receipt_access_record(counterparty, receipt_id));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk.retrieve_receipt(counterparty, receipt_id).await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+}
+
+fn receipt_draft(receipt_id: &str) -> ReceiptDraft {
+    ReceiptDraft {
+        receipt_id: Some(paykit_lib::ReceiptId::new(receipt_id).unwrap()),
+        payment_reference: paykit_lib::PaymentReference::new("invoice-2026-0001").unwrap(),
+        payment_request_id: None,
+        billing_period: None,
+        payment_endpoint_identifier: Some(
+            paykit_lib::PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap(),
+        ),
+        amount: Some(paykit_lib::PaymentAmount::new("0.001", "btc").unwrap()),
+        metadata: serde_json::json!({"settlement_id": "abc-123"})
+            .as_object()
+            .cloned()
+            .unwrap(),
+    }
+}

--- a/paykit-sdk/src/runtime/tests/recovery.rs
+++ b/paykit-sdk/src/runtime/tests/recovery.rs
@@ -1,0 +1,900 @@
+use super::*;
+
+#[tokio::test]
+async fn test_mark_private_recovery_pending_skips_newer_link_generation() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty: counterparty.clone(),
+                    link_snapshot: Some(vec![4, 5, 6]),
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 2,
+                    checkpointed_at: FixedClock.now(),
+                });
+                tx.claim_peer_link_operation(
+                    &counterparty,
+                    FixedClock.now(),
+                    FixedClock.now() + ChronoDuration::seconds(10),
+                )
+                .expect("lease should be available");
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let recovery_update = sdk
+        .mark_private_recovery_pending(&counterparty, Some(1))
+        .await
+        .unwrap();
+    assert!(matches!(recovery_update, RecoveryRequiredUpdate::Skipped));
+
+    let peer = crate::load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::Linked);
+    assert!(storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+        })
+        .await
+        .unwrap()
+        .is_some());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                let lease = tx
+                    .peer_link_operation_lease(&counterparty)
+                    .expect("test lease should still be active");
+                tx.release_peer_link_operation(&counterparty, lease.lease_id);
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let recovery_update = sdk
+        .mark_private_recovery_pending(&counterparty, Some(2))
+        .await
+        .unwrap();
+    assert!(matches!(
+        recovery_update,
+        RecoveryRequiredUpdate::Marked { new_episode: true }
+    ));
+
+    let peer = crate::load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::RecoveryRequired);
+    let link_state = crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(link_state.link_snapshot.is_none());
+    assert_eq!(link_state.generation, 3);
+    assert!(storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+        })
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn test_encrypted_link_recovery_marker_status_reports_peer_fields() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty,
+                    state: LinkedPeerState::RecoveryRequired,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 1,
+                    local_recovery_attempt_id: Some("650e8400-e29b-41d4-a716-446655440000".into()),
+                    local_recovery_marker_created_at: Some(FixedClock.now()),
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
+                    remote_recovery_marker_observed_at: Some(FixedClock.now()),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage,
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let status = sdk
+        .encrypted_link_recovery_marker_status(&counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(status.state, LinkedPeerState::RecoveryRequired);
+    assert_eq!(
+        status.local_attempt_id.as_deref(),
+        Some("650e8400-e29b-41d4-a716-446655440000")
+    );
+    assert_eq!(
+        status.remote_attempt_id.as_deref(),
+        Some("550e8400-e29b-41d4-a716-446655440000")
+    );
+    assert!(!status.remote_marker_changed);
+}
+
+#[tokio::test]
+async fn test_publish_recovery_marker_disabled_does_not_mutate_link_state() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: Some(vec![1, 2, 3]),
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 7,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig {
+            encrypted_link_recovery_markers: EncryptedLinkRecoveryMarkerPolicy::Disabled,
+            ..PaykitSdkConfig::default()
+        },
+        FixedClock,
+    );
+
+    let result = sdk
+        .publish_encrypted_link_recovery_marker(counterparty.clone())
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    let peer = crate::load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::Linked);
+    let link_state = crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(link_state.link_snapshot, Some(vec![1, 2, 3]));
+    assert_eq!(link_state.generation, 7);
+}
+
+#[tokio::test]
+async fn test_publish_recovery_marker_public_only_does_not_mutate_link_state() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_identity_state(IdentityState {
+                    public_key: Some(PubkyPublicKey::from_public_key(
+                        &pubky::Keypair::random().public_key(),
+                    )),
+                    capability: PubkyIdentityCapability::PublicOnly,
+                    local_secret_available: false,
+                    initialized_at: FixedClock.now(),
+                    sign_out_generation: 0,
+                });
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: Some(vec![1, 2, 3]),
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 7,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .publish_encrypted_link_recovery_marker(counterparty.clone())
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Identity { .. })));
+    let peer = crate::load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::Linked);
+    let link_state = crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(link_state.link_snapshot, Some(vec![1, 2, 3]));
+    assert_eq!(link_state.generation, 7);
+}
+
+#[tokio::test]
+async fn test_remote_recovery_marker_observation_rejects_active_peer_lease() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty: counterparty.clone(),
+                    link_snapshot: Some(vec![1, 2, 3]),
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 7,
+                    checkpointed_at: FixedClock.now(),
+                });
+                tx.claim_peer_link_operation(
+                    &counterparty,
+                    FixedClock.now(),
+                    FixedClock.now() + ChronoDuration::seconds(10),
+                )
+                .expect("lease should be available");
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let result = sdk
+        .mark_remote_recovery_marker_observed_if_needed(
+            &counterparty,
+            "650e8400-e29b-41d4-a716-446655440000",
+            FixedClock.now() + ChronoDuration::seconds(1),
+        )
+        .await;
+
+    assert!(matches!(result, Err(PaykitSdkError::Policy(_))));
+    let peer = crate::load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::Linked);
+    assert!(peer.remote_recovery_attempt_id.is_none());
+    let link_state = crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(link_state.link_snapshot, Some(vec![1, 2, 3]));
+    assert_eq!(link_state.generation, 7);
+    assert!(storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+        })
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_remote_recovery_marker_observation_ignores_stale_marker() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: Some(vec![1, 2, 3]),
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 7,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let changed = sdk
+        .mark_remote_recovery_marker_observed_if_needed(
+            &counterparty,
+            "650e8400-e29b-41d4-a716-446655440000",
+            FixedClock.now() - ChronoDuration::seconds(1),
+        )
+        .await
+        .unwrap();
+
+    assert!(!changed);
+    let peer = crate::load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::Linked);
+    assert!(peer.remote_recovery_attempt_id.is_none());
+    let link_state = crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(link_state.link_snapshot, Some(vec![1, 2, 3]));
+    assert_eq!(link_state.generation, 7);
+}
+
+#[tokio::test]
+async fn test_remote_recovery_marker_observation_accepts_same_second_marker() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: Some(vec![1, 2, 3]),
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 7,
+                    checkpointed_at: FixedClock.now() + ChronoDuration::milliseconds(500),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let changed = sdk
+        .mark_remote_recovery_marker_observed_if_needed(
+            &counterparty,
+            "650e8400-e29b-41d4-a716-446655440000",
+            FixedClock.now(),
+        )
+        .await
+        .unwrap();
+
+    assert!(changed);
+    let peer = crate::load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::RecoveryRequired);
+    assert_eq!(
+        peer.remote_recovery_attempt_id.as_deref(),
+        Some("650e8400-e29b-41d4-a716-446655440000")
+    );
+    let link_state = crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(link_state.link_snapshot.is_none());
+    assert_eq!(link_state.generation, 8);
+}
+
+#[tokio::test]
+async fn test_remote_recovery_marker_observation_preserves_newer_handshake() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linking,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: None,
+                    handshake_snapshot: Some(vec![1, 2, 3]),
+                    handshake_role: Some(EncryptedLinkHandshakeRole::Initiator),
+                    generation: 7,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let changed = sdk
+        .mark_remote_recovery_marker_observed_if_needed(
+            &counterparty,
+            "650e8400-e29b-41d4-a716-446655440000",
+            FixedClock.now() - ChronoDuration::seconds(1),
+        )
+        .await
+        .unwrap();
+
+    assert!(!changed);
+    let peer = crate::load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::Linking);
+    assert!(peer.remote_recovery_attempt_id.is_none());
+    let link_state = crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(link_state.handshake_snapshot, Some(vec![1, 2, 3]));
+    assert_eq!(
+        link_state.handshake_role,
+        Some(EncryptedLinkHandshakeRole::Initiator)
+    );
+    assert_eq!(link_state.generation, 7);
+}
+
+#[tokio::test]
+async fn test_mark_private_recovery_pending_skips_active_peer_lease() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty: counterparty.clone(),
+                    link_snapshot: Some(vec![1, 2, 3]),
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 7,
+                    checkpointed_at: FixedClock.now(),
+                });
+                tx.claim_peer_link_operation(
+                    &counterparty,
+                    FixedClock.now(),
+                    FixedClock.now() + ChronoDuration::seconds(10),
+                )
+                .expect("lease should be available");
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let update = sdk
+        .mark_private_recovery_pending(&counterparty, Some(7))
+        .await
+        .unwrap();
+
+    assert!(matches!(update, RecoveryRequiredUpdate::Skipped));
+    let peer = crate::load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::Linked);
+    let link_state = crate::load_encrypted_link_state(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(link_state.link_snapshot, Some(vec![1, 2, 3]));
+    assert_eq!(link_state.generation, 7);
+    assert!(storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| Ok(tx.peer_link_operation_lease(&counterparty))
+        })
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn test_automatic_recovery_marker_publish_records_missing_session() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::RecoveryRequired,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 1,
+                    local_recovery_attempt_id: None,
+                    local_recovery_marker_created_at: None,
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: None,
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 7,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    sdk.publish_local_recovery_marker_if_possible(&counterparty, true)
+        .await;
+
+    let status = sdk
+        .encrypted_link_recovery_marker_status(&counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        status.local_marker_last_error.as_deref(),
+        Some("no Pubky session available")
+    );
+}
+
+#[tokio::test]
+async fn test_automatic_recovery_marker_remove_records_missing_session() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: Some("650e8400-e29b-41d4-a716-446655440000".into()),
+                    local_recovery_marker_created_at: Some(FixedClock.now()),
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    sdk.remove_local_recovery_marker_if_recorded(&counterparty)
+        .await
+        .unwrap();
+
+    let status = sdk
+        .encrypted_link_recovery_marker_status(&counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        status.local_marker_last_error.as_deref(),
+        Some("no Pubky session available")
+    );
+}
+
+#[tokio::test]
+async fn test_mark_private_recovery_pending_preserves_marker_until_publish() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::Linked,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 0,
+                    local_recovery_attempt_id: Some("650e8400-e29b-41d4-a716-446655440000".into()),
+                    local_recovery_marker_created_at: Some(FixedClock.now()),
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
+                    remote_recovery_marker_observed_at: Some(FixedClock.now()),
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: Some(vec![4, 5, 6]),
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 2,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let recovery_update = sdk
+        .mark_private_recovery_pending(&counterparty, Some(2))
+        .await
+        .unwrap();
+    assert!(matches!(
+        recovery_update,
+        RecoveryRequiredUpdate::Marked { new_episode: true }
+    ));
+
+    let peer = crate::load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(peer.state, LinkedPeerState::RecoveryRequired);
+    assert_eq!(
+        peer.local_recovery_attempt_id.as_deref(),
+        Some("650e8400-e29b-41d4-a716-446655440000")
+    );
+    assert_eq!(
+        peer.remote_recovery_attempt_id.as_deref(),
+        Some("550e8400-e29b-41d4-a716-446655440000")
+    );
+}
+
+#[test]
+fn test_local_recovery_marker_must_belong_to_current_episode() {
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    let recovery_started_at = Utc.with_ymd_and_hms(2026, 6, 3, 12, 0, 0).unwrap();
+    let previous_episode_marker_at = Utc.with_ymd_and_hms(2026, 6, 3, 11, 59, 0).unwrap();
+    let current_episode_marker_at = Utc.with_ymd_and_hms(2026, 6, 3, 12, 1, 0).unwrap();
+    let mut peer = LinkedPeerRecord {
+        counterparty,
+        state: LinkedPeerState::RecoveryRequired,
+        last_sync_at: Some(recovery_started_at),
+        last_private_receive_at: None,
+        failure_count: 1,
+        local_recovery_attempt_id: Some("650e8400-e29b-41d4-a716-446655440000".into()),
+        local_recovery_marker_created_at: Some(previous_episode_marker_at),
+        local_recovery_marker_last_error: None,
+        remote_recovery_attempt_id: None,
+        remote_recovery_marker_observed_at: None,
+    };
+
+    assert!(!local_recovery_marker_belongs_to_current_episode(&peer));
+
+    peer.local_recovery_marker_created_at = Some(current_episode_marker_at);
+
+    assert!(local_recovery_marker_belongs_to_current_episode(&peer));
+}
+
+#[tokio::test]
+async fn test_mark_private_recovery_pending_preserves_ongoing_local_marker() {
+    let storage = InMemoryStorage::new();
+    let counterparty = PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key());
+    storage
+        .transaction({
+            let counterparty = counterparty.clone();
+            move |tx| {
+                tx.save_linked_peer(LinkedPeerRecord {
+                    counterparty: counterparty.clone(),
+                    state: LinkedPeerState::RecoveryRequired,
+                    last_sync_at: Some(FixedClock.now()),
+                    last_private_receive_at: None,
+                    failure_count: 1,
+                    local_recovery_attempt_id: Some("650e8400-e29b-41d4-a716-446655440000".into()),
+                    local_recovery_marker_created_at: Some(FixedClock.now()),
+                    local_recovery_marker_last_error: None,
+                    remote_recovery_attempt_id: None,
+                    remote_recovery_marker_observed_at: None,
+                });
+                tx.save_encrypted_link_state(EncryptedLinkStateRecord {
+                    counterparty,
+                    link_snapshot: Some(vec![4, 5, 6]),
+                    handshake_snapshot: None,
+                    handshake_role: None,
+                    generation: 2,
+                    checkpointed_at: FixedClock.now(),
+                });
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    let sdk = PaykitSdk::with_clock(
+        storage.clone(),
+        TestPubkySessionProvider { session: None },
+        TestPaymentAdapter,
+        PaykitSdkConfig::default(),
+        FixedClock,
+    );
+
+    let recovery_update = sdk
+        .mark_private_recovery_pending(&counterparty, Some(2))
+        .await
+        .unwrap();
+    assert!(matches!(
+        recovery_update,
+        RecoveryRequiredUpdate::Marked { new_episode: false }
+    ));
+
+    let peer = crate::load_linked_peer(&storage, &counterparty)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        peer.local_recovery_attempt_id.as_deref(),
+        Some("650e8400-e29b-41d4-a716-446655440000")
+    );
+}


### PR DESCRIPTION
Stack PR 5/6. Adds runtime workflow tests across identity/session behavior, public endpoint sync, Encrypted Links, private stream receive, outbound private queue processing, Payment Requests, receipts, contact payment resolution, contacts/profiles, backup restore, and recovery markers.