### PR TITLE
Document app-owned Paykit runtime model

### DIFF
--- a/paykit-sdk/README.md
+++ b/paykit-sdk/README.md
@@ -18,6 +18,13 @@ Payment execution, settlement detection, balances, route policy, product UI,
 and app backup transport stay outside the SDK and are provided by application
 or payment-adapter code.
 
+The SDK is designed around an app-owned Paykit runtime model. One SDK runtime
+represents one app or receiver runtime with its own Paykit state: Encrypted
+Links, private stream checkpoints, outbound queues, receipts, requests,
+reservations, recovery state, and backup data. Multiple apps can be linked or
+aggregated explicitly, but they do not share one private Paykit runtime by
+default.
+
 ## Current Scope
 
 Implemented in this Rust SDK crate:
@@ -49,6 +56,12 @@ Apps construct `PaykitSdk` with three pieces:
   during sign-out
 - a `PaymentAdapter` that supplies receiving details, endpoint selection, and
   payment-target construction
+
+The session provider is only the boundary for live Pubky access. It is not a
+requirement to use Ring or another wallet as an identity coordinator before an
+app can use Paykit. The app or binding layer decides how session material is
+created, stored, unlocked, or imported, then exposes the current access to the
+SDK.
 
 Typical startup:
 
@@ -122,7 +135,9 @@ Paykit Protocol route. By default the SDK uses:
 
 Apps can set `profile_namespace` to use their own public app namespace, such as
 `bitkit.to`. That changes only these SDK profile/contact helper paths. Public
-Payment Endpoints stay under `/pub/paykit/v0/`.
+Payment Endpoints stay under `/pub/paykit/v0/`, and Encrypted Link/private
+runtime state is still owned by this SDK runtime. `profile_namespace` is not a
+shared-runtime selector or app-specific core Paykit path prefix.
 
 The SDK rejects `pubky.app` as a configured profile namespace only as a local
 guardrail against accidental writes through Paykit helpers. It is not a

--- a/paykit-sdk/src/adapters.rs
+++ b/paykit-sdk/src/adapters.rs
@@ -5,11 +5,10 @@ use std::{collections::HashMap, fmt};
 
 use crate::{identity::PubkyPublicKey, PaykitSdkError, PubkySessionAccess, Result};
 
-/// Provides live Pubky session access to the SDK.
+/// Provides live Pubky session access to one app-owned Paykit runtime.
 ///
-/// The provider owns platform-specific auth handoff, secure persistence, and
-/// key rotation. The SDK consumes the returned Pubky access for Paykit
-/// workflows.
+/// The provider is the boundary where the app or bindings expose current Pubky
+/// access from platform storage and auth flows.
 #[async_trait]
 pub trait PubkySessionProvider: Send + Sync {
     /// Load live Pubky access for storage and Encrypted Link workflows.
@@ -26,7 +25,11 @@ pub trait PubkySessionProvider: Send + Sync {
     async fn clear_session_access(&self) -> Result<()>;
 }
 
-/// Adapter for payment-method-specific endpoint publication and selection.
+/// Adapter for payment-method-specific receiving and payment-target selection.
+///
+/// Paykit SDK routes endpoints and private messages, but payment execution,
+/// settlement detection, proof validation, balances, fees, and method-specific
+/// risk policy remain adapter or application responsibilities.
 #[async_trait]
 pub trait PaymentAdapter: Send + Sync {
     /// Return current receiving details for a scope.

--- a/paykit-sdk/src/config.rs
+++ b/paykit-sdk/src/config.rs
@@ -45,7 +45,8 @@ pub struct PaykitSdkConfig {
     ///
     /// This is a local SDK convention for Paykit-facing profile, blob, and
     /// public contact marker helpers. Pubky session permissions remain the
-    /// authority for what a caller can actually write.
+    /// authority for what a caller can actually write. This does not change
+    /// core Paykit Protocol paths or split private runtime state.
     #[serde(default = "default_profile_namespace")]
     pub profile_namespace: String,
     /// Public endpoint management scope.

--- a/paykit-sdk/src/identity.rs
+++ b/paykit-sdk/src/identity.rs
@@ -67,13 +67,15 @@ impl From<PubkyPublicKey> for String {
     }
 }
 
-/// Pubky capability state visible to Paykit workflows.
+/// Pubky capability state for one app-owned Paykit runtime.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum PubkyIdentityCapability {
     /// No Pubky identity is initialized, or explicit sign-out completed.
     SignedOut,
     /// Public Pubky operations may work, but private links cannot be established.
+    ///
+    /// Private Link workflows require `PrivateLinkCapable`.
     PublicOnly,
     /// Public operations and Encrypted Links can work.
     PrivateLinkCapable,
@@ -120,7 +122,7 @@ impl From<[u8; 32]> for PubkyLocalSecretKey {
     }
 }
 
-/// Live Pubky access used by SDK workflows that touch Pubky storage or links.
+/// Live Pubky access used by one SDK runtime for Pubky storage or links.
 ///
 /// Providers must ensure the optional local secret key belongs to the local
 /// session public key. The SDK treats a present secret key as private-link
@@ -168,7 +170,7 @@ impl fmt::Debug for PubkySessionAccess {
     }
 }
 
-/// Durable identity state tracked by the SDK.
+/// Durable identity state tracked by one SDK runtime.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdentityState {
     /// Current local public key, when signed in.

--- a/paykit-sdk/src/runtime.rs
+++ b/paykit-sdk/src/runtime.rs
@@ -141,7 +141,7 @@ pub struct InitializationReport {
     pub live_session_available: bool,
 }
 
-/// Stateful Paykit SDK runtime for one local Pubky identity.
+/// Stateful Paykit SDK runtime for one app-owned local Paykit runtime.
 pub struct PaykitSdk<S, K, P, C = SystemClock> {
     storage: S,
     pubky: K,

--- a/specs/paykit-sdk-bindings.md
+++ b/specs/paykit-sdk-bindings.md
@@ -15,6 +15,9 @@ default app API.
 - Expose SDK workflows, not raw storage internals.
 - Keep the Rust SDK responsible for durable state transitions, ordering,
   dedupe, recovery, and validation.
+- Preserve the app-owned runtime model. One binding handle represents one app,
+  wallet, or receiver runtime; bindings should not require Ring, another
+  wallet, or a shared identity coordinator before an app can use Paykit.
 - Keep platform APIs ergonomic and hard to construct incorrectly.
 - Treat storage, session access, payment execution, and UI as app-provided
   integration points.
@@ -43,7 +46,7 @@ not need them for ordinary Paykit runtime workflows.
 
 ## Runtime Handle
 
-Bindings should expose one opaque SDK handle per local Pubky identity.
+Bindings should expose one opaque SDK handle per app-owned local Paykit runtime.
 
 The handle should own:
 
@@ -118,6 +121,12 @@ devtools/logging exposure, and can add bridge-size and performance risks.
 
 Bindings should make session capability explicit.
 
+The session binding is the boundary where the app exposes live Pubky access to
+its own Paykit runtime. It should not be modeled as a global identity
+coordinator shared by all Paykit apps. A binding may support Ring or other auth
+handoff flows, but ordinary Paykit integration should not require users to
+install or authorize through another app first.
+
 The platform session provider should return one of:
 
 - no live session access
@@ -133,11 +142,11 @@ later.
 
 The binding-level session API should not ask Swift, Kotlin, or React Native to
 construct Rust `pubky::PubkySession` or `pubky::Pubky` values directly. For
-ordinary app use, SDK bindings should own Pubky session construction from
-app-provided session material, imported session secrets, or an opaque Ring/auth
-handoff result. If a platform binding cannot own that construction, it must make
-the required Pubky binding dependency explicit instead of implying that no Pubky
-integration is needed.
+ordinary app use, SDK bindings should turn app-provided session material,
+imported session secrets, or an auth handoff result into the Rust Pubky access
+needed by the SDK. If a platform binding cannot own that construction, it must
+make the required Pubky binding dependency explicit instead of implying that no
+Pubky integration is needed.
 
 The session provider should expose only the platform state the SDK needs:
 
@@ -290,7 +299,7 @@ backup data.
 
 Bindings should expose high-level workflows before low-level records:
 
-- initialize identity
+- initialize runtime
 - sign out
 - sync public Payment Endpoints
 - publish/fetch Paykit Profile

--- a/specs/paykit-sdk.md
+++ b/specs/paykit-sdk.md
@@ -13,6 +13,24 @@ contact/payment workflows, and ergonomic platform APIs.
 The SDK should be product-neutral and payment-method-neutral. It should support
 payment methods through adapters without baking any one method into the SDK.
 
+## App-Owned Runtime Model
+
+The SDK uses an app-owned Paykit runtime model. One SDK runtime represents one
+app, wallet, or receiver runtime that owns its own Paykit state:
+Encrypted Link snapshots, private stream checkpoints, outbound queues, Payment
+Requests, Receipts, Payment Endpoint Reservations, recovery state, and backup
+data.
+
+The app or binding layer provides live Pubky session access to that runtime.
+The SDK consumes that access for Paykit workflows, but it is not a shared
+identity coordinator and does not require Ring or another wallet before an app
+can integrate Paykit.
+
+Multiple apps that belong to the same human identity can be linked, discovered,
+or aggregated explicitly above the app-owned runtime model. That does not mean
+all apps silently share one private Paykit runtime, one Encrypted Link state
+machine, or one payment execution state.
+
 ## Design Principles
 
 - Keep `paykit-lib` stateless. It validates and sends protocol objects, but it
@@ -52,9 +70,9 @@ The system should have three main layers:
   records.
 
 The SDK may still accept narrow platform hooks for secure session persistence,
-auth UI/Ring session handoff, custom profile/contact storage, scheduling, and
-logging. Those hooks should not require each app to reimplement Pubky Paykit
-logic.
+auth UI, custom profile/contact storage, scheduling, and logging. Those hooks
+should not require each app to reimplement Pubky Paykit logic or to depend on a
+separate shared-runtime coordinator.
 
 The SDK should depend on `paykit-lib`, not replace it. Platform apps should
 prefer SDK bindings for normal product workflows and use `paykit-lib` bindings
@@ -155,7 +173,8 @@ protocol-level integrations.
 
 ## Core Runtime Object
 
-The SDK should expose a single runtime object per local Pubky identity:
+The SDK should expose a single runtime object per app-owned local Paykit
+runtime:
 
 ```rust
 pub struct PaykitSdk<S, K, P, C> {
@@ -220,7 +239,8 @@ Production apps should provide a durable implementation.
 
 ### PubkySessionProvider
 
-Required for loading and storing local Pubky session material.
+Required for loading live Pubky session access for the app-owned Paykit
+runtime.
 
 ```rust
 pub trait PubkySessionProvider {
@@ -233,7 +253,9 @@ pub trait PubkySessionProvider {
 `PubkySessionAccess` provides the live authenticated `PubkySession`, Pubky
 client for counterparty homeserver access, and optional `PubkyLocalSecretKey`
 needed for Encrypted Links. The SDK derives and persists public `IdentityState`
-from that access during initialization.
+from that access during initialization. The provider is the narrow boundary
+where the app or bindings expose current session access; it is not a Ring
+dependency or a shared identity/runtime coordinator.
 
 If `load_session_access` returns `None`, no live session access is currently
 available. Ordinary refreshes must preserve the last identity-scoped state and
@@ -264,9 +286,10 @@ succeed. A same-identity transition from `PrivateLinkCapable` to `PublicOnly`
 must preserve private SDK state; only explicit sign-out, identity change, or an
 explicit key-loss/key-rotation operation should delete it.
 
-The SDK should provide high-level import/export/sign-out APIs itself. The
-provider is the narrow platform hook for secure storage and auth-session handoff,
-not a separate Pubky SDK that integrators must use.
+The SDK should provide high-level initialization, backup/export/restore, and
+sign-out APIs itself. The provider is the narrow platform hook for secure
+storage and auth-session handoff, not a separate Pubky SDK or identity product
+that integrators must use.
 
 ### Paykit Profile And Contact Namespace
 
@@ -288,7 +311,8 @@ profile/contact namespace segment. For example, `profile_namespace =
 "bitkit.to"` makes Paykit Profile and contact marker helpers use
 `/pub/bitkit.to/profile.json`, `/pub/bitkit.to/blobs/...`, and
 `/pub/bitkit.to/contacts/...`. This does not change core Paykit Protocol paths
-such as public Payment Endpoints.
+such as public Payment Endpoints, and it does not create app-specific private
+runtime isolation under one shared key.
 
 `image_uri` may point at the configured blob prefix or another public image
 location. The SDK can publish/delete Paykit blobs under the configured blob
@@ -1228,6 +1252,7 @@ These should stay outside Paykit SDK:
 - localized copy and navigation
 - app backup transport and cloud sync
 - seed/secret derivation policy unless standardized
+- shared identity coordination or cross-app aggregation policy
 
 ## Test Plan
 
@@ -1276,3 +1301,5 @@ Platform tests:
 - Multi-app and multi-device Paykit identity synchronization, including how
   active Encrypted Link checkpoints, outbound queues, and recurring Payment
   Request execution coordinate without rewinding private message counters.
+- Explicit connected-key or linked-receiver records for aggregating multiple
+  app-owned Paykit runtimes under one user identity.


### PR DESCRIPTION
## Summary

Clarifies that the Paykit SDK uses an app-owned runtime model: one SDK runtime owns one app/wallet/receiver runtime's Paykit state, while any cross-app linking or aggregation sits above that model.

Updates the SDK README, SDK architecture spec, bindings plan, and a few public Rustdocs so the session/provider boundary is described consistently:

- `PubkySessionProvider` exposes live Pubky access to a runtime; it is not a shared identity coordinator.
- `profile_namespace` affects Paykit Profile/contact helper paths only, not core Paykit Protocol paths or private runtime state.
- Bindings should expose one SDK handle per app-owned local Paykit runtime.

## Checks

- `git diff --check`
- `cargo fmt --check`
- `cargo doc -p paykit-sdk --no-deps`