### PR TITLE
Add SDK Pubky session bootstrap helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,6 +3155,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "hex",
+ "hmac",
  "paykit-lib",
  "pubky",
  "serde",
@@ -3162,6 +3164,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
+ "url",
  "zeroize",
 ]
 

--- a/paykit-sdk/Cargo.toml
+++ b/paykit-sdk/Cargo.toml
@@ -17,12 +17,15 @@ categories = ["network-programming", "finance"]
 anyhow = "1.0.102"
 async-trait = "0.1"
 chrono = { version = "0.4.44", default-features = false, features = ["clock", "serde", "std"] }
+hex = "0.4"
+hmac = "0.12"
 paykit-lib = { path = "../paykit-lib", version = "0.1.0-rc12" }
 pubky = "0.8.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "2.0.18"
+url = "2"
 zeroize = "1"
 
 [dev-dependencies]

--- a/paykit-sdk/README.md
+++ b/paykit-sdk/README.md
@@ -109,6 +109,9 @@ Common workflows:
   exposing live access through a `PubkySessionProvider`; exported session
   secrets and auth URLs must be treated as secret material, and session export
   is an explicit call on the bootstrap result
+- when deriving a Pubky key from a wallet seed, use a stable app/runtime label
+  such as `bitkit.to`; the same seed and label derive the same key, while
+  changing the label derives a different Paykit runtime identity
 - call `receive_private_messages` before deriving private Payment Lists,
   Payment Requests, Receipt Access state, or resolving a contact payment when
   the freshest private endpoints matter

--- a/paykit-sdk/README.md
+++ b/paykit-sdk/README.md
@@ -30,7 +30,8 @@ default.
 Implemented in this Rust SDK crate:
 
 - SDK runtime facade and atomic storage adapter contract
-- Pubky identity capability tracking and sign-out handling
+- Pubky session bootstrap helpers, identity capability tracking, and sign-out
+  handling
 - public Payment Endpoint sync
 - Encrypted Link setup, private stream intake, outbound retries, and recovery
   marker workflows
@@ -89,6 +90,8 @@ Common workflows:
 - call `initialize` on startup to refresh identity capability from the Pubky
   provider when live session access is available
 - call `sync_public_endpoints` after local receiving details change
+- request and validate `config.required_session_capabilities()` for full SDK
+  auth/session handoff
 - set `profile_namespace` to a namespace segment such as `bitkit.to` when
   profile/contact helpers should publish under `/pub/bitkit.to/...`
 - use `publish_paykit_profile` / `fetch_paykit_profile` for configured
@@ -101,6 +104,11 @@ Common workflows:
   profile and follows data
 - use `resolve_contact_profile` when contact display should prefer Paykit
   Profile and fall back to Pubky Profile
+- use `PubkySessionBootstrap` for common Pubky signup, signin, session import,
+  capability-checked auth handoff, and `pubky://` normalization flows before
+  exposing live access through a `PubkySessionProvider`; exported session
+  secrets and auth URLs must be treated as secret material, and session export
+  is an explicit call on the bootstrap result
 - call `receive_private_messages` before deriving private Payment Lists,
   Payment Requests, Receipt Access state, or resolving a contact payment when
   the freshest private endpoints matter

--- a/paykit-sdk/src/config.rs
+++ b/paykit-sdk/src/config.rs
@@ -127,17 +127,14 @@ impl PaykitSdkConfig {
 
     /// Return the Pubky session capabilities required by this SDK configuration.
     pub fn required_session_capabilities(&self) -> String {
-        let mut capabilities = vec![
-            PAYKIT_SESSION_CAPABILITIES.to_string(),
-            format!("{}:rw", self.paykit_profile_path()),
-            format!("{}:rw", self.paykit_profile_blob_path_prefix()),
-        ];
-
-        if self.public_contact_sharing == PublicContactSharingPolicy::ConfiguredPublicNamespace {
-            capabilities.push(format!("{}:rw", self.public_contact_path_prefix()));
+        if self.profile_namespace == DEFAULT_PROFILE_NAMESPACE {
+            return PAYKIT_SESSION_CAPABILITIES.to_string();
         }
 
-        capabilities.join(",")
+        format!(
+            "{},/pub/{}:rw",
+            PAYKIT_SESSION_CAPABILITIES, self.profile_namespace
+        )
     }
 }
 

--- a/paykit-sdk/src/config.rs
+++ b/paykit-sdk/src/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-use crate::identity::PubkyPublicKey;
+use crate::{identity::PubkyPublicKey, pubky_session::PAYKIT_SESSION_CAPABILITIES};
 
 /// Default namespace segment for SDK profile/contact public data.
 ///
@@ -123,6 +123,21 @@ impl PaykitSdkConfig {
             self.public_contact_path_prefix(),
             public_key.as_str()
         )
+    }
+
+    /// Return the Pubky session capabilities required by this SDK configuration.
+    pub fn required_session_capabilities(&self) -> String {
+        let mut capabilities = vec![
+            PAYKIT_SESSION_CAPABILITIES.to_string(),
+            format!("{}:rw", self.paykit_profile_path()),
+            format!("{}:rw", self.paykit_profile_blob_path_prefix()),
+        ];
+
+        if self.public_contact_sharing == PublicContactSharingPolicy::ConfiguredPublicNamespace {
+            capabilities.push(format!("{}:rw", self.public_contact_path_prefix()));
+        }
+
+        capabilities.join(",")
     }
 }
 

--- a/paykit-sdk/src/config/tests.rs
+++ b/paykit-sdk/src/config/tests.rs
@@ -34,6 +34,10 @@ fn test_config_builds_default_profile_namespace_paths() {
         config.public_contact_path(&public_key),
         format!("/pub/paykit/contacts/{}.json", public_key.as_str())
     );
+    assert_eq!(
+        config.required_session_capabilities(),
+        "/pub/paykit/v0/:rw,/pub/paykit/profile.json:rw,/pub/paykit/blobs/:rw"
+    );
 }
 
 #[test]
@@ -52,6 +56,23 @@ fn test_config_allows_custom_profile_namespace_segment() {
     assert_eq!(
         config.public_contact_path_prefix(),
         "/pub/bitkit.to/contacts/"
+    );
+    assert_eq!(
+        config.required_session_capabilities(),
+        "/pub/paykit/v0/:rw,/pub/bitkit.to/profile.json:rw,/pub/bitkit.to/blobs/:rw"
+    );
+}
+
+#[test]
+fn test_config_adds_contact_capability_when_public_contact_sharing_enabled() {
+    let config = PaykitSdkConfig {
+        public_contact_sharing: PublicContactSharingPolicy::ConfiguredPublicNamespace,
+        ..PaykitSdkConfig::default()
+    };
+
+    assert_eq!(
+        config.required_session_capabilities(),
+        "/pub/paykit/v0/:rw,/pub/paykit/profile.json:rw,/pub/paykit/blobs/:rw,/pub/paykit/contacts/:rw"
     );
 }
 

--- a/paykit-sdk/src/config/tests.rs
+++ b/paykit-sdk/src/config/tests.rs
@@ -34,10 +34,7 @@ fn test_config_builds_default_profile_namespace_paths() {
         config.public_contact_path(&public_key),
         format!("/pub/paykit/contacts/{}.json", public_key.as_str())
     );
-    assert_eq!(
-        config.required_session_capabilities(),
-        "/pub/paykit/v0/:rw,/pub/paykit/profile.json:rw,/pub/paykit/blobs/:rw"
-    );
+    assert_eq!(config.required_session_capabilities(), "/pub/paykit/:rw");
 }
 
 #[test]
@@ -59,21 +56,18 @@ fn test_config_allows_custom_profile_namespace_segment() {
     );
     assert_eq!(
         config.required_session_capabilities(),
-        "/pub/paykit/v0/:rw,/pub/bitkit.to/profile.json:rw,/pub/bitkit.to/blobs/:rw"
+        "/pub/paykit/:rw,/pub/bitkit.to:rw"
     );
 }
 
 #[test]
-fn test_config_adds_contact_capability_when_public_contact_sharing_enabled() {
+fn test_config_uses_namespace_capability_when_public_contact_sharing_enabled() {
     let config = PaykitSdkConfig {
         public_contact_sharing: PublicContactSharingPolicy::ConfiguredPublicNamespace,
         ..PaykitSdkConfig::default()
     };
 
-    assert_eq!(
-        config.required_session_capabilities(),
-        "/pub/paykit/v0/:rw,/pub/paykit/profile.json:rw,/pub/paykit/blobs/:rw,/pub/paykit/contacts/:rw"
-    );
+    assert_eq!(config.required_session_capabilities(), "/pub/paykit/:rw");
 }
 
 #[test]

--- a/paykit-sdk/src/identity.rs
+++ b/paykit-sdk/src/identity.rs
@@ -1,9 +1,16 @@
 use std::fmt;
 
 use chrono::{DateTime, Utc};
+use hmac::{Hmac, Mac};
 use paykit_lib::PublicKey;
+use pubky::{Capabilities, Capability};
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 use zeroize::Zeroize;
+
+const PUBKY_DERIVATION_CONTEXT: &[u8] = b"paykit/pubky";
+const BIP39_SEED_BYTES: usize = 64;
+const MAX_DERIVATION_LABEL_BYTES: usize = 128;
 
 /// Pubky public key string used by SDK records.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -81,7 +88,7 @@ pub enum PubkyIdentityCapability {
     PrivateLinkCapable,
 }
 
-/// Local Pubky secret key used for Encrypted Links.
+/// Local Pubky secret key used for Pubky sessions and Encrypted Links.
 #[derive(Clone, PartialEq, Eq)]
 pub struct PubkyLocalSecretKey([u8; 32]);
 
@@ -94,6 +101,62 @@ impl PubkyLocalSecretKey {
     /// Borrow the secret key bytes.
     pub fn as_bytes(&self) -> &[u8; 32] {
         &self.0
+    }
+
+    /// Parse a 32-byte secret key from hex text.
+    pub fn from_hex(value: &str) -> crate::Result<Self> {
+        let mut bytes = [0; 32];
+        hex::decode_to_slice(value, &mut bytes).map_err(|err| {
+            let context = if value.len() != 64 {
+                "Pubky secret key hex must decode to 32 bytes".into()
+            } else {
+                format!("invalid Pubky secret key hex: {err}")
+            };
+            crate::PaykitSdkError::Identity {
+                context,
+                source: None,
+            }
+        })?;
+        Ok(Self::new(bytes))
+    }
+
+    /// Derive a local Pubky secret key from a 64-byte wallet seed.
+    ///
+    /// `runtime_label` must be stable and app/runtime-specific, such as a
+    /// product namespace. Different labels derive different Pubky keys from the
+    /// same wallet seed.
+    pub fn derive_from_seed(seed: &[u8], runtime_label: &str) -> crate::Result<Self> {
+        if seed.len() != BIP39_SEED_BYTES {
+            return Err(crate::PaykitSdkError::Identity {
+                context: format!(
+                    "Pubky seed derivation requires {BIP39_SEED_BYTES} bytes, got {}",
+                    seed.len()
+                ),
+                source: None,
+            });
+        }
+        validate_derivation_label(runtime_label)?;
+
+        let mut mac = Hmac::<Sha256>::new_from_slice(seed).map_err(|err| {
+            crate::PaykitSdkError::Identity {
+                context: format!("create Pubky key derivation MAC: {err}"),
+                source: None,
+            }
+        })?;
+        mac.update(PUBKY_DERIVATION_CONTEXT);
+        mac.update(&[0]);
+        mac.update(runtime_label.as_bytes());
+        let bytes: [u8; 32] = mac.finalize().into_bytes().into();
+        Ok(Self::new(bytes))
+    }
+
+    /// Return the Pubky public key for this secret key.
+    pub fn public_key(&self) -> PubkyPublicKey {
+        PubkyPublicKey::from_public_key(&self.keypair().public_key())
+    }
+
+    pub(crate) fn keypair(&self) -> pubky::Keypair {
+        pubky::Keypair::from_secret(&self.0)
     }
 
     /// Consume the wrapper and return the secret key bytes.
@@ -122,11 +185,34 @@ impl From<[u8; 32]> for PubkyLocalSecretKey {
     }
 }
 
+fn validate_derivation_label(value: &str) -> crate::Result<()> {
+    if value.is_empty() {
+        return Err(crate::PaykitSdkError::Identity {
+            context: "Pubky derivation label must not be empty".into(),
+            source: None,
+        });
+    }
+    if value.len() > MAX_DERIVATION_LABEL_BYTES {
+        return Err(crate::PaykitSdkError::Identity {
+            context: format!(
+                "Pubky derivation label must not exceed {MAX_DERIVATION_LABEL_BYTES} bytes"
+            ),
+            source: None,
+        });
+    }
+    if !value.is_ascii() || value.bytes().any(|byte| byte.is_ascii_control()) {
+        return Err(crate::PaykitSdkError::Identity {
+            context: "Pubky derivation label must be printable ASCII".into(),
+            source: None,
+        });
+    }
+    Ok(())
+}
+
 /// Live Pubky access used by one SDK runtime for Pubky storage or links.
 ///
-/// Providers must ensure the optional local secret key belongs to the local
-/// session public key. The SDK treats a present secret key as private-link
-/// capability.
+/// The SDK validates that a present local secret key belongs to the session
+/// public key before using it for private-link capability.
 #[derive(Clone)]
 pub struct PubkySessionAccess {
     /// Authenticated Pubky session for local homeserver writes.
@@ -145,19 +231,97 @@ impl PubkySessionAccess {
         ))
     }
 
-    /// Return the Paykit capability implied by this access.
-    pub fn capability(&self) -> PubkyIdentityCapability {
-        if self.private_link_capable() {
+    /// Validate that the local secret key, when present, belongs to the session.
+    pub fn validate(&self) -> crate::Result<()> {
+        let Some(local_secret_key) = &self.local_secret_key else {
+            return Ok(());
+        };
+
+        let session_public_key = self.public_key()?;
+        if local_secret_key.public_key() != session_public_key {
+            return Err(crate::PaykitSdkError::Identity {
+                context: "local Pubky secret key does not match session public key".into(),
+                source: None,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Validate local secret ownership and required Pubky write capabilities.
+    pub fn validate_for_capabilities(&self, required_capabilities: &str) -> crate::Result<()> {
+        self.validate()?;
+        validate_session_capabilities(self.session.info().capabilities(), required_capabilities)
+    }
+
+    /// Return the Paykit capability implied by this access and capability scope.
+    pub fn capability_for_capabilities(
+        &self,
+        required_capabilities: &str,
+    ) -> crate::Result<PubkyIdentityCapability> {
+        self.validate_for_capabilities(required_capabilities)?;
+        Ok(if self.private_link_capable_unchecked() {
             PubkyIdentityCapability::PrivateLinkCapable
         } else {
             PubkyIdentityCapability::PublicOnly
-        }
+        })
     }
 
-    /// Whether this access can establish Encrypted Links.
-    pub fn private_link_capable(&self) -> bool {
+    /// Report whether this validated access can establish Encrypted Links.
+    pub fn private_link_capable_for_capabilities(
+        &self,
+        required_capabilities: &str,
+    ) -> crate::Result<bool> {
+        self.validate_for_capabilities(required_capabilities)?;
+        Ok(self.private_link_capable_unchecked())
+    }
+
+    fn private_link_capable_unchecked(&self) -> bool {
         self.local_secret_key.is_some()
     }
+}
+
+fn validate_session_capabilities(
+    actual_capabilities: &[Capability],
+    required_capabilities: &str,
+) -> crate::Result<()> {
+    let actual = Capabilities::from(actual_capabilities.to_vec()).normalize();
+    let required = crate::pubky_session::parse_capabilities(required_capabilities)?;
+    let missing = required
+        .as_slice()
+        .iter()
+        .filter(|required| {
+            !actual
+                .as_slice()
+                .iter()
+                .any(|actual| capability_covers(actual, required))
+        })
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(crate::PaykitSdkError::Identity {
+            context: format!(
+                "Pubky session is missing required Paykit capabilities: {}",
+                missing.join(",")
+            ),
+            source: None,
+        })
+    }
+}
+
+fn capability_covers(actual: &Capability, required: &Capability) -> bool {
+    scope_covers(&actual.scope, &required.scope)
+        && required
+            .actions
+            .iter()
+            .all(|required_action| actual.actions.contains(required_action))
+}
+
+fn scope_covers(parent: &str, child: &str) -> bool {
+    parent == child || (parent.ends_with('/') && child.starts_with(parent))
 }
 
 impl fmt::Debug for PubkySessionAccess {

--- a/paykit-sdk/src/identity/tests.rs
+++ b/paykit-sdk/src/identity/tests.rs
@@ -63,23 +63,23 @@ fn test_session_capabilities_cover_required_paykit_scopes() {
         .as_slice()
         .to_vec();
     let bitkit_namespace = pubky::Capabilities::builder()
-        .read_write("/pub/paykit/v0/")
+        .read_write("/pub/paykit/")
         .read_write("/pub/bitkit.to/")
         .finish()
         .as_slice()
         .to_vec();
-    let granular_bitkit = "/pub/paykit/v0/:rw,/pub/bitkit.to/profile.json:rw,/pub/bitkit.to/blobs/:rw,/pub/bitkit.to/contacts/:rw";
+    let bitkit_required = "/pub/paykit/:rw,/pub/bitkit.to/:rw";
     let read_only = pubky::Capabilities::builder()
         .read("/pub/paykit/")
         .finish()
         .as_slice()
         .to_vec();
 
-    assert!(validate_session_capabilities(&root, "/pub/paykit/v0/:rw").is_ok());
-    assert!(validate_session_capabilities(&root, granular_bitkit).is_ok());
-    assert!(validate_session_capabilities(&bitkit_namespace, granular_bitkit).is_ok());
-    assert!(validate_session_capabilities(&paykit_only, granular_bitkit).is_err());
-    assert!(validate_session_capabilities(&read_only, "/pub/paykit/v0/:rw").is_err());
+    assert!(validate_session_capabilities(&root, "/pub/paykit/:rw").is_ok());
+    assert!(validate_session_capabilities(&root, bitkit_required).is_ok());
+    assert!(validate_session_capabilities(&bitkit_namespace, bitkit_required).is_ok());
+    assert!(validate_session_capabilities(&paykit_only, bitkit_required).is_err());
+    assert!(validate_session_capabilities(&read_only, "/pub/paykit/:rw").is_err());
 }
 
 #[test]

--- a/paykit-sdk/src/identity/tests.rs
+++ b/paykit-sdk/src/identity/tests.rs
@@ -8,6 +8,81 @@ fn test_pubky_local_secret_key_debug_is_redacted() {
 }
 
 #[test]
+fn test_pubky_local_secret_key_from_hex_validates_length() {
+    let key = PubkyLocalSecretKey::from_hex(&"07".repeat(32)).unwrap();
+
+    assert_eq!(key.as_bytes(), &[7; 32]);
+    assert!(PubkyLocalSecretKey::from_hex("07").is_err());
+    assert!(PubkyLocalSecretKey::from_hex("not-hex").is_err());
+}
+
+#[test]
+fn test_pubky_local_secret_key_derivation_is_deterministic() {
+    let seed = [3; 64];
+    let first = PubkyLocalSecretKey::derive_from_seed(&seed, "bitkit.to").unwrap();
+    let second = PubkyLocalSecretKey::derive_from_seed(&seed, "bitkit.to").unwrap();
+    let other_app = PubkyLocalSecretKey::derive_from_seed(&seed, "paykit.example").unwrap();
+
+    assert_eq!(first.as_bytes(), second.as_bytes());
+    assert_eq!(
+        hex::encode(first.as_bytes()),
+        "7cd9a283688abc70e2cb0a13bb7aa4826ee4d7972f3070d4dade0706a83c5dee"
+    );
+    assert_eq!(
+        first.public_key().as_str(),
+        "wifjcot1pyutzt4g5jbuz9mweuh53cxyngrj4dbom6684pppzhwy"
+    );
+    assert_ne!(first.as_bytes(), other_app.as_bytes());
+    assert_ne!(first.as_bytes(), &[3; 32]);
+    assert!(PubkyLocalSecretKey::derive_from_seed(&seed[..32], "bitkit.to").is_err());
+    assert!(PubkyLocalSecretKey::derive_from_seed(&seed, "").is_err());
+    assert!(PubkyLocalSecretKey::derive_from_seed(&seed, "bad\nlabel").is_err());
+}
+
+#[test]
+fn test_pubky_local_secret_key_returns_public_key() {
+    let key = PubkyLocalSecretKey::new([9; 32]);
+    let public_key = key.public_key();
+
+    assert_eq!(
+        public_key.to_public_key().unwrap(),
+        key.keypair().public_key()
+    );
+}
+
+#[test]
+fn test_session_capabilities_cover_required_paykit_scopes() {
+    let root = pubky::Capabilities::builder()
+        .read_write("/")
+        .finish()
+        .as_slice()
+        .to_vec();
+    let paykit_only = pubky::Capabilities::builder()
+        .read_write("/pub/paykit/")
+        .finish()
+        .as_slice()
+        .to_vec();
+    let bitkit_namespace = pubky::Capabilities::builder()
+        .read_write("/pub/paykit/v0/")
+        .read_write("/pub/bitkit.to/")
+        .finish()
+        .as_slice()
+        .to_vec();
+    let granular_bitkit = "/pub/paykit/v0/:rw,/pub/bitkit.to/profile.json:rw,/pub/bitkit.to/blobs/:rw,/pub/bitkit.to/contacts/:rw";
+    let read_only = pubky::Capabilities::builder()
+        .read("/pub/paykit/")
+        .finish()
+        .as_slice()
+        .to_vec();
+
+    assert!(validate_session_capabilities(&root, "/pub/paykit/v0/:rw").is_ok());
+    assert!(validate_session_capabilities(&root, granular_bitkit).is_ok());
+    assert!(validate_session_capabilities(&bitkit_namespace, granular_bitkit).is_ok());
+    assert!(validate_session_capabilities(&paykit_only, granular_bitkit).is_err());
+    assert!(validate_session_capabilities(&read_only, "/pub/paykit/v0/:rw").is_err());
+}
+
+#[test]
 fn test_pubky_public_key_validates_and_round_trips_z32() {
     let public_key = pubky::Keypair::random().public_key();
     let wrapped = PubkyPublicKey::new(public_key.z32()).unwrap();

--- a/paykit-sdk/src/lib.rs
+++ b/paykit-sdk/src/lib.rs
@@ -13,6 +13,7 @@ mod outbound_private;
 mod payment_requests;
 mod private_lists;
 mod private_stream;
+mod pubky_session;
 mod publication;
 mod receipts;
 mod records;
@@ -77,6 +78,12 @@ pub use private_lists::PrivatePaymentListView;
 pub use private_stream::{
     EventIdConflict, PrivateStreamCounterpartyIntakeReport, PrivateStreamIntakeReport,
     PrivateStreamParseStatus,
+};
+#[doc(inline)]
+pub use pubky_session::{
+    parse_pubky_auth_url, parse_pubky_resource, resolve_pubky_url, PubkyAuthDetails,
+    PubkyAuthRequest, PubkyAuthRequestKind, PubkyResourceRef, PubkySessionBootstrap,
+    PubkySessionBootstrapResult, PubkySessionSecret, PAYKIT_SESSION_CAPABILITIES,
 };
 #[doc(inline)]
 pub use publication::PublicationStatus;

--- a/paykit-sdk/src/pubky_session.rs
+++ b/paykit-sdk/src/pubky_session.rs
@@ -15,8 +15,8 @@ use crate::{
     PaykitSdkError, Result,
 };
 
-/// Default Pubky capabilities needed for core Paykit public storage writes.
-pub const PAYKIT_SESSION_CAPABILITIES: &str = "/pub/paykit/v0/:rw";
+/// Default Pubky capabilities needed for Paykit public storage writes.
+pub const PAYKIT_SESSION_CAPABILITIES: &str = "/pub/paykit/:rw";
 
 /// Parsed Pubky resource with a normalized owner and path.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/paykit-sdk/src/pubky_session.rs
+++ b/paykit-sdk/src/pubky_session.rs
@@ -1,0 +1,497 @@
+//! Pubky account, session, and auth-flow helpers.
+
+use std::{fmt, str::FromStr};
+
+use pubky::{
+    deep_links::DeepLink, AuthFlowKind, Capabilities, Capability, Pubky, PubkyAuthFlow,
+    PubkyResource, PubkySession,
+};
+use serde::{Deserialize, Serialize};
+use url::Url;
+use zeroize::Zeroize;
+
+use crate::{
+    identity::{PubkyIdentityCapability, PubkyLocalSecretKey, PubkyPublicKey},
+    PaykitSdkError, Result,
+};
+
+/// Default Pubky capabilities needed for core Paykit public storage writes.
+pub const PAYKIT_SESSION_CAPABILITIES: &str = "/pub/paykit/v0/:rw";
+
+/// Parsed Pubky resource with a normalized owner and path.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PubkyResourceRef {
+    /// Resource owner.
+    pub public_key: PubkyPublicKey,
+    /// Absolute resource path.
+    pub path: String,
+    /// Transport URL resolved by the Pubky client.
+    pub transport_url: String,
+}
+
+/// Kind of Pubky auth request represented by an auth deep link.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PubkyAuthRequestKind {
+    /// Sign in to an existing Pubky account.
+    SignIn,
+    /// Sign up on a Pubky homeserver.
+    SignUp,
+    /// Export a secret from a signer.
+    SecretExport,
+}
+
+/// Public details parsed from a Pubky auth deep link.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PubkyAuthDetails {
+    /// Auth request kind.
+    pub kind: PubkyAuthRequestKind,
+    /// Requested capabilities as canonical Pubky capability text.
+    pub capabilities: Option<String>,
+    /// Relay URL used by the auth flow.
+    pub relay_url: Option<String>,
+    /// Homeserver requested by a signup flow.
+    pub homeserver_public_key: Option<PubkyPublicKey>,
+}
+
+impl fmt::Debug for PubkyAuthDetails {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PubkyAuthDetails")
+            .field("kind", &self.kind)
+            .field("capabilities", &self.capabilities)
+            .field("relay_url", &self.relay_url)
+            .field("homeserver_public_key", &self.homeserver_public_key)
+            .finish()
+    }
+}
+
+/// Exported Pubky session bearer secret.
+pub struct PubkySessionSecret(String);
+
+impl PubkySessionSecret {
+    fn new(value: String) -> Self {
+        Self(value)
+    }
+
+    /// Borrow the secret text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the wrapper and return the secret text.
+    pub fn into_inner(mut self) -> String {
+        let value = std::mem::take(&mut self.0);
+        self.0.zeroize();
+        value
+    }
+}
+
+impl fmt::Debug for PubkySessionSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PubkySessionSecret(<redacted>)")
+    }
+}
+
+impl Drop for PubkySessionSecret {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+/// Result of creating or importing a Pubky session for Paykit SDK use.
+pub struct PubkySessionBootstrapResult {
+    /// Live Pubky session access that can be passed to a `PubkySessionProvider`.
+    pub access: crate::PubkySessionAccess,
+    /// Local public key for the session.
+    pub public_key: PubkyPublicKey,
+    /// Capability implied by the session and optional local secret key.
+    pub capability: PubkyIdentityCapability,
+}
+
+impl fmt::Debug for PubkySessionBootstrapResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PubkySessionBootstrapResult")
+            .field("access", &"<redacted>")
+            .field("public_key", &self.public_key)
+            .field("capability", &self.capability)
+            .finish()
+    }
+}
+
+impl PubkySessionBootstrapResult {
+    /// Export the bearer secret token used to restore this Pubky session later.
+    pub fn export_session_secret(&self) -> PubkySessionSecret {
+        PubkySessionSecret::new(self.access.session.export_secret())
+    }
+}
+
+/// Handle for a pending Pubky auth flow.
+pub struct PubkyAuthRequest {
+    pubky: Pubky,
+    flow: PubkyAuthFlow,
+    authorization_url: String,
+}
+
+impl PubkyAuthRequest {
+    /// Short-lived secret-bearing auth URL to show as a deeplink or QR code.
+    pub fn authorization_url(&self) -> &str {
+        &self.authorization_url
+    }
+
+    /// Wait for auth approval and validate the resulting session capabilities.
+    pub async fn complete(
+        self,
+        local_secret_key: Option<PubkyLocalSecretKey>,
+        required_capabilities: &str,
+    ) -> Result<PubkySessionBootstrapResult> {
+        validate_auth_url_capabilities(&self.authorization_url, required_capabilities)?;
+        let session = self
+            .flow
+            .await_approval()
+            .await
+            .map_err(|err| map_pubky_identity_error("complete Pubky auth flow", err))?;
+        validate_session_exact_capabilities(&session, required_capabilities)?;
+        session_result(session, self.pubky, local_secret_key, required_capabilities)
+    }
+}
+
+impl fmt::Debug for PubkyAuthRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PubkyAuthRequest")
+            .field("authorization_url", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Pubky session bootstrap helper for Paykit integrations.
+#[derive(Clone, Debug)]
+pub struct PubkySessionBootstrap {
+    pubky: Pubky,
+}
+
+impl PubkySessionBootstrap {
+    /// Create a bootstrap helper with a default Pubky client.
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            pubky: Pubky::new()
+                .map_err(|err| map_pubky_identity_error("create Pubky client", err))?,
+        })
+    }
+
+    /// Create a bootstrap helper from an existing Pubky client.
+    pub fn with_pubky(pubky: Pubky) -> Self {
+        Self { pubky }
+    }
+
+    /// Sign up on a homeserver and return validated session access.
+    pub async fn sign_up(
+        &self,
+        secret_key: &PubkyLocalSecretKey,
+        homeserver_public_key: &PubkyPublicKey,
+        signup_code: Option<&str>,
+    ) -> Result<PubkySessionBootstrapResult> {
+        let homeserver = homeserver_public_key.to_public_key()?;
+        let session = self
+            .pubky
+            .signer(secret_key.keypair())
+            .signup(&homeserver, signup_code)
+            .await
+            .map_err(|err| map_pubky_identity_error("sign up Pubky session", err))?;
+        session_result(
+            session,
+            self.pubky.clone(),
+            Some(secret_key.clone()),
+            PAYKIT_SESSION_CAPABILITIES,
+        )
+    }
+
+    /// Sign in with a local Pubky secret key and return validated session access.
+    pub async fn sign_in(
+        &self,
+        secret_key: &PubkyLocalSecretKey,
+    ) -> Result<PubkySessionBootstrapResult> {
+        let session = self
+            .pubky
+            .signer(secret_key.keypair())
+            .signin()
+            .await
+            .map_err(|err| map_pubky_identity_error("sign in Pubky session", err))?;
+        session_result(
+            session,
+            self.pubky.clone(),
+            Some(secret_key.clone()),
+            PAYKIT_SESSION_CAPABILITIES,
+        )
+    }
+
+    /// Import an exported Pubky session secret and validate its capabilities.
+    pub async fn import_session(
+        &self,
+        session_secret: &str,
+        local_secret_key: Option<PubkyLocalSecretKey>,
+        required_capabilities: &str,
+    ) -> Result<PubkySessionBootstrapResult> {
+        let session =
+            PubkySession::import_secret(session_secret, Some(self.pubky.client().clone()))
+                .await
+                .map_err(|err| map_pubky_identity_error("import Pubky session", err))?;
+        session_result(
+            session,
+            self.pubky.clone(),
+            local_secret_key,
+            required_capabilities,
+        )
+    }
+
+    /// Start a sign-in auth flow for an external signer such as Pubky Ring.
+    pub fn start_sign_in_auth(&self, capabilities: &str) -> Result<PubkyAuthRequest> {
+        self.start_auth(capabilities, AuthFlowKind::signin())
+    }
+
+    /// Start a signup auth flow for an external signer such as Pubky Ring.
+    pub fn start_sign_up_auth(
+        &self,
+        capabilities: &str,
+        homeserver_public_key: &PubkyPublicKey,
+        signup_token: Option<String>,
+    ) -> Result<PubkyAuthRequest> {
+        self.start_auth(
+            capabilities,
+            AuthFlowKind::signup(homeserver_public_key.to_public_key()?, signup_token),
+        )
+    }
+
+    /// Resume a short-lived auth flow from its authorization URL.
+    ///
+    /// The requested capabilities must exactly match `expected_capabilities`.
+    pub fn resume_auth(
+        &self,
+        authorization_url: &str,
+        expected_capabilities: &str,
+    ) -> Result<PubkyAuthRequest> {
+        validate_sign_in_or_sign_up_auth_url(authorization_url)?;
+        validate_auth_url_capabilities(authorization_url, expected_capabilities)?;
+        let flow = self
+            .pubky
+            .resume_auth_flow(authorization_url)
+            .map_err(|err| map_pubky_identity_error("resume Pubky auth flow", err))?;
+        Ok(PubkyAuthRequest {
+            pubky: self.pubky.clone(),
+            flow,
+            authorization_url: authorization_url.to_string(),
+        })
+    }
+
+    /// Approve a Pubky auth URL with this local secret key.
+    ///
+    /// The requested capabilities must exactly match `expected_capabilities`.
+    pub async fn approve_auth(
+        &self,
+        auth_url: &str,
+        expected_capabilities: &str,
+        secret_key: &PubkyLocalSecretKey,
+    ) -> Result<()> {
+        validate_sign_in_or_sign_up_auth_url(auth_url)?;
+        validate_auth_url_capabilities(auth_url, expected_capabilities)?;
+        self.pubky
+            .signer(secret_key.keypair())
+            .approve_auth(auth_url)
+            .await
+            .map_err(|err| map_pubky_identity_error("approve Pubky auth flow", err))
+    }
+
+    fn start_auth(&self, capabilities: &str, kind: AuthFlowKind) -> Result<PubkyAuthRequest> {
+        let capabilities = parse_capabilities(capabilities)?;
+        let flow = self
+            .pubky
+            .start_auth_flow(&capabilities, kind)
+            .map_err(|err| map_pubky_identity_error("start Pubky auth flow", err))?;
+        let authorization_url = flow.authorization_url().to_string();
+        Ok(PubkyAuthRequest {
+            pubky: self.pubky.clone(),
+            flow,
+            authorization_url,
+        })
+    }
+}
+
+/// Parse an auth deep link into public request details.
+pub fn parse_pubky_auth_url(auth_url: &str) -> Result<PubkyAuthDetails> {
+    let deep_link = DeepLink::from_str(auth_url)
+        .map_err(|err| PaykitSdkError::Protocol(format!("invalid Pubky auth URL: {err}")))?;
+
+    match deep_link {
+        DeepLink::Signin(link) => Ok(PubkyAuthDetails {
+            kind: PubkyAuthRequestKind::SignIn,
+            capabilities: Some(parse_auth_url_capabilities(auth_url)?.to_string()),
+            relay_url: Some(link.relay().to_string()),
+            homeserver_public_key: None,
+        }),
+        DeepLink::Signup(link) => Ok(PubkyAuthDetails {
+            kind: PubkyAuthRequestKind::SignUp,
+            capabilities: Some(parse_auth_url_capabilities(auth_url)?.to_string()),
+            relay_url: Some(link.relay().to_string()),
+            homeserver_public_key: Some(PubkyPublicKey::from_public_key(link.homeserver())),
+        }),
+        DeepLink::SeedExport(_) => Ok(PubkyAuthDetails {
+            kind: PubkyAuthRequestKind::SecretExport,
+            capabilities: None,
+            relay_url: None,
+            homeserver_public_key: None,
+        }),
+    }
+}
+
+/// Resolve a Pubky URI into the transport URL used by Pubky storage.
+pub fn resolve_pubky_url(uri: &str) -> Result<String> {
+    pubky::resolve_pubky(uri)
+        .map(|url| url.to_string())
+        .map_err(|err| PaykitSdkError::Protocol(format!("invalid Pubky URI: {err}")))
+}
+
+/// Parse a `pubky://<public-key>/<path>` resource into stable parts.
+pub fn parse_pubky_resource(uri: &str) -> Result<PubkyResourceRef> {
+    let resource = PubkyResource::from_str(uri)
+        .map_err(|err| PaykitSdkError::Protocol(format!("invalid Pubky resource: {err}")))?;
+    let public_key = PubkyPublicKey::from_public_key(&resource.owner);
+    let path = resource.path.as_str().to_string();
+    let normalized = resource.to_pubky_url();
+    Ok(PubkyResourceRef {
+        public_key,
+        path,
+        transport_url: resolve_pubky_url(&normalized)?,
+    })
+}
+
+fn session_result(
+    session: PubkySession,
+    outbox_client: Pubky,
+    local_secret_key: Option<PubkyLocalSecretKey>,
+    required_capabilities: &str,
+) -> Result<PubkySessionBootstrapResult> {
+    let local_secret_key = validate_local_secret_for_session(&session, local_secret_key)?;
+    let access = crate::PubkySessionAccess {
+        session,
+        outbox_client,
+        local_secret_key,
+    };
+    let public_key = access.public_key()?;
+    let capability = access.capability_for_capabilities(required_capabilities)?;
+    Ok(PubkySessionBootstrapResult {
+        access,
+        public_key,
+        capability,
+    })
+}
+
+pub(crate) fn parse_capabilities(value: &str) -> Result<Capabilities> {
+    let mut capabilities = Vec::new();
+    for entry in value.split(',').map(str::trim) {
+        if entry.is_empty() {
+            return Err(PaykitSdkError::Protocol(
+                "Pubky capabilities must not contain empty entries".into(),
+            ));
+        }
+        let capability = Capability::try_from(entry)
+            .map_err(|err| PaykitSdkError::Protocol(format!("invalid Pubky capability: {err}")))?;
+        capabilities.push(capability);
+    }
+    if capabilities.is_empty() {
+        return Err(PaykitSdkError::Protocol(
+            "Pubky capabilities must contain at least one valid entry".into(),
+        ));
+    }
+    Ok(Capabilities::from(capabilities).normalize())
+}
+
+fn validate_sign_in_or_sign_up_auth_url(auth_url: &str) -> Result<()> {
+    match parse_pubky_auth_url(auth_url)?.kind {
+        PubkyAuthRequestKind::SignIn | PubkyAuthRequestKind::SignUp => Ok(()),
+        PubkyAuthRequestKind::SecretExport => Err(PaykitSdkError::Protocol(
+            "Pubky secret-export auth URLs cannot be resumed or approved as sessions".into(),
+        )),
+    }
+}
+
+fn validate_session_exact_capabilities(
+    session: &PubkySession,
+    expected_capabilities: &str,
+) -> Result<()> {
+    let actual = Capabilities::from(session.info().capabilities().to_vec()).normalize();
+    let expected = parse_capabilities(expected_capabilities)?;
+    if actual != expected {
+        return Err(PaykitSdkError::Identity {
+            context: format!(
+                "Pubky session capabilities `{actual}` did not match requested capabilities `{expected}`"
+            ),
+            source: None,
+        });
+    }
+    Ok(())
+}
+
+fn validate_auth_url_capabilities(auth_url: &str, expected_capabilities: &str) -> Result<()> {
+    let actual = parse_auth_url_capabilities(auth_url)?;
+    let expected = parse_capabilities(expected_capabilities)?;
+    if actual != expected {
+        return Err(PaykitSdkError::Policy(format!(
+            "Pubky auth URL requested capabilities `{actual}`, expected `{expected}`"
+        )));
+    }
+    Ok(())
+}
+
+fn parse_auth_url_capabilities(auth_url: &str) -> Result<Capabilities> {
+    let url = Url::parse(auth_url)
+        .map_err(|err| PaykitSdkError::Protocol(format!("invalid Pubky auth URL: {err}")))?;
+    let mut caps = None;
+    for (key, value) in url.query_pairs() {
+        if key != "caps" {
+            continue;
+        }
+        if caps.is_some() {
+            return Err(PaykitSdkError::Protocol(
+                "Pubky auth URL must not contain duplicate caps parameters".into(),
+            ));
+        }
+        caps = Some(value.into_owned());
+    }
+    let caps =
+        caps.ok_or_else(|| PaykitSdkError::Protocol("Pubky auth URL missing caps".into()))?;
+    parse_capabilities(&caps)
+}
+
+fn validate_local_secret_for_session(
+    session: &PubkySession,
+    local_secret_key: Option<PubkyLocalSecretKey>,
+) -> Result<Option<PubkyLocalSecretKey>> {
+    let Some(local_secret_key) = local_secret_key else {
+        return Ok(None);
+    };
+    let session_public_key = PubkyPublicKey::from_public_key(session.info().public_key());
+    validate_local_secret_for_public_key(&session_public_key, local_secret_key).map(Some)
+}
+
+fn validate_local_secret_for_public_key(
+    session_public_key: &PubkyPublicKey,
+    local_secret_key: PubkyLocalSecretKey,
+) -> Result<PubkyLocalSecretKey> {
+    let secret_public_key = local_secret_key.public_key();
+    if &secret_public_key != session_public_key {
+        return Err(PaykitSdkError::Identity {
+            context: "local Pubky secret key does not match session public key".into(),
+            source: None,
+        });
+    }
+    Ok(local_secret_key)
+}
+
+fn map_pubky_identity_error(context: &'static str, err: pubky::Error) -> PaykitSdkError {
+    PaykitSdkError::Identity {
+        context: context.into(),
+        source: Some(err.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/paykit-sdk/src/pubky_session/tests.rs
+++ b/paykit-sdk/src/pubky_session/tests.rs
@@ -85,10 +85,7 @@ fn test_parse_capabilities_rejects_invalid_entries() {
             .to_string(),
         PAYKIT_SESSION_CAPABILITIES
     );
-    assert_eq!(
-        PAYKIT_SESSION_CAPABILITIES,
-        format!("{}:rw", paykit_lib::PAYKIT_PATH_PREFIX)
-    );
+    assert_eq!(PAYKIT_SESSION_CAPABILITIES, "/pub/paykit/:rw");
     assert!(parse_capabilities("/:rw,not-a-capability").is_err());
     assert!(parse_capabilities("/:rw,").is_err());
     assert!(parse_capabilities(",/:rw").is_err());
@@ -98,7 +95,7 @@ fn test_parse_capabilities_rejects_invalid_entries() {
 #[test]
 fn test_validate_auth_url_capabilities_requires_exact_match() {
     let auth_url =
-        "pubkyauth://signin?caps=/pub/paykit/v0/:rw&relay=https://httprelay.pubky.app/inbox/&secret=e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3s";
+        "pubkyauth://signin?caps=/pub/paykit/:rw&relay=https://httprelay.pubky.app/inbox/&secret=e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3s";
 
     assert!(validate_auth_url_capabilities(auth_url, PAYKIT_SESSION_CAPABILITIES).is_ok());
     assert!(validate_auth_url_capabilities(auth_url, "/:rw").is_err());

--- a/paykit-sdk/src/pubky_session/tests.rs
+++ b/paykit-sdk/src/pubky_session/tests.rs
@@ -1,0 +1,140 @@
+use super::*;
+
+#[test]
+fn test_parse_pubky_auth_url_sign_in() {
+    let details = parse_pubky_auth_url(
+        "pubkyauth://signin?caps=/:rw&relay=https://httprelay.pubky.app/inbox/&secret=e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3s",
+    )
+    .unwrap();
+
+    assert_eq!(details.kind, PubkyAuthRequestKind::SignIn);
+    assert_eq!(details.capabilities.as_deref(), Some("/:rw"));
+    assert_eq!(
+        details.relay_url.as_deref(),
+        Some("https://httprelay.pubky.app/inbox/")
+    );
+    assert!(details.homeserver_public_key.is_none());
+}
+
+#[test]
+fn test_parse_pubky_auth_url_sign_up() {
+    let homeserver =
+        PubkyPublicKey::new("5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo").unwrap();
+    let details = parse_pubky_auth_url(
+        "pubkyauth://signup?caps=/:rw&relay=https://httprelay.pubky.app/inbox/&secret=e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3s&hs=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo&st=invite",
+    )
+    .unwrap();
+
+    assert_eq!(details.kind, PubkyAuthRequestKind::SignUp);
+    assert_eq!(details.capabilities.as_deref(), Some("/:rw"));
+    assert_eq!(details.homeserver_public_key.as_ref(), Some(&homeserver));
+    assert!(!format!("{details:?}").contains("invite"));
+    assert!(!serde_json::to_string(&details).unwrap().contains("invite"));
+}
+
+#[test]
+fn test_parse_pubky_auth_url_rejects_invalid_url() {
+    assert!(parse_pubky_auth_url("not-an-auth-url").is_err());
+    assert!(
+        parse_pubky_auth_url(
+            "pubkyauth://signin?caps=/:rw,not-a-capability&relay=https://httprelay.pubky.app/inbox/&secret=e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3s",
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn test_parse_pubky_resource_normalizes_uri() {
+    let public_key = PubkyLocalSecretKey::new([4; 32]).public_key();
+    let resource = parse_pubky_resource(&format!(
+        "pubky://{}/pub/paykit/profile.json",
+        public_key.as_str()
+    ))
+    .unwrap();
+
+    assert_eq!(resource.public_key, public_key);
+    assert_eq!(resource.path, "/pub/paykit/profile.json");
+    assert!(resource.transport_url.starts_with("https://"));
+}
+
+#[test]
+fn test_parse_pubky_resource_accepts_pubky_identifier_form() {
+    let public_key = PubkyLocalSecretKey::new([5; 32]).public_key();
+    let resource = parse_pubky_resource(&format!(
+        "pubky{}/pub/paykit/profile.json",
+        public_key.as_str()
+    ))
+    .unwrap();
+
+    assert_eq!(resource.public_key, public_key);
+    assert_eq!(resource.path, "/pub/paykit/profile.json");
+}
+
+#[test]
+fn test_parse_pubky_resource_rejects_missing_path() {
+    let public_key = PubkyLocalSecretKey::new([6; 32]).public_key();
+
+    assert!(parse_pubky_resource(public_key.as_str()).is_err());
+}
+
+#[test]
+fn test_parse_capabilities_rejects_invalid_entries() {
+    assert_eq!(
+        parse_capabilities(PAYKIT_SESSION_CAPABILITIES)
+            .unwrap()
+            .to_string(),
+        PAYKIT_SESSION_CAPABILITIES
+    );
+    assert_eq!(
+        PAYKIT_SESSION_CAPABILITIES,
+        format!("{}:rw", paykit_lib::PAYKIT_PATH_PREFIX)
+    );
+    assert!(parse_capabilities("/:rw,not-a-capability").is_err());
+    assert!(parse_capabilities("/:rw,").is_err());
+    assert!(parse_capabilities(",/:rw").is_err());
+    assert!(parse_capabilities("").is_err());
+}
+
+#[test]
+fn test_validate_auth_url_capabilities_requires_exact_match() {
+    let auth_url =
+        "pubkyauth://signin?caps=/pub/paykit/v0/:rw&relay=https://httprelay.pubky.app/inbox/&secret=e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3s";
+
+    assert!(validate_auth_url_capabilities(auth_url, PAYKIT_SESSION_CAPABILITIES).is_ok());
+    assert!(validate_auth_url_capabilities(auth_url, "/:rw").is_err());
+}
+
+#[test]
+fn test_validate_auth_url_capabilities_rejects_broad_capabilities() {
+    let auth_url =
+        "pubkyauth://signin?caps=/:rw&relay=https://httprelay.pubky.app/inbox/&secret=e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3s";
+
+    assert!(validate_auth_url_capabilities(auth_url, PAYKIT_SESSION_CAPABILITIES).is_err());
+}
+
+#[test]
+fn test_validate_session_auth_url_rejects_secret_export() {
+    assert!(validate_sign_in_or_sign_up_auth_url(
+        "pubkyauth://secret_export?secret=e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3s",
+    )
+    .is_err());
+}
+
+#[test]
+fn test_validate_local_secret_for_public_key_rejects_mismatch() {
+    let session_key = PubkyLocalSecretKey::new([7; 32]).public_key();
+    let matching_secret = PubkyLocalSecretKey::new([7; 32]);
+    let wrong_secret = PubkyLocalSecretKey::new([8; 32]);
+
+    assert!(validate_local_secret_for_public_key(&session_key, matching_secret).is_ok());
+    assert!(validate_local_secret_for_public_key(&session_key, wrong_secret).is_err());
+}
+
+#[test]
+fn test_pubky_session_secret_debug_is_redacted() {
+    let secret = PubkySessionSecret::new("pubky-session-secret".into());
+
+    assert_eq!(format!("{secret:?}"), "PubkySessionSecret(<redacted>)");
+    assert_eq!(secret.as_str(), "pubky-session-secret");
+    assert_eq!(secret.into_inner(), "pubky-session-secret");
+}

--- a/paykit-sdk/src/runtime.rs
+++ b/paykit-sdk/src/runtime.rs
@@ -233,9 +233,12 @@ where
         let _identity_guard = self.claim_identity_operation("initialize")?;
         let (session, state) = self.load_session_access_and_refresh_identity().await?;
         let live_session_available = session.is_some();
+        let required_capabilities = self.config.required_session_capabilities();
         let private_link_capable = session
             .as_ref()
-            .is_some_and(PubkySessionAccess::private_link_capable);
+            .map(|session| session.private_link_capable_for_capabilities(&required_capabilities))
+            .transpose()?
+            .unwrap_or(false);
 
         Ok(InitializationReport {
             identity: IdentityStatus::from_state(
@@ -324,8 +327,9 @@ where
             return Ok((session, state));
         };
 
+        let required_capabilities = self.config.required_session_capabilities();
         let public_key = Some(session_access.public_key()?);
-        let capability = session_access.capability();
+        let capability = session_access.capability_for_capabilities(&required_capabilities)?;
         let state = self
             .storage
             .transaction(move |tx| {
@@ -399,6 +403,7 @@ where
                 source: None,
             });
         }
+        session_access.validate_for_capabilities(&self.config.required_session_capabilities())?;
         Ok(session_access)
     }
 
@@ -408,13 +413,21 @@ where
         let Some(state) = self.storage.load_identity_state().await? else {
             return Ok(None);
         };
+        if let Some(session) = &session {
+            session.validate()?;
+        }
+        let required_capabilities = self.config.required_session_capabilities();
         let matching_session = session
             .as_ref()
             .filter(|session| session.public_key().ok().as_ref() == state.public_key.as_ref());
+        let private_link_capable = matching_session
+            .map(|session| session.private_link_capable_for_capabilities(&required_capabilities))
+            .transpose()?
+            .unwrap_or(false);
         Ok(Some(IdentityStatus::from_state(
             &state,
             matching_session.is_some(),
-            matching_session.is_some_and(PubkySessionAccess::private_link_capable),
+            private_link_capable,
         )))
     }
 

--- a/paykit-sdk/src/runtime/backup.rs
+++ b/paykit-sdk/src/runtime/backup.rs
@@ -19,8 +19,12 @@ where
         if backup.identity_public_key().is_some() || backup.has_identity_scoped_state() {
             let session_access = self.validate_backup_restore_session(&backup).await?;
             if let Some(identity_state) = backup.identity_state.as_mut() {
-                identity_state.capability = session_access.capability();
-                identity_state.local_secret_available = session_access.private_link_capable();
+                identity_state.capability = session_access
+                    .capability_for_capabilities(&self.config.required_session_capabilities())?;
+                identity_state.local_secret_available = session_access
+                    .private_link_capable_for_capabilities(
+                        &self.config.required_session_capabilities(),
+                    )?;
             }
             trusted_identity = Some(self.restore_validation_identity(&session_access).await?);
         }
@@ -48,8 +52,11 @@ where
                 source: None,
             });
         }
+        let required_capabilities = self.config.required_session_capabilities();
+        session_access.validate_for_capabilities(&required_capabilities)?;
         if backup.has_private_identity_scoped_state()
-            && session_access.capability() != PubkyIdentityCapability::PrivateLinkCapable
+            && session_access.capability_for_capabilities(&required_capabilities)?
+                != PubkyIdentityCapability::PrivateLinkCapable
         {
             return Err(PaykitSdkError::Identity {
                 context: "cannot restore private Paykit state without private-link capability"
@@ -65,8 +72,10 @@ where
         session_access: &PubkySessionAccess,
     ) -> Result<IdentityState> {
         let public_key = session_access.public_key()?;
-        let capability = session_access.capability();
-        let local_secret_available = session_access.private_link_capable();
+        let required_capabilities = self.config.required_session_capabilities();
+        let capability = session_access.capability_for_capabilities(&required_capabilities)?;
+        let local_secret_available =
+            session_access.private_link_capable_for_capabilities(&required_capabilities)?;
         let initialized_at = self.clock.now();
         self.storage
             .transaction(move |tx| {

--- a/paykit-sdk/src/runtime/contacts.rs
+++ b/paykit-sdk/src/runtime/contacts.rs
@@ -151,7 +151,8 @@ where
     ///
     /// Cleanup is allowed even when public contact sharing is disabled, so an
     /// app can stop publishing markers and still remove previously published
-    /// markers.
+    /// markers. The active session still needs write access to the configured
+    /// public contact marker path.
     pub async fn remove_public_contact(
         &self,
         public_key: PubkyPublicKey,

--- a/paykit-sdk/src/runtime/private_lists.rs
+++ b/paykit-sdk/src/runtime/private_lists.rs
@@ -17,9 +17,12 @@ where
             return Ok(None);
         }
         self.ensure_peer_not_blocked(counterparty).await?;
+        let required_capabilities = self.config.required_session_capabilities();
         if session_access
             .as_ref()
-            .is_some_and(PubkySessionAccess::private_link_capable)
+            .map(|session| session.private_link_capable_for_capabilities(&required_capabilities))
+            .transpose()?
+            .unwrap_or(false)
         {
             self.observe_remote_recovery_marker_for_cached_private_state(
                 counterparty,

--- a/specs/paykit-sdk-bindings.md
+++ b/specs/paykit-sdk-bindings.md
@@ -144,9 +144,18 @@ The binding-level session API should not ask Swift, Kotlin, or React Native to
 construct Rust `pubky::PubkySession` or `pubky::Pubky` values directly. For
 ordinary app use, SDK bindings should turn app-provided session material,
 imported session secrets, or an auth handoff result into the Rust Pubky access
-needed by the SDK. If a platform binding cannot own that construction, it must
-make the required Pubky binding dependency explicit instead of implying that no
-Pubky integration is needed.
+needed by the SDK. SDK bindings use `PubkySessionBootstrap` for signup, signin,
+session import, capability-checked auth handoff, and `pubky://` normalization.
+Binding helpers should request the capability scope returned by the active
+`PaykitSdkConfig` and validate completed/imported sessions against that same
+scope.
+`PubkyLocalSecretKey` exposes app/runtime-domain-separated key derivation and
+public-key-from-secret helpers. Platform bindings should wrap those helpers
+where the platform has no better native primitive. Auth URLs and exported
+session secrets are secret-bearing values, so bindings should avoid exposing
+them through ordinary logs or debug output. If a platform binding cannot own
+that construction, it must make the required Pubky binding dependency explicit
+instead of implying that no Pubky integration is needed.
 
 The session provider should expose only the platform state the SDK needs:
 

--- a/specs/paykit-sdk.md
+++ b/specs/paykit-sdk.md
@@ -298,12 +298,15 @@ session access consumed by the provider. It covers common Pubky account/session
 workflows: signup, signin, session-secret import, auth handoff
 start/resume/approve helpers, and `pubky://` resource normalization. Full SDK
 runtime auth should use `config.required_session_capabilities()` as the expected
-scope for auth start/resume/approve, completion, and session import. The core
-Paykit capability constant only covers the versioned Paykit Protocol paths.
+scope for auth start/resume/approve, completion, and session import. The
+default Paykit capability covers the public Paykit namespace used by protocol
+paths and SDK-managed Paykit public data.
 `PubkyLocalSecretKey` also provides app/runtime-domain-separated seed
 derivation and public-key-from-secret helpers for apps that choose that key
-convention. Exported session secrets and auth URLs are secret-bearing values
-and must be stored or displayed only for their intended short-lived flow.
+convention. The `runtime_label` must be a stable app/runtime label such as
+`bitkit.to`; changing it derives a different Paykit runtime identity from the
+same wallet seed. Exported session secrets and auth URLs are secret-bearing
+values and must be stored or displayed only for their intended short-lived flow.
 Bindings should wrap these helpers so mobile apps do not need a second Pubky
 SDK dependency for ordinary Paykit onboarding.
 
@@ -330,9 +333,9 @@ profile/contact namespace segment. For example, `profile_namespace =
 such as public Payment Endpoints, and it does not create app-specific private
 runtime isolation under one shared key. The app should request the capability
 scope returned by `PaykitSdkConfig::required_session_capabilities()` and
-validate imported/completed sessions against that same scope. That scope
-includes public contact marker writes only when public contact sharing is
-enabled in the SDK configuration.
+validate imported/completed sessions against that same scope. The default
+namespace is covered by `/pub/paykit/:rw`; a custom profile/contact namespace
+adds the matching `/pub/<namespace>/:rw` capability.
 
 `image_uri` may point at the configured blob prefix or another public image
 location. The SDK can publish/delete Paykit blobs under the configured blob

--- a/specs/paykit-sdk.md
+++ b/specs/paykit-sdk.md
@@ -63,7 +63,7 @@ The system should have three main layers:
   validation.
 - Paykit SDK runtime: durable state, private stream routing, lifecycle
   derivation, endpoint publication, contact payment resolution, retries,
-  recovery, Pubky session/capability handling, Pubky-backed Paykit
+  recovery, Pubky session bootstrap/capability handling, Pubky-backed Paykit
   profile/contact metadata, and app-facing APIs.
 - Payment adapter layer: receiving-detail generation, payable endpoint
   ordering, payment-target construction, method/provider state, and activity
@@ -133,8 +133,10 @@ Module responsibilities:
 - `storage`: durable records, transaction interface, and in-memory test
   storage.
 - `records`: shared durable record field types.
-- `identity`: SDK-owned Pubky session capability state and identity
-  refresh/import/export workflows.
+- `identity`: SDK-owned Pubky session capability state, identity refresh state,
+  and local Pubky key helpers.
+- `pubky_session`: Pubky signup, signin, session import, auth handoff, and
+  `pubky://` normalization helpers.
 - `endpoints`: public Payment Endpoint publication, cleanup, and remote public
   Payment List reads.
 - `publication`: shared local publication status values for SDK-managed public
@@ -291,6 +293,20 @@ sign-out APIs itself. The provider is the narrow platform hook for secure
 storage and auth-session handoff, not a separate Pubky SDK or identity product
 that integrators must use.
 
+Rust integrations can use `PubkySessionBootstrap` to create or import the live
+session access consumed by the provider. It covers common Pubky account/session
+workflows: signup, signin, session-secret import, auth handoff
+start/resume/approve helpers, and `pubky://` resource normalization. Full SDK
+runtime auth should use `config.required_session_capabilities()` as the expected
+scope for auth start/resume/approve, completion, and session import. The core
+Paykit capability constant only covers the versioned Paykit Protocol paths.
+`PubkyLocalSecretKey` also provides app/runtime-domain-separated seed
+derivation and public-key-from-secret helpers for apps that choose that key
+convention. Exported session secrets and auth URLs are secret-bearing values
+and must be stored or displayed only for their intended short-lived flow.
+Bindings should wrap these helpers so mobile apps do not need a second Pubky
+SDK dependency for ordinary Paykit onboarding.
+
 ### Paykit Profile And Contact Namespace
 
 The SDK provides default Pubky-backed Paykit-facing profile metadata so
@@ -312,7 +328,11 @@ profile/contact namespace segment. For example, `profile_namespace =
 `/pub/bitkit.to/profile.json`, `/pub/bitkit.to/blobs/...`, and
 `/pub/bitkit.to/contacts/...`. This does not change core Paykit Protocol paths
 such as public Payment Endpoints, and it does not create app-specific private
-runtime isolation under one shared key.
+runtime isolation under one shared key. The app should request the capability
+scope returned by `PaykitSdkConfig::required_session_capabilities()` and
+validate imported/completed sessions against that same scope. That scope
+includes public contact marker writes only when public contact sharing is
+enabled in the SDK configuration.
 
 `image_uri` may point at the configured blob prefix or another public image
 location. The SDK can publish/delete Paykit blobs under the configured blob
@@ -1031,7 +1051,7 @@ Backup should not include:
 - app cloud transport details
 - product-specific profile/contact data outside SDK Contact Records
 - payment-provider secrets unless explicitly provided by the payment adapter
-- seed material unless Paykit standardizes that policy
+- wallet seed material
 
 Restore flow:
 
@@ -1251,7 +1271,7 @@ These should stay outside Paykit SDK:
 - product profile/contact UI
 - localized copy and navigation
 - app backup transport and cloud sync
-- seed/secret derivation policy unless standardized
+- payment-provider seed/secret derivation policy
 - shared identity coordination or cross-app aggregation policy
 
 ## Test Plan


### PR DESCRIPTION
## Summary
- add `PubkySessionBootstrap` for SDK-level Pubky signup, signin, session import, and auth handoff helpers
- add Pubky local secret/public key helpers, seed derivation with an app/runtime label, and required capability validation
- wire runtime/session docs so Paykit SDK can own common Pubky session bootstrap flows without requiring Ring or Bitkit-specific code
- update SDK and bindings plans to describe the new generic bootstrap surface

This intentionally keeps Homegate/free-account provisioning out of scope for now. The SDK exposes generic signup with `homeserver_public_key` + optional signup code; apps can still fetch those from Homegate or another provisioning service themselves.

## Validation
- `cargo fmt --check`
- `cargo test -q -p paykit-sdk identity::tests`
- `cargo test -q -p paykit-sdk`
- `cargo clippy -q -p paykit-sdk --all-targets --all-features`
- `cargo doc -q -p paykit-sdk --no-deps`
- `git diff --check`
- `git diff --cached --check`
