### PR TITLE
Add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Report a defect in Paykit
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear, concise description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+<!-- What you expected to happen. -->
+
+## Actual behaviour
+
+<!-- What actually happened. Include error messages, panics, or logs. -->
+
+## Environment
+
+- Paykit version / commit:
+- Crate(s) affected (`paykit-lib`, `paykit-sdk`, `paykit-ffi`, bindings):
+- Rust version (`rustc --version`):
+- OS / platform:
+
+## Additional context
+
+<!--
+Anything else that helps, e.g. relevant THESAURUS.md terms, spec references,
+or a minimal reproducible example. Do NOT include real routing keys or secrets.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/pubky/paykit-rs/security/advisories/new
+    about: Please report security vulnerabilities privately, not as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: Feature or protocol request
+about: Propose a new capability or protocol change for Paykit
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem / motivation
+
+<!-- What problem does this solve? Who needs it and why? -->
+
+## Proposed solution
+
+<!-- Describe the API, protocol, or behaviour you'd like. -->
+
+## Protocol impact
+
+<!--
+Does this touch the wire format, storage paths, message kinds, or capability
+strings? Link relevant spec sections and use THESAURUS.md vocabulary.
+Write "None" if there is no protocol impact.
+-->
+
+## Downstream bindings
+
+<!--
+Would this change exposed structs, enums, or capability strings consumed by the
+Swift / React Native / Kotlin bindings? Write "None" if not applicable.
+-->
+
+## Alternatives considered
+
+<!-- Other approaches you weighed and why you discarded them. -->
+
+## Additional context
+
+<!-- Links, references, or prior art. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for contributing to Paykit! Please fill in the sections below.
+Keep the title imperative and <=72 chars (e.g. "Implement private list fetch API").
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? Describe the motivation. -->
+
+## Protocol impact
+
+<!--
+Does this change the wire format, storage paths, message kinds, or capability
+strings? Link the relevant spec/issue. Reference THESAURUS.md for domain terms.
+Write "None" if this PR has no protocol impact.
+-->
+
+## Downstream bindings
+
+<!--
+Does this change any exposed struct, enum, or capability string that the
+Swift / React Native / Kotlin bindings consume? If so, note what needs to be
+regenerated or updated in sync. Write "None" if not applicable.
+-->
+
+## Checklist
+
+- [ ] `cargo fmt` passes
+- [ ] `cargo clippy --all-targets --all-features` is clean (or allows are justified)
+- [ ] `cargo test` passes (unit + doc tests)
+- [ ] `cargo doc --no-deps` builds without warnings
+- [ ] Added tests for new behaviour (at least one positive and one failure-path test for new protocol features)
+- [ ] Public API changes include `///` docs and use THESAURUS.md vocabulary
+- [ ] Platform bindings rebuilt for **all** targets if FFI changed (`cd paykit-ffi && ./build.sh all`)
+- [ ] I reviewed this PR myself and asked an LLM to review it and check whether it can be simplified

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities **privately — do not open a public issue.**
+
+Use GitHub's private vulnerability reporting:
+**https://github.com/pubky/paykit-rs/security/advisories/new**
+(Repository → **Security** → **Report a vulnerability**)
+
+Include as much as you can:
+
+- affected crate(s) and version or commit — `paykit-lib`, `paykit-sdk`,
+  `paykit-ffi`, or a Swift / React Native / Kotlin binding
+- the impact (e.g. key exposure, ciphertext malleability, path traversal,
+  timing leak, broken access control on private messages/Receipts)
+- steps to reproduce, or a minimal proof of concept
+- any suggested remediation
+
+**Do not include real routing keys, secrets, or private keys** in a report —
+redact them or use fixtures.
+
+We aim to acknowledge reports within a few business days and will keep you
+updated as we investigate.
+
+## Supported Versions
+
+Paykit is pre-1.0 and published as release candidates. Only the most recent
+release candidate — and `master` — receives security fixes; older
+`0.1.0-rc*` tags are not back-patched.
+
+| Version                       | Supported |
+| ----------------------------- | --------- |
+| latest `0.1.0-rc*` / `master` | ✅        |
+| older `0.1.0-rc*`             | ❌        |
+
+## Scope
+
+**In scope** — the crates in this repository (`paykit-lib`, `paykit-sdk`,
+`paykit-ffi`) and their generated bindings, specifically Paykit's own:
+
+- cryptographic and private-message / Receipt handling
+- storage-path construction (e.g. traversal via a Payment Endpoint identifier)
+- access-control and durability assumptions around private Paykit storage
+
+**Out of scope — report upstream instead:**
+
+- the Pubky SDK, `pubky-noise`, homeservers, or other dependencies
+- applications that consume Paykit
+
+## Coordinated Disclosure
+
+Please give us reasonable time to ship a fix before public disclosure. We're
+happy to credit reporters who would like acknowledgement.


### PR DESCRIPTION
## Summary
- add `.github/pull_request_template.md` with Paykit-specific sections (summary, protocol impact, downstream bindings) plus an fmt/clippy/test/doc pre-submission checklist
- add issue templates for bug reports and feature/protocol requests under `.github/ISSUE_TEMPLATE/`
- add `ISSUE_TEMPLATE/config.yml` that keeps blank issues enabled and steers security reports to a private advisory rather than a public issue

pubky-core has no templates and pubky-nexus only has an LLM-review PR checklist tied to its own crates, so rather than copy either verbatim these follow paykit-rs's own conventions from AGENTS.md (THESAURUS vocabulary, protocol impact, Swift/RN/Kotlin binding sync).

## Admin action needed
The security contact link targets `…/security/advisories/new`, which only resolves once **Private vulnerability reporting** is turned on (Settings → Security → Private vulnerability reporting). It's currently disabled and I don't have admin rights to enable it, so the link 404s until then. If you'd rather not enable it, drop the `contact_link` block from `config.yml`.

## Validation
- Templates/config only; no code changes. `git diff --check` clean.