### PR TITLE
Fix coverage badge publish on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,11 @@ jobs:
           EOF
       - name: Publish badge to orphan 'badges' branch
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           mkdir -p /tmp/badge && mv coverage.svg /tmp/badge/
           cd /tmp/badge
           git init -q
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -q -b badges
           git add coverage.svg
           git commit -q -m "Update coverage badge"


### PR DESCRIPTION
## Summary
- move the `git config user.name/email` lines after `git init` in the coverage
  job's badge-publish step, so the identity applies to the `/tmp/badge` repo
  that actually commits

The coverage job on the first master run failed at the final "publish badge"
step with `fatal: empty ident name`. Identity was set on the main checkout, but
the commit happens in a freshly `git init`-ed repo that inherited no identity.
Coverage itself computed fine (63.6%); only the badge push broke, so the
`badges` branch was never created. This gets master green and lets the badge
publish.

## Validation
- inspected the failed master run — the badge step exited 128; the rest of the
  coverage job (measurement + SVG generation) succeeded
- note: the `Coverage` job is master-only, so it won't run on this PR; its
  fix is exercised on the master run after merge. PR checks cover fmt/clippy/
  test/doc/MSRV only.