### PR TITLE
Add testnet-backed integration tests for paykit-sdk runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,6 +3166,7 @@ dependencies = [
  "hmac",
  "paykit-lib",
  "pubky",
+ "pubky-testnet",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/paykit-sdk/Cargo.toml
+++ b/paykit-sdk/Cargo.toml
@@ -29,4 +29,5 @@ url = "2"
 zeroize = "1"
 
 [dev-dependencies]
+pubky-testnet = { version = "0.8.0", features = ["embedded-postgres"] }
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }

--- a/paykit-sdk/tests/testnet_e2e/encrypted_links.rs
+++ b/paykit-sdk/tests/testnet_e2e/encrypted_links.rs
@@ -1,0 +1,74 @@
+use paykit_sdk::{
+    load_encrypted_link_state, EncryptedLinkHandshakeRole, LinkedPeerState, PaykitSdkError,
+    PubkyPublicKey,
+};
+use pubky_testnet::pubky::Keypair;
+
+use crate::harness::{build_testnet, drive_link_to_linked, two_party, TestUser};
+
+#[tokio::test]
+async fn test_link_handshake_two_party_reaches_linked() {
+    let pair = two_party().await;
+
+    let initiated = pair
+        .alice
+        .sdk
+        .initiate_link_with_peer(pair.bob.public_key.clone())
+        .await
+        .expect("initiating the handshake should succeed");
+    assert_eq!(initiated.state, LinkedPeerState::Linking);
+    assert_eq!(
+        initiated.handshake_role,
+        Some(EncryptedLinkHandshakeRole::Initiator)
+    );
+
+    let accepted = pair
+        .bob
+        .sdk
+        .accept_link_with_peer(pair.alice.public_key.clone())
+        .await
+        .expect("accepting the handshake should succeed");
+    assert_eq!(accepted.state, LinkedPeerState::Linking);
+    assert_eq!(
+        accepted.handshake_role,
+        Some(EncryptedLinkHandshakeRole::Responder)
+    );
+
+    drive_link_to_linked(&pair.alice, &pair.bob).await;
+
+    let peers = pair
+        .alice
+        .sdk
+        .linked_peers()
+        .await
+        .expect("loading linked peers should succeed");
+    assert_eq!(peers.len(), 1);
+    assert_eq!(peers[0].state, LinkedPeerState::Linked);
+
+    // The durable link state holds an active link snapshot and no leftover
+    // handshake state.
+    let link_state = load_encrypted_link_state(&pair.alice.storage, &pair.bob.public_key)
+        .await
+        .expect("loading link state should succeed")
+        .expect("link state should exist after handshake completion");
+    assert!(link_state.link_snapshot.is_some());
+    assert!(link_state.handshake_snapshot.is_none());
+    assert!(link_state.handshake_role.is_none());
+}
+
+#[tokio::test]
+async fn test_advance_link_handshake_without_started_handshake_fails() {
+    let testnet = build_testnet().await;
+    let user = TestUser::sign_up(&testnet).await;
+    let stranger = PubkyPublicKey::from_public_key(&Keypair::random().public_key());
+
+    let err = user
+        .sdk
+        .advance_link_handshake(stranger)
+        .await
+        .expect_err("advancing without stored handshake state must fail");
+    assert!(
+        matches!(err, PaykitSdkError::RecoveryRequired(_)),
+        "unexpected error: {err:?}"
+    );
+}

--- a/paykit-sdk/tests/testnet_e2e/harness.rs
+++ b/paykit-sdk/tests/testnet_e2e/harness.rs
@@ -1,0 +1,271 @@
+//! Shared harness for testnet-backed end-to-end tests.
+//!
+//! Mirrors the embedded-testnet pattern from paykit-lib's test suite: one
+//! embedded Postgres instance shared across the test binary, one ephemeral
+//! Pubky testnet (homeserver) per test, and real signed-up sessions wrapped in
+//! the SDK's own `PubkySessionAccess` via `PubkySessionBootstrap`.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use paykit_sdk::{
+    InMemoryStorage, LinkedPeerState, PaykitSdk, PaykitSdkConfig, PaymentAdapter,
+    PaymentEndpointCandidate, PaymentEndpointSelectionRequest, PaymentTarget, PubkyLocalSecretKey,
+    PubkyPublicKey, PubkySessionAccess, PubkySessionBootstrap, PubkySessionProvider,
+    ReceivingDetail, ReceivingDetailScope, Result,
+};
+use pubky_testnet::{embedded_postgres::EmbeddedPostgres, pubky::Keypair, EphemeralTestnet};
+use tokio::sync::{Mutex as TokioMutex, OnceCell};
+
+static SHARED_POSTGRES: OnceCell<EmbeddedPostgres> = OnceCell::const_new();
+static TESTNET_BUILD_LOCK: TokioMutex<()> = TokioMutex::const_new(());
+
+async fn shared_postgres() -> &'static EmbeddedPostgres {
+    SHARED_POSTGRES
+        .get_or_init(|| async {
+            EmbeddedPostgres::start()
+                .await
+                .expect("failed to start embedded postgres")
+        })
+        .await
+}
+
+pub async fn build_testnet() -> EphemeralTestnet {
+    let _guard = TESTNET_BUILD_LOCK.lock().await;
+
+    let builder = if std::env::var_os("TEST_PUBKY_CONNECTION_STRING").is_some() {
+        EphemeralTestnet::builder()
+    } else {
+        let postgres = shared_postgres()
+            .await
+            .connection_string()
+            .expect("embedded postgres connection string should be valid");
+        EphemeralTestnet::builder().postgres(postgres)
+    };
+
+    builder.build().await.unwrap()
+}
+
+/// Session provider backed by a real testnet session.
+///
+/// `clear_session_access` genuinely drops the stored access so sign-out
+/// behaves like an app clearing platform credential storage.
+#[derive(Clone)]
+pub struct TestnetSessionProvider {
+    session: Arc<Mutex<Option<PubkySessionAccess>>>,
+}
+
+impl TestnetSessionProvider {
+    pub fn new(access: PubkySessionAccess) -> Self {
+        Self {
+            session: Arc::new(Mutex::new(Some(access))),
+        }
+    }
+}
+
+#[async_trait]
+impl PubkySessionProvider for TestnetSessionProvider {
+    async fn load_session_access(&self) -> Result<Option<PubkySessionAccess>> {
+        Ok(self.session.lock().expect("session lock poisoned").clone())
+    }
+
+    async fn load_public_storage(&self) -> Result<Option<pubky::PublicStorage>> {
+        Ok(self
+            .session
+            .lock()
+            .expect("session lock poisoned")
+            .as_ref()
+            .map(|access| access.outbox_client.public_storage()))
+    }
+
+    async fn clear_session_access(&self) -> Result<()> {
+        *self.session.lock().expect("session lock poisoned") = None;
+        Ok(())
+    }
+}
+
+/// Payment adapter whose receiving details can be changed mid-test.
+#[derive(Clone, Default)]
+pub struct TestnetPaymentAdapter {
+    public_details: Arc<Mutex<Vec<ReceivingDetail>>>,
+    private_details: Arc<Mutex<Vec<ReceivingDetail>>>,
+}
+
+impl TestnetPaymentAdapter {
+    pub fn set_public_details(&self, details: Vec<ReceivingDetail>) {
+        *self.public_details.lock().expect("details lock poisoned") = details;
+    }
+
+    pub fn set_private_details(&self, details: Vec<ReceivingDetail>) {
+        *self.private_details.lock().expect("details lock poisoned") = details;
+    }
+}
+
+#[async_trait]
+impl PaymentAdapter for TestnetPaymentAdapter {
+    async fn current_receiving_details(
+        &self,
+        scope: ReceivingDetailScope,
+    ) -> Result<Vec<ReceivingDetail>> {
+        let details = if matches!(scope, ReceivingDetailScope::Public) {
+            &self.public_details
+        } else {
+            &self.private_details
+        };
+        Ok(details.lock().expect("details lock poisoned").clone())
+    }
+
+    async fn select_payment_endpoints(
+        &self,
+        request: &PaymentEndpointSelectionRequest,
+    ) -> Result<Vec<PaymentEndpointCandidate>> {
+        Ok(request.candidates.clone())
+    }
+
+    async fn build_payment_target(
+        &self,
+        endpoint: &PaymentEndpointCandidate,
+    ) -> Result<PaymentTarget> {
+        Ok(PaymentTarget {
+            payload: endpoint.payload.clone(),
+        })
+    }
+}
+
+/// One signed-up testnet user with an initialized SDK runtime.
+///
+/// `storage` is a clone sharing state with the SDK's storage, kept for direct
+/// record assertions. `access` retains the real session for unauthenticated
+/// public-storage reads in assertions.
+pub struct TestUser {
+    pub sdk: PaykitSdk<InMemoryStorage, TestnetSessionProvider, TestnetPaymentAdapter>,
+    pub storage: InMemoryStorage,
+    pub adapter: TestnetPaymentAdapter,
+    pub access: PubkySessionAccess,
+    pub public_key: PubkyPublicKey,
+}
+
+impl TestUser {
+    /// Sign up a fresh keypair on the testnet homeserver through the SDK's own
+    /// bootstrap, then build and initialize a runtime around the session.
+    ///
+    /// One keypair is used for both signup and the local secret key so that
+    /// `PubkySessionAccess::validate` holds and the session is
+    /// private-link-capable.
+    pub async fn sign_up(testnet: &EphemeralTestnet) -> TestUser {
+        let keypair = Keypair::random();
+        let secret_key = PubkyLocalSecretKey::new(keypair.secret_key());
+        let homeserver_public_key =
+            PubkyPublicKey::from_public_key(&testnet.homeserver_app().public_key());
+        let bootstrap =
+            PubkySessionBootstrap::with_pubky(testnet.sdk().expect("testnet Pubky client"));
+        let result = bootstrap
+            .sign_up(&secret_key, &homeserver_public_key, None)
+            .await
+            .expect("testnet sign-up should succeed");
+
+        let storage = InMemoryStorage::default();
+        let adapter = TestnetPaymentAdapter::default();
+        let provider = TestnetSessionProvider::new(result.access.clone());
+        let sdk = PaykitSdk::new(
+            storage.clone(),
+            provider,
+            adapter.clone(),
+            PaykitSdkConfig::default(),
+        )
+        .expect("SDK construction should succeed");
+
+        let report = sdk
+            .initialize()
+            .await
+            .expect("SDK initialization should succeed");
+        assert!(report.live_session_available);
+        assert!(report.identity.private_link_capable);
+
+        TestUser {
+            sdk,
+            storage,
+            adapter,
+            access: result.access,
+            public_key: result.public_key,
+        }
+    }
+}
+
+/// Two signed-up users sharing one testnet homeserver.
+pub struct TwoParty {
+    pub _testnet: EphemeralTestnet,
+    pub alice: TestUser,
+    pub bob: TestUser,
+}
+
+pub async fn two_party() -> TwoParty {
+    let testnet = build_testnet().await;
+    let alice = TestUser::sign_up(&testnet).await;
+    let bob = TestUser::sign_up(&testnet).await;
+    TwoParty {
+        _testnet: testnet,
+        alice,
+        bob,
+    }
+}
+
+/// Two users with an established Encrypted Link between them.
+pub async fn linked_two_party() -> TwoParty {
+    let pair = two_party().await;
+    pair.alice
+        .sdk
+        .initiate_link_with_peer(pair.bob.public_key.clone())
+        .await
+        .expect("initiating the Encrypted Link Handshake should succeed");
+    pair.bob
+        .sdk
+        .accept_link_with_peer(pair.alice.public_key.clone())
+        .await
+        .expect("accepting the Encrypted Link Handshake should succeed");
+    drive_link_to_linked(&pair.alice, &pair.bob).await;
+    pair
+}
+
+/// Poll both sides of an in-progress Encrypted Link Handshake until both
+/// report `Linked`.
+///
+/// One `advance_link_handshake` call performs one Noise XX step; a missing
+/// counterparty message is `Linking` (not an error), so advance failures are
+/// real faults and unwrap loudly.
+pub async fn drive_link_to_linked(alice: &TestUser, bob: &TestUser) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut alice_state = LinkedPeerState::Linking;
+    let mut bob_state = LinkedPeerState::Linking;
+    while alice_state != LinkedPeerState::Linked || bob_state != LinkedPeerState::Linked {
+        assert!(
+            Instant::now() < deadline,
+            "Encrypted Link Handshake timed out"
+        );
+        if alice_state != LinkedPeerState::Linked {
+            alice_state = alice
+                .sdk
+                .advance_link_handshake(bob.public_key.clone())
+                .await
+                .expect("initiator handshake advance should succeed")
+                .state;
+        }
+        if bob_state != LinkedPeerState::Linked {
+            bob_state = bob
+                .sdk
+                .advance_link_handshake(alice.public_key.clone())
+                .await
+                .expect("responder handshake advance should succeed")
+                .state;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+pub fn receiving_detail(identifier: &str, payload: &str) -> ReceivingDetail {
+    ReceivingDetail {
+        identifier: identifier.into(),
+        payload: payload.into(),
+    }
+}

--- a/paykit-sdk/tests/testnet_e2e/main.rs
+++ b/paykit-sdk/tests/testnet_e2e/main.rs
@@ -1,0 +1,13 @@
+//! Testnet-backed end-to-end tests for the paykit-sdk runtime.
+//!
+//! These tests run the real network paths (publish, handshake, private
+//! send/receive, recovery markers, profiles) against an ephemeral Pubky
+//! homeserver, complementing the mock-based unit tests under `src/`.
+
+mod harness;
+
+mod encrypted_links;
+mod private_lists;
+mod profiles;
+mod public_endpoints;
+mod recovery;

--- a/paykit-sdk/tests/testnet_e2e/private_lists.rs
+++ b/paykit-sdk/tests/testnet_e2e/private_lists.rs
@@ -1,0 +1,77 @@
+use paykit_sdk::{OutboundPrivateMessageStatus, PaykitSdkError};
+
+use crate::harness::{linked_two_party, receiving_detail, two_party};
+
+#[tokio::test]
+async fn test_private_payment_list_roundtrip_between_linked_peers() {
+    let pair = linked_two_party().await;
+    pair.alice
+        .adapter
+        .set_private_details(vec![receiving_detail(
+            "btc-lightning-bolt11",
+            "ln-private-alice",
+        )]);
+
+    let queued = pair
+        .alice
+        .sdk
+        .enqueue_private_payment_list(pair.bob.public_key.clone())
+        .await
+        .expect("enqueue should succeed for a linked peer");
+    assert_eq!(queued.status, OutboundPrivateMessageStatus::Pending);
+
+    let send_report = pair
+        .alice
+        .sdk
+        .process_outbound_private_messages(pair.bob.public_key.clone())
+        .await
+        .expect("processing the outbound queue should succeed");
+    assert_eq!(send_report.sent, vec![queued.outbound_message_id]);
+    assert!(send_report.failed.is_empty());
+
+    let intake = pair
+        .bob
+        .sdk
+        .receive_private_messages(pair.alice.public_key.clone())
+        .await
+        .expect("receiving private messages should succeed");
+    assert!(!intake.stream_item_ids.is_empty());
+    assert!(intake.event_conflicts.is_empty());
+
+    let view = pair
+        .bob
+        .sdk
+        .current_private_payment_list(&pair.alice.public_key)
+        .await
+        .expect("reading the Private Payment List should succeed")
+        .expect("a valid list should be present after receive");
+    assert_eq!(
+        view.payment_endpoints
+            .get("btc-lightning-bolt11")
+            .map(String::as_str),
+        Some("ln-private-alice")
+    );
+    assert!(view.latest_stream_item_id.is_some());
+}
+
+#[tokio::test]
+async fn test_enqueue_private_payment_list_without_link_fails() {
+    let pair = two_party().await;
+    pair.alice
+        .adapter
+        .set_private_details(vec![receiving_detail(
+            "btc-lightning-bolt11",
+            "ln-private-alice",
+        )]);
+
+    let err = pair
+        .alice
+        .sdk
+        .enqueue_private_payment_list(pair.bob.public_key.clone())
+        .await
+        .expect_err("enqueue without an Encrypted Link must fail");
+    assert!(
+        matches!(err, PaykitSdkError::RecoveryRequired(_)),
+        "unexpected error: {err:?}"
+    );
+}

--- a/paykit-sdk/tests/testnet_e2e/profiles.rs
+++ b/paykit-sdk/tests/testnet_e2e/profiles.rs
@@ -1,0 +1,40 @@
+use paykit_sdk::PaykitProfile;
+
+use crate::harness::two_party;
+
+#[tokio::test]
+async fn test_paykit_profile_publish_and_fetch_roundtrip() {
+    let pair = two_party().await;
+
+    let profile = PaykitProfile {
+        display_name: Some("Alice".into()),
+        image_uri: None,
+        extra: None,
+    };
+    let record = pair
+        .alice
+        .sdk
+        .publish_paykit_profile(profile.clone())
+        .await
+        .expect("publishing the profile should succeed");
+    assert_eq!(record.public_key, pair.alice.public_key);
+
+    let fetched = pair
+        .bob
+        .sdk
+        .fetch_paykit_profile(pair.alice.public_key.clone())
+        .await
+        .expect("fetching the profile should succeed")
+        .expect("the published profile should be present");
+    assert_eq!(fetched.profile, profile);
+    assert_eq!(fetched.public_key, pair.alice.public_key);
+
+    // A missing profile is a real homeserver 404 mapped to Ok(None).
+    let missing = pair
+        .bob
+        .sdk
+        .fetch_paykit_profile(pair.bob.public_key.clone())
+        .await
+        .expect("fetching an absent profile should not error");
+    assert!(missing.is_none());
+}

--- a/paykit-sdk/tests/testnet_e2e/public_endpoints.rs
+++ b/paykit-sdk/tests/testnet_e2e/public_endpoints.rs
@@ -2,6 +2,14 @@ use paykit_sdk::{load_public_endpoint_records, PaykitSdkError, PublicationStatus
 
 use crate::harness::{build_testnet, receiving_detail, TestUser};
 
+/// Payload published for `identifier`, or `None` when the endpoint is absent.
+fn payload_of<'a>(list: &'a paykit_lib::PaymentList, identifier: &str) -> Option<&'a str> {
+    list.payment_endpoints
+        .iter()
+        .find(|(id, _)| id.as_str() == identifier)
+        .map(|(_, payload)| payload.as_str())
+}
+
 #[tokio::test]
 async fn test_sync_public_endpoints_publishes_and_removes_managed_endpoints() {
     let testnet = build_testnet().await;
@@ -33,14 +41,11 @@ async fn test_sync_public_endpoints_publishes_and_removes_managed_endpoints() {
     let list = paykit_lib::get_payment_list(&storage, &payee)
         .await
         .expect("Payment List fetch should succeed");
-    assert!(list
-        .payment_endpoints
-        .keys()
-        .any(|id| id.as_str() == "btc-lightning-bolt11"));
-    assert!(list
-        .payment_endpoints
-        .keys()
-        .any(|id| id.as_str() == "btc-onchain"));
+    assert_eq!(
+        payload_of(&list, "btc-lightning-bolt11"),
+        Some("lnbc-test-invoice")
+    );
+    assert_eq!(payload_of(&list, "btc-onchain"), Some("bc1q-test-address"));
 
     // Local publication records mirror the remote state.
     let records = load_public_endpoint_records(&user.storage)
@@ -69,14 +74,11 @@ async fn test_sync_public_endpoints_publishes_and_removes_managed_endpoints() {
     let list = paykit_lib::get_payment_list(&storage, &payee)
         .await
         .expect("Payment List fetch should succeed");
-    assert!(!list
-        .payment_endpoints
-        .keys()
-        .any(|id| id.as_str() == "btc-onchain"));
-    assert!(list
-        .payment_endpoints
-        .keys()
-        .any(|id| id.as_str() == "btc-lightning-bolt11"));
+    assert_eq!(payload_of(&list, "btc-onchain"), None);
+    assert_eq!(
+        payload_of(&list, "btc-lightning-bolt11"),
+        Some("lnbc-test-invoice")
+    );
 }
 
 #[tokio::test]

--- a/paykit-sdk/tests/testnet_e2e/public_endpoints.rs
+++ b/paykit-sdk/tests/testnet_e2e/public_endpoints.rs
@@ -1,0 +1,102 @@
+use paykit_sdk::{load_public_endpoint_records, PaykitSdkError, PublicationStatus};
+
+use crate::harness::{build_testnet, receiving_detail, TestUser};
+
+#[tokio::test]
+async fn test_sync_public_endpoints_publishes_and_removes_managed_endpoints() {
+    let testnet = build_testnet().await;
+    let user = TestUser::sign_up(&testnet).await;
+    user.adapter.set_public_details(vec![
+        receiving_detail("btc-lightning-bolt11", "lnbc-test-invoice"),
+        receiving_detail("btc-onchain", "bc1q-test-address"),
+    ]);
+
+    let report = user
+        .sdk
+        .sync_public_endpoints()
+        .await
+        .expect("public endpoint sync should succeed");
+    assert_eq!(report.published.len(), 2);
+    assert!(report.removed.is_empty());
+    assert!(report.failed.is_empty());
+    for change in &report.published {
+        assert_eq!(change.status, PublicationStatus::Published);
+        assert!(change.error.is_none());
+    }
+
+    // Remote state: both endpoints readable through unauthenticated storage.
+    let storage = user.access.outbox_client.public_storage();
+    let payee = user
+        .public_key
+        .to_public_key()
+        .expect("public key conversion should succeed");
+    let list = paykit_lib::get_payment_list(&storage, &payee)
+        .await
+        .expect("Payment List fetch should succeed");
+    assert!(list
+        .payment_endpoints
+        .keys()
+        .any(|id| id.as_str() == "btc-lightning-bolt11"));
+    assert!(list
+        .payment_endpoints
+        .keys()
+        .any(|id| id.as_str() == "btc-onchain"));
+
+    // Local publication records mirror the remote state.
+    let records = load_public_endpoint_records(&user.storage)
+        .await
+        .expect("loading endpoint records should succeed");
+    assert_eq!(records.len(), 2);
+    assert!(records
+        .iter()
+        .all(|record| record.status == PublicationStatus::Published));
+
+    // Shrinking the desired set removes the stale endpoint remotely.
+    user.adapter.set_public_details(vec![receiving_detail(
+        "btc-lightning-bolt11",
+        "lnbc-test-invoice",
+    )]);
+    let report = user
+        .sdk
+        .sync_public_endpoints()
+        .await
+        .expect("second public endpoint sync should succeed");
+    assert_eq!(report.removed.len(), 1);
+    assert_eq!(report.removed[0].identifier, "btc-onchain");
+    assert_eq!(report.removed[0].status, PublicationStatus::Removed);
+    assert!(report.failed.is_empty());
+
+    let list = paykit_lib::get_payment_list(&storage, &payee)
+        .await
+        .expect("Payment List fetch should succeed");
+    assert!(!list
+        .payment_endpoints
+        .keys()
+        .any(|id| id.as_str() == "btc-onchain"));
+    assert!(list
+        .payment_endpoints
+        .keys()
+        .any(|id| id.as_str() == "btc-lightning-bolt11"));
+}
+
+#[tokio::test]
+async fn test_sync_public_endpoints_after_sign_out_fails() {
+    let testnet = build_testnet().await;
+    let user = TestUser::sign_up(&testnet).await;
+    user.adapter.set_public_details(vec![receiving_detail(
+        "btc-lightning-bolt11",
+        "lnbc-test-invoice",
+    )]);
+
+    user.sdk.sign_out().await.expect("sign-out should succeed");
+
+    let err = user
+        .sdk
+        .sync_public_endpoints()
+        .await
+        .expect_err("sync without a session must fail");
+    assert!(
+        matches!(err, PaykitSdkError::Identity { .. }),
+        "unexpected error: {err:?}"
+    );
+}

--- a/paykit-sdk/tests/testnet_e2e/recovery.rs
+++ b/paykit-sdk/tests/testnet_e2e/recovery.rs
@@ -52,6 +52,32 @@ async fn test_recovery_marker_publish_observe_remove_roundtrip() {
     );
     assert_eq!(observed.state, LinkedPeerState::RecoveryRequired);
 
+    // Direct fetch through unauthenticated storage proves the marker file is
+    // on the homeserver before removal. This also validates the fetch
+    // arguments themselves, so the post-removal `None` below is meaningful.
+    let storage = pair.bob.access.outbox_client.public_storage();
+    let bob_secret_key = pair
+        .bob
+        .access
+        .local_secret_key
+        .as_ref()
+        .expect("bob's session should retain a local secret key")
+        .as_bytes();
+    let alice_public_key = pair
+        .alice
+        .public_key
+        .to_public_key()
+        .expect("public key conversion should succeed");
+    let marker = paykit_lib::fetch_encrypted_link_recovery_marker(
+        &storage,
+        bob_secret_key,
+        &alice_public_key,
+    )
+    .await
+    .expect("direct marker fetch should succeed")
+    .expect("the published marker should be present on the homeserver");
+    assert_eq!(marker.attempt_id(), attempt_id.as_str());
+
     // Removal clears the local marker; a later observe sees no new marker.
     let removed = pair
         .alice
@@ -60,6 +86,21 @@ async fn test_recovery_marker_publish_observe_remove_roundtrip() {
         .await
         .expect("removing the recovery marker should succeed");
     assert!(removed.local_attempt_id.is_none());
+
+    // `remote_marker_changed` stays false both when the marker is gone and
+    // when the already-observed marker is still present, so assert remote
+    // deletion directly.
+    let marker = paykit_lib::fetch_encrypted_link_recovery_marker(
+        &storage,
+        bob_secret_key,
+        &alice_public_key,
+    )
+    .await
+    .expect("direct marker fetch after removal should succeed");
+    assert!(
+        marker.is_none(),
+        "the recovery marker must be deleted from the homeserver"
+    );
 
     let observed_again = pair
         .bob

--- a/paykit-sdk/tests/testnet_e2e/recovery.rs
+++ b/paykit-sdk/tests/testnet_e2e/recovery.rs
@@ -1,0 +1,87 @@
+use paykit_sdk::{LinkedPeerState, PaykitSdkError};
+
+use crate::harness::{linked_two_party, receiving_detail, two_party};
+
+#[tokio::test]
+async fn test_recovery_marker_publish_observe_remove_roundtrip() {
+    let pair = linked_two_party().await;
+
+    let published = pair
+        .alice
+        .sdk
+        .publish_encrypted_link_recovery_marker(pair.bob.public_key.clone())
+        .await
+        .expect("publishing the recovery marker should succeed");
+    assert_eq!(published.state, LinkedPeerState::RecoveryRequired);
+    assert!(published.local_marker_last_error.is_none());
+    let attempt_id = published
+        .local_attempt_id
+        .clone()
+        .expect("a local recovery attempt id should be recorded");
+
+    // Recovery fails closed: private automation is blocked until the link is
+    // re-established.
+    pair.alice
+        .adapter
+        .set_private_details(vec![receiving_detail(
+            "btc-lightning-bolt11",
+            "ln-private-alice",
+        )]);
+    let err = pair
+        .alice
+        .sdk
+        .enqueue_private_payment_list(pair.bob.public_key.clone())
+        .await
+        .expect_err("private automation must be blocked during recovery");
+    assert!(
+        matches!(err, PaykitSdkError::RecoveryRequired(_)),
+        "unexpected error: {err:?}"
+    );
+
+    // The counterparty observes the marker through public storage.
+    let observed = pair
+        .bob
+        .sdk
+        .observe_encrypted_link_recovery_marker(pair.alice.public_key.clone())
+        .await
+        .expect("observing the recovery marker should succeed");
+    assert!(observed.remote_marker_changed);
+    assert_eq!(
+        observed.remote_attempt_id.as_deref(),
+        Some(attempt_id.as_str())
+    );
+    assert_eq!(observed.state, LinkedPeerState::RecoveryRequired);
+
+    // Removal clears the local marker; a later observe sees no new marker.
+    let removed = pair
+        .alice
+        .sdk
+        .remove_encrypted_link_recovery_marker(pair.bob.public_key.clone())
+        .await
+        .expect("removing the recovery marker should succeed");
+    assert!(removed.local_attempt_id.is_none());
+
+    let observed_again = pair
+        .bob
+        .sdk
+        .observe_encrypted_link_recovery_marker(pair.alice.public_key.clone())
+        .await
+        .expect("re-observing after removal should succeed");
+    assert!(!observed_again.remote_marker_changed);
+}
+
+#[tokio::test]
+async fn test_publish_recovery_marker_without_private_link_state_fails() {
+    let pair = two_party().await;
+
+    let err = pair
+        .alice
+        .sdk
+        .publish_encrypted_link_recovery_marker(pair.bob.public_key.clone())
+        .await
+        .expect_err("publishing a marker without private link state must fail");
+    assert!(
+        matches!(err, PaykitSdkError::Policy(_)),
+        "unexpected error: {err:?}"
+    );
+}


### PR DESCRIPTION
## Motivation

The SDK's network-facing runtime modules were nearly untested. Every existing runtime test uses a session provider that returns `None`, so all network entry points short-circuit at "no Pubky session available" and the real publish, handshake, send/receive, and recovery paths never execute. Before this PR: `public_endpoints.rs` 5.3% line coverage, `private_stream.rs` 4.2%, `outbound_private.rs` 19.7%, `encrypted_links.rs` 28.9%, `recovery.rs` 38.7%.

paykit-lib solves this with an embedded-testnet harness and sits at 88%. This PR gives paykit-sdk the same treatment.

## What this adds

- `pubky-testnet` (with `embedded-postgres`) as a paykit-sdk dev-dependency. Already in Cargo.lock via paykit-lib, so zero new resolved crates.
- A new `paykit-sdk/tests/testnet_e2e/` integration-test binary that signs up real users on an ephemeral homeserver through the SDK's own `PubkySessionBootstrap`, wraps the resulting `PubkySessionAccess` in a real session provider, and drives the public API end to end.
- 9 tests across 5 flows, each file with at least one failure path:
  - public endpoint sync: publish + stale removal verified through unauthenticated `PublicStorage`; sync after sign-out fails with `Identity`
  - Encrypted Link Handshake: two-party Noise XX to `Linked` over real homeserver files; advance without stored handshake fails with `RecoveryRequired`
  - Private Payment List: enqueue -> send -> receive -> read roundtrip between linked peers; enqueue without a link fails with `RecoveryRequired`
  - recovery markers: publish/observe/remove roundtrip, including fail-closed blocking of private automation during recovery; publish without private link state fails with `Policy`
  - Paykit profiles: publish/fetch roundtrip; absent profile maps homeserver 404 to `Ok(None)`

## Protocol impacts

None. Test-only change, no `src/**` modifications, no public API changes.

## Coverage impact

Workspace line coverage 63.6% -> 69.5% (cargo llvm-cov). The new suite alone exercises 23% of paykit-sdk's lines. Target modules, measured before -> after on this branch:

| module | before | after |
|---|---|---|
| runtime/recovery.rs | 38.7% | 76.9% |
| runtime/outbound_private.rs | 19.7% | 54.8% |
| runtime/public_endpoints.rs | 5.3% | 52.0% |
| runtime/encrypted_links.rs | 28.9% | 51.1% |
| runtime/private_stream.rs | 4.2% | 38.7% |
| runtime/profiles.rs | 16.6% | 37.6% |
| pubky_session.rs | 35.9% | 50.7% |

## Validation

- `cargo test -p paykit-sdk --test testnet_e2e`: 9 passed, 0 failed, 22.9s
- `cargo test --workspace --all-features`: runs under `cargo llvm-cov` above, all green
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean

## Follow-ups (out of scope)

- Advanceable test clock for lease-expiry and retry-backoff paths
- Crash-safety/replay tests (persist-order invariants, homeserver write faults)
- Receipts, Payment Requests, contacts, and backup end-to-end flows