### PR TITLE
Remove two reachable-in-principle library panics

### DIFF
--- a/paykit-ffi/src/profiles.rs
+++ b/paykit-ffi/src/profiles.rs
@@ -462,10 +462,12 @@ impl From<PaykitProfile> for FfiPaykitProfile {
         Self {
             display_name: value.display_name,
             image_uri: value.image_uri,
-            extra_json: value.extra.map(|extra| {
-                serde_json::to_string(&extra)
-                    .expect("profile extra is a serde_json object and serializes")
-            }),
+            // serde_json::to_string cannot fail for a string-keyed Value map
+            // (no arbitrary_precision), so this is defensive: prefer None over a
+            // fabricated "{}" that would round-trip into Some(empty map).
+            extra_json: value
+                .extra
+                .and_then(|extra| serde_json::to_string(&extra).ok()),
         }
     }
 }

--- a/paykit-lib/src/payment_request/api.rs
+++ b/paykit-lib/src/payment_request/api.rs
@@ -166,14 +166,34 @@ mod tests {
     // future kind from reaching a panic, so this exercises parse_event directly.
     #[test]
     fn test_parse_event_non_request_kind_rejected() {
+        // Sentinel plaintext standing in for a decrypted private payload. The
+        // non-request arm must reject the kind without ever copying `raw` into
+        // the error context; `build_event_message` renders that context via
+        // `PaykitError::to_string`, so a leak here would surface the plaintext.
+        let raw = "{\"secret\":\"SENTINEL_DECRYPTED_PLAINTEXT\"}";
         for kind in [
             PrivateMessageKind::PrivatePaymentList,
             PrivateMessageKind::ReceiptAccess,
         ] {
-            let result = parse_event(kind, "{}");
+            let result = parse_event(kind, raw);
+            let Err(PaykitError::InvalidData { context, source }) = result else {
+                panic!("expected InvalidData for non-request kind {kind}, got {result:?}");
+            };
+            // The non-request arm sets no source.
             assert!(
-                matches!(result, Err(PaykitError::InvalidData { .. })),
-                "expected InvalidData for non-request kind {kind}",
+                source.is_none(),
+                "expected no source for non-request kind {kind}",
+            );
+            // The decrypted plaintext must never leak into the error context.
+            assert!(
+                !context.contains("SENTINEL_DECRYPTED_PLAINTEXT"),
+                "decrypted raw plaintext leaked into error context for kind {kind}: {context}",
+            );
+            // The context is the exact kind-only string the arm produces.
+            assert_eq!(
+                context,
+                format!("unexpected private message kind for a Payment Request event: {kind}"),
+                "unexpected context for non-request kind {kind}",
             );
         }
     }

--- a/paykit-lib/src/payment_request/api.rs
+++ b/paykit-lib/src/payment_request/api.rs
@@ -1,6 +1,6 @@
 use tracing::instrument;
 
-use crate::{error::map_error, EncryptedLink, PrivateApplicationMessage, Result};
+use crate::{error::map_error, EncryptedLink, PaykitError, PrivateApplicationMessage, Result};
 
 use super::{
     types::{
@@ -34,7 +34,18 @@ fn parse_event(kind: PrivateMessageKind, raw: &str) -> Result<PaymentRequestEven
         PrivateMessageKind::PaymentProof => {
             parse_payment_proof_json(raw).map(PaymentRequestEvent::Proof)
         }
-        _ => unreachable!("only Payment Request event kinds are selected"),
+        // Explicit non-request arms (not a `_` wildcard) so a future
+        // PrivateMessageKind variant becomes a compile error here instead of a
+        // silent panic on decrypted network data. Context carries the kind
+        // string only, never `raw` (decrypted private payload).
+        PrivateMessageKind::PrivatePaymentList | PrivateMessageKind::ReceiptAccess => {
+            Err(PaykitError::InvalidData {
+                context: format!(
+                    "unexpected private message kind for a Payment Request event: {kind}"
+                ),
+                source: None,
+            })
+        }
     }
 }
 
@@ -143,4 +154,27 @@ pub async fn send_payment_proof(link: &mut EncryptedLink, event: &PaymentProof) 
     link.send_payment_proof_message(json.as_bytes())
         .await
         .map_err(|err| map_error("send_payment_proof", err))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // parse_event is only reached for Payment Request event kinds in production
+    // (parse_payment_request_event_message filters via is_payment_request_event
+    // and returns None for other kinds). The explicit non-request arms guard a
+    // future kind from reaching a panic, so this exercises parse_event directly.
+    #[test]
+    fn test_parse_event_non_request_kind_rejected() {
+        for kind in [
+            PrivateMessageKind::PrivatePaymentList,
+            PrivateMessageKind::ReceiptAccess,
+        ] {
+            let result = parse_event(kind, "{}");
+            assert!(
+                matches!(result, Err(PaykitError::InvalidData { .. })),
+                "expected InvalidData for non-request kind {kind}",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Two panics that are unreachable for today's inputs but could be reached as the
code evolves:

- The stateless parser `parse_event` in `paykit-lib/src/payment_request/api.rs`
  (which runs over *decrypted private network data*) ended in
  `_ => unreachable!()`.
- `From<PaykitProfile>` in `paykit-ffi/src/profiles.rs` used
  `serde_json::to_string(...).expect(...)` at the FFI boundary.

## Changes

- **`paykit-lib/src/payment_request/api.rs`.** Replaced the wildcard with explicit
  `PrivateMessageKind::PrivatePaymentList | ReceiptAccess` arms returning
  `PaykitError::InvalidData`. The explicit arms are the point: a future
  `PrivateMessageKind` variant now becomes a **compile error** here instead of a
  silent panic on network data. Context carries the **kind string only**, never the
  decrypted payload.
- **`paykit-ffi/src/profiles.rs`.** Replaced the `.expect(...)` with
  `and_then(...).ok()`, preferring `None` over a panic and over a fabricated `"{}"`
  (which would round-trip into `Some(empty map)`).

## Tests

- New failure-path test `test_parse_event_non_request_kind_rejected` asserts
  `InvalidData` for each non-request kind.
- **Note on the test path:** it calls the private `parse_event` directly rather than
  going through the public API, because `parse_payment_request_event_message`
  filters non-request kinds to `None` (via `is_payment_request_event`) *before*
  reaching the new arm — so building a non-request message and passing it through
  the public API would return `None`, not exercise the fix. `parse_event` is the
  function whose behavior changed.
- **No failure-path test for the profiles change:** a string-keyed
  `serde_json::Map<String, Value>` cannot fail to serialize without the
  `arbitrary_precision` feature, so the failure is unconstructible. Existing
  `test_profile_extra_json_round_trips` and `test_profile_extra_json_rejects_non_object`
  still pass.

## Protocol / bindings impact

- **Protocol impact:** none. Behavior-preserving for all real inputs.
- **No UniFFI shape change** — the profiles edit is internal to a `From` impl body;
  no binding regeneration needed.

## Verification (local)

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p paykit-lib -p paykit-ffi`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `cargo check --workspace --all-features`

The full networked e2e suite runs in CI.
