### PR TITLE
Redact persisted error strings in record Debug output

### DIFF
--- a/paykit-sdk/src/domain/recovery.rs
+++ b/paykit-sdk/src/domain/recovery.rs
@@ -1,5 +1,7 @@
 //! Encrypted Link recovery marker state.
 
+use std::fmt;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -10,7 +12,12 @@ use crate::{
 };
 
 /// Public recovery marker state tracked for one Linked Peer.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `local_marker_last_error` mirrors the raw publish/remove failure string from
+/// the durable Linked Peer record, which can embed private storage paths or
+/// payload material. `Debug` redacts it to length only, matching the
+/// `LinkedPeerRecord` idiom, so `format!("{report:?}")` cannot leak it.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EncryptedLinkRecoveryMarkerReport {
     /// Counterparty public key.
     pub counterparty: PubkyPublicKey,
@@ -30,6 +37,31 @@ pub struct EncryptedLinkRecoveryMarkerReport {
     pub remote_marker_observed_at: Option<DateTime<Utc>>,
     /// Whether this operation observed a new counterparty marker.
     pub remote_marker_changed: bool,
+}
+
+impl fmt::Debug for EncryptedLinkRecoveryMarkerReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EncryptedLinkRecoveryMarkerReport")
+            .field("counterparty", &self.counterparty)
+            .field(
+                "counterparty_receiver_path",
+                &self.counterparty_receiver_path,
+            )
+            .field("state", &self.state)
+            .field("local_attempt_id", &self.local_attempt_id)
+            .field("local_marker_created_at", &self.local_marker_created_at)
+            .field(
+                "local_marker_last_error",
+                &self
+                    .local_marker_last_error
+                    .as_ref()
+                    .map(|error| format!("<redacted:{} bytes>", error.len())),
+            )
+            .field("remote_attempt_id", &self.remote_attempt_id)
+            .field("remote_marker_observed_at", &self.remote_marker_observed_at)
+            .field("remote_marker_changed", &self.remote_marker_changed)
+            .finish()
+    }
 }
 
 impl EncryptedLinkRecoveryMarkerReport {
@@ -64,4 +96,46 @@ where
                 .map(|peer| EncryptedLinkRecoveryMarkerReport::from_peer(peer, false)))
         })
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn counterparty() -> PubkyPublicKey {
+        PubkyPublicKey::from_public_key(&pubky::Keypair::random().public_key())
+    }
+
+    fn receiver_path() -> PaykitReceiverPath {
+        PaykitReceiverPath::new("bitkit/wallet").unwrap()
+    }
+
+    #[test]
+    fn test_recovery_marker_report_debug_redacts_local_marker_error() {
+        // The sentinel stands in for a raw publish/remove failure string that may
+        // embed private storage paths or payload material. It must never survive
+        // into Debug output, including via the `from_peer` copy path.
+        let sentinel = "recovery-marker-error-secret";
+        let peer = LinkedPeerRecord {
+            counterparty: counterparty(),
+            counterparty_receiver_path: receiver_path(),
+            state: LinkedPeerState::Linked,
+            last_sync_at: None,
+            last_private_receive_at: None,
+            failure_count: 0,
+            local_recovery_attempt_id: None,
+            local_recovery_marker_created_at: None,
+            local_recovery_marker_last_error: Some(sentinel.to_string()),
+            remote_recovery_attempt_id: None,
+            remote_recovery_marker_observed_at: None,
+        };
+
+        let report = EncryptedLinkRecoveryMarkerReport::from_peer(&peer, true);
+        // The raw error is retained on the value (only Debug redacts it).
+        assert_eq!(report.local_marker_last_error.as_deref(), Some(sentinel));
+
+        let debug = format!("{report:?}");
+        assert!(!debug.contains(sentinel));
+        assert!(debug.contains("<redacted:"));
+    }
 }

--- a/paykit-sdk/src/storage/records.rs
+++ b/paykit-sdk/src/storage/records.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Durable Linked Peer state.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LinkedPeerRecord {
     /// Counterparty public key.
     pub counterparty: PubkyPublicKey,
@@ -40,6 +40,42 @@ pub struct LinkedPeerRecord {
     pub remote_recovery_attempt_id: Option<String>,
     /// Time the counterparty recovery marker was observed.
     pub remote_recovery_marker_observed_at: Option<DateTime<Utc>>,
+}
+
+impl fmt::Debug for LinkedPeerRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkedPeerRecord")
+            .field("counterparty", &self.counterparty)
+            .field(
+                "counterparty_receiver_path",
+                &self.counterparty_receiver_path,
+            )
+            .field("state", &self.state)
+            .field("last_sync_at", &self.last_sync_at)
+            .field("last_private_receive_at", &self.last_private_receive_at)
+            .field("failure_count", &self.failure_count)
+            .field("local_recovery_attempt_id", &self.local_recovery_attempt_id)
+            .field(
+                "local_recovery_marker_created_at",
+                &self.local_recovery_marker_created_at,
+            )
+            .field(
+                "local_recovery_marker_last_error",
+                &self
+                    .local_recovery_marker_last_error
+                    .as_ref()
+                    .map(|error| format!("<redacted:{} bytes>", error.len())),
+            )
+            .field(
+                "remote_recovery_attempt_id",
+                &self.remote_recovery_attempt_id,
+            )
+            .field(
+                "remote_recovery_marker_observed_at",
+                &self.remote_recovery_marker_observed_at,
+            )
+            .finish()
+    }
 }
 
 /// Durable SDK-managed public Payment Endpoint publication record.
@@ -70,7 +106,13 @@ impl fmt::Debug for PublicEndpointRecord {
             )
             .field("status", &self.status)
             .field("updated_at", &self.updated_at)
-            .field("last_error", &self.last_error)
+            .field(
+                "last_error",
+                &self
+                    .last_error
+                    .as_ref()
+                    .map(|error| format!("<redacted:{} bytes>", error.len())),
+            )
             .finish()
     }
 }
@@ -423,7 +465,13 @@ impl fmt::Debug for NewPrivateStreamItem {
             .field("parsed_kind", &self.parsed_kind)
             .field("known_paykit_kind", &self.known_paykit_kind)
             .field("parse_status", &self.parse_status)
-            .field("parse_error", &self.parse_error)
+            .field(
+                "parse_error",
+                &self
+                    .parse_error
+                    .as_ref()
+                    .map(|error| format!("<redacted:{} bytes>", error.len())),
+            )
             .field("received_at", &self.received_at)
             .finish()
     }
@@ -476,7 +524,13 @@ impl fmt::Debug for PrivateStreamItemRecord {
             .field("parsed_kind", &self.parsed_kind)
             .field("known_paykit_kind", &self.known_paykit_kind)
             .field("parse_status", &self.parse_status)
-            .field("parse_error", &self.parse_error)
+            .field(
+                "parse_error",
+                &self
+                    .parse_error
+                    .as_ref()
+                    .map(|error| format!("<redacted:{} bytes>", error.len())),
+            )
             .field("received_at", &self.received_at)
             .finish()
     }

--- a/paykit-sdk/src/storage/tests.rs
+++ b/paykit-sdk/src/storage/tests.rs
@@ -188,25 +188,37 @@ fn test_sensitive_storage_debug_is_redacted() {
         outbound_private_message(stream_counterparty.clone()),
     );
     outbound.last_error = Some("outbound-secret".into());
-    let stream = PrivateStreamItemRecord::from_new(
-        0,
-        NewPrivateStreamItem::new(NewPrivateStreamItemDetails {
-            counterparty: stream_counterparty,
-            counterparty_receiver_path: receiver_path(),
-            receive_batch_id: 0,
-            raw_json: r#"{"key":"secret"}"#.into(),
-            parsed_version: Some(1),
-            parsed_kind: Some("paykit.receipt_access".into()),
-            known_paykit_kind: Some("paykit.receipt_access".into()),
-            parse_status: PrivateStreamParseStatus::Valid,
-            parse_error: None,
-            received_at: timestamp(),
-        }),
-    );
+    let new_stream = NewPrivateStreamItem::new(NewPrivateStreamItemDetails {
+        counterparty: stream_counterparty.clone(),
+        counterparty_receiver_path: receiver_path(),
+        receive_batch_id: 0,
+        raw_json: r#"{"key":"secret"}"#.into(),
+        parsed_version: Some(1),
+        parsed_kind: Some("paykit.receipt_access".into()),
+        known_paykit_kind: Some("paykit.receipt_access".into()),
+        parse_status: PrivateStreamParseStatus::Valid,
+        parse_error: Some("parse-error-secret".into()),
+        received_at: timestamp(),
+    });
+    let stream = PrivateStreamItemRecord::from_new(0, new_stream.clone());
     let receipt_access = receipt_access_record(stream.counterparty.clone());
     let receipt = receipt_record(receipt_access.counterparty.clone());
     let reservation = payment_endpoint_reservation_record(receipt_access.counterparty.clone());
-    let public_endpoint = public_endpoint_record("btc-lightning-bolt11");
+    let mut public_endpoint = public_endpoint_record("btc-lightning-bolt11");
+    public_endpoint.last_error = Some("endpoint-error-secret".into());
+    let linked_peer = LinkedPeerRecord {
+        counterparty: stream_counterparty.clone(),
+        counterparty_receiver_path: receiver_path(),
+        state: LinkedPeerState::Linked,
+        last_sync_at: Some(timestamp()),
+        last_private_receive_at: Some(timestamp()),
+        failure_count: 0,
+        local_recovery_attempt_id: None,
+        local_recovery_marker_created_at: None,
+        local_recovery_marker_last_error: Some("linked-peer-error-secret".into()),
+        remote_recovery_attempt_id: None,
+        remote_recovery_marker_observed_at: None,
+    };
     let contact_public_key = counterparty();
     let contact = ContactRecord {
         public_key: contact_public_key.clone(),
@@ -236,7 +248,7 @@ fn test_sensitive_storage_debug_is_redacted() {
     };
 
     let debug = format!(
-            "{link_state:?} {outbound:?} {stream:?} {receipt_access:?} {receipt:?} {reservation:?} {public_endpoint:?} {contact:?} {storage_state:?}"
+            "{link_state:?} {outbound:?} {new_stream:?} {stream:?} {linked_peer:?} {receipt_access:?} {receipt:?} {reservation:?} {public_endpoint:?} {contact:?} {storage_state:?}"
         );
     assert!(debug.contains("<redacted:"));
     assert!(!debug.contains("secret"));
@@ -245,6 +257,9 @@ fn test_sensitive_storage_debug_is_redacted() {
     assert!(!debug.contains("alice"));
     assert!(!debug.contains(contact_public_key.as_str()));
     assert!(!debug.contains("[1, 2, 3]"));
+    assert!(!debug.contains("endpoint-error-secret"));
+    assert!(!debug.contains("linked-peer-error-secret"));
+    assert!(!debug.contains("parse-error-secret"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

In `paykit-sdk/src/storage/records.rs`, four persisted error strings were printed
**raw** in `Debug` output while sibling record types redact theirs. The two
private-stream `parse_error` fields derive from private plaintext, making them the
most sensitive.

## Changes (all within `records.rs` + its test)

- `PublicEndpointRecord.last_error` — redacted (its manual `Debug` already redacted
  `payload`, but not the error).
- `LinkedPeerRecord.local_recovery_marker_last_error` — replaced the **derived**
  `Debug` with a manual impl that mirrors every field and redacts only the error.
- `NewPrivateStreamItem.parse_error` and `PrivateStreamItemRecord.parse_error` —
  redacted.
- Each redaction mirrors the existing `<redacted:N bytes>` style exactly (as used
  by `OutboundPrivateMessageRecord.last_error`).

## Tests

- Extended `test_sensitive_storage_debug_is_redacted` with fixtures that populate
  each of the four fields with a unique `*-secret` marker and assert it does not
  appear in the `Debug` output — fixtures that would have caught this. The test now
  exercises both `NewPrivateStreamItem` and `PrivateStreamItemRecord` (the shared
  `parse_error` field) plus `LinkedPeerRecord` and `PublicEndpointRecord`.

## Scope / impact

- **Not a live leak:** backups are documented as caller-encrypted, so this is a
  Debug-consistency / log-hygiene fix.
- Kept the diff to one `impl` block per type (the `LinkedPeerRecord` manual impl is
  a minor conflict surface with in-flight recovery-marker work — trivial to rebase).
  **Protocol impact: none.**

## Verification (local)

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p paykit-sdk --lib` (redaction test passes)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `cargo check --workspace --all-features`

The full networked e2e suite runs in CI.
