### PR TITLE
chore(ffi): remove dead default-on dev-auth feature

### DIFF
--- a/paykit-ffi/Cargo.toml
+++ b/paykit-ffi/Cargo.toml
@@ -15,10 +15,6 @@ path = "src/lib.rs"
 name = "uniffi-bindgen"
 path = "src/bin/uniffi-bindgen.rs"
 
-[features]
-default = ["dev-auth"]
-dev-auth = []
-
 [dependencies]
 paykit-lib = { path = "../paykit-lib" }
 paykit-sdk = { path = "../paykit-sdk" }


### PR DESCRIPTION
## Problem

`paykit-ffi/Cargo.toml` declared a **default-on** feature named `dev-auth`
that gated no code. It once gated raw-secret-key dev helpers (meant to be
disabled for production builds); commit 4387518 ("Add SDK bindings
foundation") removed the `#[cfg(feature = "dev-auth")]` gates but left the
feature declaration behind.

A dead, default-on feature named `dev-auth` is a trap: any future
`#[cfg(feature = "dev-auth")]` code would silently ship **enabled by default**
in released bindings, under a name that implies it should be off in
production.

## Change

- Delete the entire `[features]` section from `paykit-ffi/Cargo.toml`
  (`default = ["dev-auth"]` and `dev-auth = []`). Full removal, not commented
  out.

A workspace sweep (Rust `#[cfg(feature = ...)]`, `.toml`, `.github/` CI,
`paykit-ffi/build.sh`, docs, `Cargo.lock`) finds **zero** other references,
so nothing depends on the feature. The default feature set is now empty and
build behavior is unchanged. `--no-default-features` and `--all-features`
both remain valid on the crate.

## Scope / impact

- One-line-region `Cargo.toml` edit; no source, no tests (a feature gating
  nothing has no behavior to assert).
- No UniFFI surface change → no binding regeneration.
- **Protocol impact: none.**

## Verification (local)

- `cargo fmt --all -- --check`
- `cargo check -p paykit-ffi`
- `cargo check -p paykit-ffi --no-default-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p paykit-ffi --lib` (46 passed)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `cargo check --workspace --all-features`
