### PR TITLE
test(ffi): cover the 32-byte secret-key length gate

### DIFF
--- a/paykit-ffi/tests/secret_key_validation.rs
+++ b/paykit-ffi/tests/secret_key_validation.rs
@@ -1,0 +1,66 @@
+//! Rejection tests for the FFI 32-byte Pubky secret-key length gate.
+//!
+//! `pubky_public_key_from_secret` is the nearest public entry point that
+//! exercises the internal `local_secret_from_bytes` length gate. That gate is
+//! the single guard protecting every session-bootstrap call site in
+//! `paykit-ffi`, so these tests pin its rejection behavior. They live in a
+//! standalone integration-test crate to keep the hot `session.rs` and
+//! `tests.rs` files untouched.
+//!
+//! The gate rejects any non-32-byte input with `PaykitFfiError::Protocol`
+//! carrying `code == "validation"`. That is the FFI error taxonomy, which is
+//! deliberately distinct from the library's four-variant `PaykitError`: the FFI
+//! layer has no `Validation` variant, so the assertions match on
+//! `Protocol { code, .. }` rather than a dedicated variant.
+
+use std::sync::Arc;
+
+use paykit::{pubky_public_key_from_secret, FfiPubkyLocalSecretKey, PaykitFfiError};
+
+/// Wrap raw bytes in the FFI secret-key type without any length check.
+///
+/// The constructor performs no validation, so this faithfully reproduces the
+/// malformed input a caller could hand across the FFI boundary.
+fn secret_from(bytes: Vec<u8>) -> Arc<FfiPubkyLocalSecretKey> {
+    Arc::new(FfiPubkyLocalSecretKey::new(bytes))
+}
+
+/// Assert the result is the length-gate rejection: `Protocol { code: "validation" }`.
+fn assert_validation_rejection(result: Result<String, PaykitFfiError>) {
+    match result {
+        Ok(key) => panic!("expected a validation rejection, got Ok({key})"),
+        Err(PaykitFfiError::Protocol { code, .. }) => {
+            assert_eq!(
+                code, "validation",
+                "expected the length-gate validation code"
+            );
+        }
+        Err(other) => {
+            panic!("expected PaykitFfiError::Protocol {{ code: \"validation\" }}, got {other:?}")
+        }
+    }
+}
+
+#[test]
+fn test_secret_key_length_gate_empty_rejected() {
+    assert_validation_rejection(pubky_public_key_from_secret(secret_from(Vec::new())));
+}
+
+#[test]
+fn test_secret_key_length_gate_thirty_one_bytes_rejected() {
+    assert_validation_rejection(pubky_public_key_from_secret(secret_from(vec![7u8; 31])));
+}
+
+#[test]
+fn test_secret_key_length_gate_thirty_three_bytes_rejected() {
+    assert_validation_rejection(pubky_public_key_from_secret(secret_from(vec![7u8; 33])));
+}
+
+#[test]
+fn test_secret_key_length_gate_thirty_two_bytes_accepted() {
+    let result = pubky_public_key_from_secret(secret_from(vec![7u8; 32]));
+    assert!(
+        result.is_ok(),
+        "expected a valid 32-byte secret key to be accepted, got {result:?}"
+    );
+}


### PR DESCRIPTION
## Problem

`local_secret_from_bytes` (`paykit-ffi/src/session.rs`) is the **single**
32-byte length gate protecting all session-bootstrap call sites in paykit-ffi,
and it had **no rejection test**. `session.rs` is a hot file under active
development, so the tests must not live there.

## Change (tests only, zero src edits)

New `paykit-ffi/tests/secret_key_validation.rs` — a standalone integration-test
crate (`paykit-ffi/tests/` did not exist), so **no `src/` file is touched** and
the hot `session.rs` / `tests.rs` stay untouched. Cargo auto-discovers it; no
`Cargo.toml` change.

It drives the gate through the public FFI entry point
`pubky_public_key_from_secret`:

- **empty**, **31-byte**, and **33-byte** inputs → rejected
- **32-byte** input → accepted (so the negative cases can't pass vacuously)

`FfiPubkyLocalSecretKey::new` performs no length check, so wrapping raw bytes
faithfully reproduces the malformed input a caller could hand across the FFI
boundary.

## Error taxonomy

Rejections assert `PaykitFfiError::Protocol { code: "validation", .. }` — **not**
a `Validation` variant. The library's four-variant `PaykitError` taxonomy
applies to paykit-lib, **not** the FFI layer, which has no `Validation` variant
and signals validation failures via `Protocol { code: "validation" }`. The
tests match on the stable `code` rather than the human-readable `context`, so
they won't break if the message wording changes.

## Scope / impact

- **Tests only**; no production code, no public/UniFFI surface change → **no
  binding regeneration**. **Protocol impact: none.**
- Positive case is pure crypto (infallible key derivation) — no testnet, no
  network.

## Verification (local)

- `cargo fmt --all -- --check`
- `cargo test -p paykit-ffi --test secret_key_validation` — **4 passed**
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `cargo check --workspace --all-features`
