### PR TITLE
test(encrypted-link): pin the 1000-byte noise message boundary

### DIFF
--- a/paykit-lib/src/encrypted_link/private_application_message.rs
+++ b/paykit-lib/src/encrypted_link/private_application_message.rs
@@ -349,6 +349,11 @@ pub(super) async fn send_private_application_message(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        serialize_private_payment_list_json, PaymentEndpointIdentifier, PaymentEndpointPayload,
+        PrivatePaymentList,
+    };
+    use std::collections::HashMap;
 
     #[test]
     fn test_send_attempts_from_retries_bounds() {
@@ -425,6 +430,46 @@ mod tests {
         let payload = vec![b'x'; pubky_noise::snow_crypto::PUBKY_NOISE_MSG_LEN + 1];
         let err =
             validate_private_application_message_size(&payload, "Payment Request").unwrap_err();
+        assert!(
+            matches!(err, PaykitError::Validation(ref msg) if msg.contains("exceeds")),
+            "expected oversize validation error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_private_application_message_size_validation_accepts_payload_at_limit() {
+        // Guards against a `>` -> `>=` regression in the send-time size check:
+        // a payload of exactly PUBKY_NOISE_MSG_LEN bytes must be accepted.
+        let payload = vec![b'x'; pubky_noise::snow_crypto::PUBKY_NOISE_MSG_LEN];
+        validate_private_application_message_size(&payload, "Payment Request")
+            .expect("payload of exactly PUBKY_NOISE_MSG_LEN bytes should be accepted");
+    }
+
+    #[test]
+    fn test_private_application_message_size_validation_rejects_oversized_private_payment_list() {
+        // A Private Payment List can cross the pubky-noise message ceiling via
+        // many small Payment Endpoints rather than one oversized payload.
+        // Send-time validation is the documented enforcement point; there is
+        // no construction-time size limit. The context string matches the real
+        // send path (EncryptedLink::send_private_payment_list_message).
+        let mut payment_endpoints = HashMap::new();
+        for i in 0..20 {
+            payment_endpoints.insert(
+                PaymentEndpointIdentifier::new(format!("endpoint-{i:02}")).unwrap(),
+                PaymentEndpointPayload::new(format!("payload-{i:02}-{}", "x".repeat(40))),
+            );
+        }
+        let list = PrivatePaymentList::new(payment_endpoints);
+        let json = serialize_private_payment_list_json(&list).unwrap();
+        assert!(
+            json.len() > pubky_noise::snow_crypto::PUBKY_NOISE_MSG_LEN,
+            "fixture must exceed the pubky-noise message ceiling, got {} bytes",
+            json.len()
+        );
+
+        let err =
+            validate_private_application_message_size(json.as_bytes(), "Private Payment List")
+                .unwrap_err();
         assert!(
             matches!(err, PaykitError::Validation(ref msg) if msg.contains("exceeds")),
             "expected oversize validation error, got: {err}"


### PR DESCRIPTION
## Problem

The send-time size ceiling in
`paykit-lib/src/encrypted_link/private_application_message.rs`
(`plaintext.len() > PUBKY_NOISE_MSG_LEN`) was only tested at `LEN+1`. There
was no **at-limit acceptance** test, so a `>` → `>=` off-by-one regression
(rejecting exactly-1000-byte messages) would pass the suite. There was also no
realistic test of a Private Payment List crossing the ceiling via many small
Payment Endpoints.

## Change (tests only)

Two tests inside the file's existing `#[cfg(test)]` module (the validator is
module-private, so they cannot live in the centralized `tests/` directory):

- **At-limit acceptance:** a payload of exactly `PUBKY_NOISE_MSG_LEN` bytes is
  accepted (uses the constant, not a literal `1000`).
- **Many-small-endpoints rejection:** a real `PrivatePaymentList` of 20
  endpoints built via the validated constructors serializes past the ceiling
  (sanity-asserted in the test) and is rejected with
  `PaykitError::Validation`, using the real send-path context string.

No construction-time size enforcement was added — send-time validation is the
documented design.

## Scope / impact

- **Tests only**; no production code. **Protocol impact: none.**
- Pure synchronous unit tests.

## Verification (local)

- `cargo fmt --all -- --check`
- `cargo clippy -p paykit-lib --all-targets --all-features -- -D warnings`
- `cargo test -p paykit-lib --lib private_application_message` — **16 passed**
