### PR TITLE
test: cover the five 404/GONE not-found classifier copies

### DIFF
--- a/paykit-lib/src/encrypted_link/private_application_message.rs
+++ b/paykit-lib/src/encrypted_link/private_application_message.rs
@@ -509,4 +509,31 @@ mod tests {
             .raw_json
             .starts_with(INVALID_UTF8_PRIVATE_MESSAGE_PREFIX));
     }
+
+    // CLAUDE.md contract: public reads treat 404/GONE as absence, never as errors.
+    fn server_error(status: StatusCode) -> PubkyError {
+        PubkyError::Request(RequestError::Server {
+            status,
+            message: "test response".into(),
+        })
+    }
+
+    #[test]
+    fn test_is_not_found_matches_not_found_and_gone() {
+        assert!(is_not_found(&server_error(StatusCode::NOT_FOUND)));
+        assert!(is_not_found(&server_error(StatusCode::GONE)));
+    }
+
+    #[test]
+    fn test_is_not_found_rejects_other_statuses_and_variants() {
+        assert!(!is_not_found(&server_error(
+            StatusCode::INTERNAL_SERVER_ERROR
+        )));
+        assert!(!is_not_found(&server_error(StatusCode::FORBIDDEN)));
+
+        let validation_error = PubkyError::Request(RequestError::Validation {
+            message: "invalid request".into(),
+        });
+        assert!(!is_not_found(&validation_error));
+    }
 }

--- a/paykit-lib/src/encrypted_link_recovery.rs
+++ b/paykit-lib/src/encrypted_link_recovery.rs
@@ -348,4 +348,31 @@ mod tests {
 
         assert_ne!(write_to_bob_receiver, write_to_bob_other_receiver);
     }
+
+    // CLAUDE.md contract: public reads treat 404/GONE as absence, never as errors.
+    fn server_error(status: StatusCode) -> PubkyError {
+        PubkyError::Request(RequestError::Server {
+            status,
+            message: "test response".into(),
+        })
+    }
+
+    #[test]
+    fn test_is_not_found_matches_not_found_and_gone() {
+        assert!(is_not_found(&server_error(StatusCode::NOT_FOUND)));
+        assert!(is_not_found(&server_error(StatusCode::GONE)));
+    }
+
+    #[test]
+    fn test_is_not_found_rejects_other_statuses_and_variants() {
+        assert!(!is_not_found(&server_error(
+            StatusCode::INTERNAL_SERVER_ERROR
+        )));
+        assert!(!is_not_found(&server_error(StatusCode::FORBIDDEN)));
+
+        let validation_error = PubkyError::Request(RequestError::Validation {
+            message: "invalid request".into(),
+        });
+        assert!(!is_not_found(&validation_error));
+    }
 }

--- a/paykit-lib/src/pubky_routing.rs
+++ b/paykit-lib/src/pubky_routing.rs
@@ -625,4 +625,31 @@ mod tests {
             assert!(!is_valid_receiver_app_segment(segment), "{segment}");
         }
     }
+
+    // CLAUDE.md contract: public reads treat 404/GONE as absence, never as errors.
+    fn server_error(status: StatusCode) -> PubkyError {
+        PubkyError::Request(RequestError::Server {
+            status,
+            message: "test response".into(),
+        })
+    }
+
+    #[test]
+    fn test_is_not_found_matches_not_found_and_gone() {
+        assert!(is_not_found(&server_error(StatusCode::NOT_FOUND)));
+        assert!(is_not_found(&server_error(StatusCode::GONE)));
+    }
+
+    #[test]
+    fn test_is_not_found_rejects_other_statuses_and_variants() {
+        assert!(!is_not_found(&server_error(
+            StatusCode::INTERNAL_SERVER_ERROR
+        )));
+        assert!(!is_not_found(&server_error(StatusCode::FORBIDDEN)));
+
+        let validation_error = PubkyError::Request(RequestError::Validation {
+            message: "invalid request".into(),
+        });
+        assert!(!is_not_found(&validation_error));
+    }
 }

--- a/paykit-sdk/src/domain/receipts/tests.rs
+++ b/paykit-sdk/src/domain/receipts/tests.rs
@@ -317,3 +317,30 @@ fn test_decrypt_receipt_record_from_access_rejects_wrong_recipient() {
 
     assert!(matches!(err, PaykitSdkError::Protocol(message) if message.contains("recipient")));
 }
+
+// CLAUDE.md contract: public reads treat 404/GONE as absence, never as errors.
+fn server_error(status: StatusCode) -> PubkyError {
+    PubkyError::Request(RequestError::Server {
+        status,
+        message: "test response".into(),
+    })
+}
+
+#[test]
+fn test_is_not_found_matches_not_found_and_gone() {
+    assert!(is_not_found(&server_error(StatusCode::NOT_FOUND)));
+    assert!(is_not_found(&server_error(StatusCode::GONE)));
+}
+
+#[test]
+fn test_is_not_found_rejects_other_statuses_and_variants() {
+    assert!(!is_not_found(&server_error(
+        StatusCode::INTERNAL_SERVER_ERROR
+    )));
+    assert!(!is_not_found(&server_error(StatusCode::FORBIDDEN)));
+
+    let validation_error = PubkyError::Request(RequestError::Validation {
+        message: "invalid request".into(),
+    });
+    assert!(!is_not_found(&validation_error));
+}

--- a/paykit-sdk/src/runtime/tests.rs
+++ b/paykit-sdk/src/runtime/tests.rs
@@ -735,6 +735,7 @@ mod contacts;
 mod encrypted_links;
 mod identity;
 mod linked_peers;
+mod not_found_classifier;
 mod outbound_private;
 mod payment_requests;
 mod payment_resolution;

--- a/paykit-sdk/src/runtime/tests/not_found_classifier.rs
+++ b/paykit-sdk/src/runtime/tests/not_found_classifier.rs
@@ -1,0 +1,30 @@
+use pubky::{errors::RequestError, Error as PubkyError, StatusCode};
+
+use crate::runtime::is_pubky_not_found;
+
+// CLAUDE.md contract: public reads treat 404/GONE as absence, never as errors.
+fn server_error(status: StatusCode) -> PubkyError {
+    PubkyError::Request(RequestError::Server {
+        status,
+        message: "test response".into(),
+    })
+}
+
+#[test]
+fn test_is_pubky_not_found_matches_not_found_and_gone() {
+    assert!(is_pubky_not_found(&server_error(StatusCode::NOT_FOUND)));
+    assert!(is_pubky_not_found(&server_error(StatusCode::GONE)));
+}
+
+#[test]
+fn test_is_pubky_not_found_rejects_other_statuses_and_variants() {
+    assert!(!is_pubky_not_found(&server_error(
+        StatusCode::INTERNAL_SERVER_ERROR
+    )));
+    assert!(!is_pubky_not_found(&server_error(StatusCode::FORBIDDEN)));
+
+    let validation_error = PubkyError::Request(RequestError::Validation {
+        message: "invalid request".into(),
+    });
+    assert!(!is_pubky_not_found(&validation_error));
+}


### PR DESCRIPTION
## Problem

The contract that public reads treat 404/GONE as absence (`None`/empty),
never as errors, is implemented by **five byte-identical private predicates**
across the workspace — and none of the five had any test: `RequestError::
Server` was constructed in exactly one unrelated test in the whole workspace.
A regression in any copy (e.g. dropping the GONE arm) would ship silently.

## Change (tests only)

Positive (`NOT_FOUND` → true, `GONE` → true) and negative (500 → false,
403 → false, non-`Server` `RequestError::Validation` → false) coverage next
to each copy:

- `paykit-lib/src/pubky_routing.rs` — in-module tests.
- `paykit-lib/src/encrypted_link_recovery.rs` — in-module tests.
- `paykit-lib/src/encrypted_link/private_application_message.rs` — in-module
  tests.
- `paykit-sdk/src/domain/receipts/tests.rs` — extended.
- `paykit-sdk/src/runtime/` copy — tested from a **new file**
  `runtime/tests/not_found_classifier.rs`, declared with one `mod` line in
  `runtime/tests.rs`. `runtime/mod.rs` is untouched.

The five copies are deliberately **not consolidated** — that requires widening
paykit-lib's public API and editing active runtime code; these tests are the
prerequisite that makes a later consolidation safe.

All test names contain `not_found`, so `cargo test --lib not_found` scopes to
them in both crates.

## Scope / impact

- **Tests only**; no production code. **Protocol impact: none.**
- Pure synchronous unit tests; `RequestError::Server`/`Validation` construct
  directly (public fields, enum not `#[non_exhaustive]` in pubky 0.8.0).

## Verification (local)

- `cargo fmt --all -- --check`
- `cargo clippy -p paykit-lib -p paykit-sdk --all-targets --all-features -- -D warnings`
- `cargo test -p paykit-lib --lib not_found` — **6 passed**
- `cargo test -p paykit-sdk --lib not_found` — **5 passed** (4 new + 1 existing)
