### PR TITLE
fix(payment-request): reject inverted recurrence windows

### DIFF
--- a/paykit-ffi/src/payment_requests/mod.rs
+++ b/paykit-ffi/src/payment_requests/mod.rs
@@ -83,7 +83,8 @@ pub struct FfiPaymentRequestRecurrence {
     pub starts_at: String,
     /// RFC3339 UTC timestamp using `Z`.
     pub anchor: String,
-    /// Optional RFC3339 UTC timestamp using `Z`.
+    /// Optional RFC3339 UTC timestamp using `Z`, after `starts_at` when
+    /// present.
     pub ends_at: Option<String>,
 }
 

--- a/paykit-lib/src/payment_request/types.rs
+++ b/paykit-lib/src/payment_request/types.rs
@@ -96,7 +96,8 @@ pub struct Recurrence {
     pub starts_at: String,
     /// RFC3339 UTC timestamp using `Z`.
     pub anchor: String,
-    /// Optional RFC3339 UTC timestamp using `Z`.
+    /// Optional RFC3339 UTC timestamp using `Z`, after `starts_at` when
+    /// present.
     pub ends_at: Option<String>,
 }
 
@@ -527,16 +528,23 @@ impl PaymentRequestEventMessage {
 }
 
 impl Recurrence {
+    /// Check `every`, timestamp formats, and that a non-null `ends_at` is
+    /// after `starts_at`. `anchor` ordering is not constrained.
     pub(super) fn validate(&self) -> Result<()> {
         if self.every == 0 {
             return Err(PaykitError::Validation(
                 "Recurrence every must be a positive integer".into(),
             ));
         }
-        parse_utc_timestamp(&self.starts_at, "Recurrence starts_at")?;
+        let starts_at = parse_utc_timestamp(&self.starts_at, "Recurrence starts_at")?;
         parse_utc_timestamp(&self.anchor, "Recurrence anchor")?;
         if let Some(ends_at) = &self.ends_at {
-            parse_utc_timestamp(ends_at, "Recurrence ends_at")?;
+            let ends_at = parse_utc_timestamp(ends_at, "Recurrence ends_at")?;
+            if ends_at <= starts_at {
+                return Err(PaykitError::Validation(
+                    "Recurrence ends_at must be after starts_at".into(),
+                ));
+            }
         }
         Ok(())
     }
@@ -621,61 +629,39 @@ mod tests {
         assert!(matches!(err, PaykitError::Validation(ref msg) if msg.contains("Z suffix")));
     }
 
-    #[test]
-    fn test_recurrence_inverted_window_currently_accepted() {
-        // Pins current spec-conformant behavior: `specs/payment-requests.md`
-        // requires Recurrence `ends_at` to be null or an RFC3339 UTC timestamp
-        // but sets no ordering rule against `starts_at`, so an inverted window
-        // (`ends_at` before `starts_at`) is accepted by the real parser.
-        // Rejecting it would be a spec change with replay implications:
-        // previously valid stored `paykit.payment_request` events would become
-        // validation errors on durable replay. Tightening requires a spec
-        // amendment with spec-owner sign-off and must show up as a visible
-        // diff against this test.
-        let json = r#"{
-            "version": 1,
-            "kind": "paykit.payment_request",
-            "event_id": "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
-            "payment_request_id": "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
-            "request": {
-                "amount": { "value": "0.001", "asset": "btc" },
-                "payment_reference": "invoice-2026-0001",
-                "proposal_expires_at": null,
-                "recurrence": {
-                    "every": 1,
-                    "unit": "month",
-                    "starts_at": "2026-07-01T00:00:00Z",
-                    "anchor": "2026-07-01T00:00:00Z",
-                    "ends_at": "2026-06-01T00:00:00Z"
-                },
-                "accepted_payment_endpoint_identifiers": ["btc-lightning-bolt11"],
-                "metadata": {}
-            }
-        }"#;
-
-        let request = super::super::wire::parse_payment_request_json(json)
-            .expect("inverted Recurrence window is currently accepted");
-        let recurrence = request.request.recurrence.expect("Recurrence is present");
-        assert!(recurrence.validate().is_ok());
-        assert_eq!(recurrence.starts_at, "2026-07-01T00:00:00Z");
-        assert_eq!(recurrence.ends_at.as_deref(), Some("2026-06-01T00:00:00Z"));
+    fn recurrence_with_ends_at(ends_at: Option<&str>) -> Recurrence {
+        Recurrence {
+            every: 1,
+            unit: RecurrenceUnit::Month,
+            starts_at: "2026-07-01T00:00:00Z".to_string(),
+            anchor: "2026-07-01T00:00:00Z".to_string(),
+            ends_at: ends_at.map(str::to_string),
+        }
     }
 
     #[test]
-    fn test_billing_period_inverted_rejected() {
-        // Contrast with `test_recurrence_inverted_window_currently_accepted`:
-        // `specs/payment-requests.md` DOES require Billing Period `ends_at` to
-        // be after `starts_at`, and the validator enforces it. The Recurrence
-        // gap pinned above is a genuine spec-level asymmetry between two
-        // distinct validation paths, not an oversight in one shared validator.
-        let period = BillingPeriod {
-            starts_at: "2026-07-01T00:00:00Z".to_string(),
-            ends_at: "2026-06-01T00:00:00Z".to_string(),
-        };
-        let err = period.validate().unwrap_err();
+    fn recurrence_rejects_ends_at_before_starts_at() {
+        // specs/payment-requests.md: non-null ends_at MUST be after starts_at.
+        let recurrence = recurrence_with_ends_at(Some("2026-06-01T00:00:00Z"));
+        let err = recurrence.validate().unwrap_err();
         assert!(
             matches!(err, PaykitError::Validation(ref msg) if msg.contains("ends_at must be after starts_at"))
         );
+    }
+
+    #[test]
+    fn recurrence_rejects_ends_at_equal_to_starts_at() {
+        let recurrence = recurrence_with_ends_at(Some("2026-07-01T00:00:00Z"));
+        let err = recurrence.validate().unwrap_err();
+        assert!(
+            matches!(err, PaykitError::Validation(ref msg) if msg.contains("ends_at must be after starts_at"))
+        );
+    }
+
+    #[test]
+    fn recurrence_accepts_ends_at_after_starts_at() {
+        let recurrence = recurrence_with_ends_at(Some("2026-08-01T00:00:00Z"));
+        recurrence.validate().unwrap();
     }
 
     #[test]

--- a/paykit-lib/src/payment_request/types.rs
+++ b/paykit-lib/src/payment_request/types.rs
@@ -622,6 +622,63 @@ mod tests {
     }
 
     #[test]
+    fn test_recurrence_inverted_window_currently_accepted() {
+        // Pins current spec-conformant behavior: `specs/payment-requests.md`
+        // requires Recurrence `ends_at` to be null or an RFC3339 UTC timestamp
+        // but sets no ordering rule against `starts_at`, so an inverted window
+        // (`ends_at` before `starts_at`) is accepted by the real parser.
+        // Rejecting it would be a spec change with replay implications:
+        // previously valid stored `paykit.payment_request` events would become
+        // validation errors on durable replay. Tightening requires a spec
+        // amendment with spec-owner sign-off and must show up as a visible
+        // diff against this test.
+        let json = r#"{
+            "version": 1,
+            "kind": "paykit.payment_request",
+            "event_id": "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            "payment_request_id": "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+            "request": {
+                "amount": { "value": "0.001", "asset": "btc" },
+                "payment_reference": "invoice-2026-0001",
+                "proposal_expires_at": null,
+                "recurrence": {
+                    "every": 1,
+                    "unit": "month",
+                    "starts_at": "2026-07-01T00:00:00Z",
+                    "anchor": "2026-07-01T00:00:00Z",
+                    "ends_at": "2026-06-01T00:00:00Z"
+                },
+                "accepted_payment_endpoint_identifiers": ["btc-lightning-bolt11"],
+                "metadata": {}
+            }
+        }"#;
+
+        let request = super::super::wire::parse_payment_request_json(json)
+            .expect("inverted Recurrence window is currently accepted");
+        let recurrence = request.request.recurrence.expect("Recurrence is present");
+        assert!(recurrence.validate().is_ok());
+        assert_eq!(recurrence.starts_at, "2026-07-01T00:00:00Z");
+        assert_eq!(recurrence.ends_at.as_deref(), Some("2026-06-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn test_billing_period_inverted_rejected() {
+        // Contrast with `test_recurrence_inverted_window_currently_accepted`:
+        // `specs/payment-requests.md` DOES require Billing Period `ends_at` to
+        // be after `starts_at`, and the validator enforces it. The Recurrence
+        // gap pinned above is a genuine spec-level asymmetry between two
+        // distinct validation paths, not an oversight in one shared validator.
+        let period = BillingPeriod {
+            starts_at: "2026-07-01T00:00:00Z".to_string(),
+            ends_at: "2026-06-01T00:00:00Z".to_string(),
+        };
+        let err = period.validate().unwrap_err();
+        assert!(
+            matches!(err, PaykitError::Validation(ref msg) if msg.contains("ends_at must be after starts_at"))
+        );
+    }
+
+    #[test]
     fn payment_reference_is_not_required_to_be_uuid() {
         let terms = request_terms();
         assert_eq!(terms.payment_reference.as_str(), "invoice-2026-0001");

--- a/paykit-lib/src/payment_request/wire.rs
+++ b/paykit-lib/src/payment_request/wire.rs
@@ -764,6 +764,35 @@ mod tests {
     }
 
     #[test]
+    fn payment_request_rejects_invalid_recurrence_window_order() {
+        let json = r#"{
+            "version": 1,
+            "kind": "paykit.payment_request",
+            "event_id": "8a0d8b4c-913f-4e31-9f2c-2a6f5bb4d101",
+            "payment_request_id": "b7f9c2a1-6d43-4b0e-a8d4-0fe2c712ab33",
+            "request": {
+                "amount": { "value": "0.001", "asset": "btc" },
+                "payment_reference": "invoice-2026-0001",
+                "proposal_expires_at": null,
+                "recurrence": {
+                    "every": 1,
+                    "unit": "month",
+                    "starts_at": "2026-07-01T00:00:00Z",
+                    "anchor": "2026-07-01T00:00:00Z",
+                    "ends_at": "2026-06-01T00:00:00Z"
+                },
+                "accepted_payment_endpoint_identifiers": ["btc-lightning-bolt11"],
+                "metadata": {}
+            }
+        }"#;
+
+        let err = parse_payment_request_json(json).unwrap_err();
+        assert!(
+            matches!(err, PaykitError::InvalidData { ref context, .. } if context.contains("ends_at must be after starts_at"))
+        );
+    }
+
+    #[test]
     fn acceptance_reason_is_invalid_when_present() {
         let json = r#"{
             "version": 1,

--- a/paykit-lib/src/payment_request/wire.rs
+++ b/paykit-lib/src/payment_request/wire.rs
@@ -792,6 +792,40 @@ mod tests {
         );
     }
 
+    fn recurrence_with_ends_at(ends_at: &str) -> Recurrence {
+        Recurrence {
+            every: 1,
+            unit: RecurrenceUnit::Month,
+            starts_at: "2026-07-01T00:00:00Z".to_string(),
+            anchor: "2026-07-01T00:00:00Z".to_string(),
+            ends_at: Some(ends_at.to_string()),
+        }
+    }
+
+    #[test]
+    fn payment_request_rejects_outgoing_recurrence_ends_at_before_starts_at() {
+        let mut terms = request_terms();
+        terms.recurrence = Some(recurrence_with_ends_at("2026-06-01T00:00:00Z"));
+        let event = PaymentRequest::new(EventId::new_v4(), PaymentRequestId::new_v4(), terms);
+
+        let err = serialize_payment_request_json(&event).unwrap_err();
+        assert!(
+            matches!(err, PaykitError::Validation(ref msg) if msg.contains("ends_at must be after starts_at"))
+        );
+    }
+
+    #[test]
+    fn payment_request_rejects_outgoing_recurrence_ends_at_equal_to_starts_at() {
+        let mut terms = request_terms();
+        terms.recurrence = Some(recurrence_with_ends_at("2026-07-01T00:00:00Z"));
+        let event = PaymentRequest::new(EventId::new_v4(), PaymentRequestId::new_v4(), terms);
+
+        let err = serialize_payment_request_json(&event).unwrap_err();
+        assert!(
+            matches!(err, PaykitError::Validation(ref msg) if msg.contains("ends_at must be after starts_at"))
+        );
+    }
+
     #[test]
     fn acceptance_reason_is_invalid_when_present() {
         let json = r#"{

--- a/paykit-lib/src/tests/payment_request_properties.rs
+++ b/paykit-lib/src/tests/payment_request_properties.rs
@@ -166,6 +166,30 @@ fn recurrence_unit() -> impl Strategy<Value = RecurrenceUnit> {
     ]
 }
 
+/// Build a valid Recurrence window: the optional `ends_at` is the `starts_at`
+/// instant shifted a whole number of years forward, so it is always strictly
+/// after `starts_at` as the validator requires.
+///
+/// NARROWER THAN THE DOMAIN: `ends_at` shares the month/day/time of
+/// `starts_at`; the validator accepts any strictly later timestamp.
+fn recurrence_window() -> impl Strategy<Value = (String, Option<String>)> {
+    (
+        2000u32..2050,
+        1u32..=12,
+        1u32..=28,
+        0u32..=23,
+        0u32..=59,
+        0u32..=59,
+        proptest::option::of(1u32..=50),
+    )
+        .prop_map(|(y, mo, d, h, mi, s, end_year_offset)| {
+            let starts_at = format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z");
+            let ends_at = end_year_offset
+                .map(|offset| format!("{:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z", y + offset));
+            (starts_at, ends_at)
+        })
+}
+
 /// Build a valid `Recurrence`.
 ///
 /// NARROWER THAN THE DOMAIN: `every` is capped at 1_000; the type allows any
@@ -174,11 +198,10 @@ fn recurrence() -> impl Strategy<Value = Recurrence> {
     (
         1u32..=1000,
         recurrence_unit(),
+        recurrence_window(),
         utc_timestamp(),
-        utc_timestamp(),
-        proptest::option::of(utc_timestamp()),
     )
-        .prop_map(|(every, unit, starts_at, anchor, ends_at)| Recurrence {
+        .prop_map(|(every, unit, (starts_at, ends_at), anchor)| Recurrence {
             every,
             unit,
             starts_at,

--- a/paykit-sdk/src/domain/payment_requests/mod.rs
+++ b/paykit-sdk/src/domain/payment_requests/mod.rs
@@ -137,7 +137,8 @@ pub struct PaymentRequestRecurrenceRecord {
     pub starts_at: String,
     /// RFC3339 UTC timestamp using `Z`.
     pub anchor: String,
-    /// Optional RFC3339 UTC timestamp using `Z`.
+    /// Optional RFC3339 UTC timestamp using `Z`, after `starts_at` when
+    /// present.
     pub ends_at: Option<String>,
 }
 

--- a/specs/payment-requests.md
+++ b/specs/payment-requests.md
@@ -219,6 +219,7 @@ Rules:
 - `starts_at` MUST be an RFC3339 UTC timestamp using the `Z` suffix.
 - `anchor` MUST be an RFC3339 UTC timestamp using the `Z` suffix.
 - `ends_at` MUST be `null` or an RFC3339 UTC timestamp using the `Z` suffix.
+- When `ends_at` is non-null, it MUST be after `starts_at`.
 - Recurrence describes the requested schedule. Payment Request v0.2 does not
   define canonical calendar expansion or reusable recurrence math for SDKs.
 - Implementations that materialize monthly or yearly recurrence periods SHOULD


### PR DESCRIPTION
## Problem

Review asked for two changes: actually reject a `Recurrence` whose `ends_at` is
before `starts_at` instead of pinning the acceptance, and drop the
`BillingPeriod` inversion test as duplicate coverage.

## Change

- `Recurrence::validate` now rejects a non-null `ends_at` at or before
  `starts_at` ("Recurrence ends_at must be after starts_at"), mirroring the
  `BillingPeriod` check: parsed-timestamp comparison, `PaykitError::Validation`
  at the validate layer, `PaykitError::InvalidData` on the wire parse path.
  `anchor` remains unconstrained.
- `specs/payment-requests.md` gains the matching rule in the Recurrence
  section: "When `ends_at` is non-null, it MUST be after `starts_at`." The
  spec previously set no ordering rule, so the guard is a spec-level
  tightening; landing code and spec together keeps them in sync.
- The acceptance-pinning test is replaced by rejection tests (before and equal
  boundaries), a positive case, and a wire-path test asserting `InvalidData`
  through `parse_payment_request_json`.
- `test_billing_period_inverted_rejected` removed: duplicate of
  `payment_proof_rejects_invalid_billing_period_shape` (types.rs) and
  `payment_proof_rejects_invalid_billing_period_order` (wire.rs). The earlier
  claim in this PR that the BillingPeriod side was untested was wrong.
- The recurrence proptest generator now only emits valid windows (`ends_at`
  strictly after `starts_at`), since the serialize path validates terms.
- Doc note on the SDK/FFI mirror types (`PaymentRequestRecurrenceRecord`,
  `FfiPaymentRequestRecurrence`); no exported struct shapes change.

## Protocol impact

- Tightening: wire messages with inverted recurrence windows, previously
  accepted, now fail parse with `InvalidData`; constructing or serializing such
  a request fails with `Validation`. Validation lives in paykit-lib, so
  Swift/Kotlin bindings see the tightening through existing error surfaces.
- Replay and durability: live intake persists a now-invalid message as
  malformed-recognized without aborting the batch; derivation replay marks only
  the affected record invalid and continues. One edge for reviewer awareness:
  backup restore validates stored parse-status metadata against the current
  classifier, so a backup containing a stream item stored as valid with an
  inverted window would fail restore with a stale-parse-status error. This only
  affects backups that actually contain such an item.

## Verification (local)

- `cargo fmt --all -- --check`
- `cargo clippy -p paykit-lib --all-targets --all-features -- -D warnings` and
  `cargo clippy -p paykit-sdk --all-targets -- -D warnings`
- `cargo test -p paykit-lib --all-targets` (209 passed, includes the proptests)
  and `cargo test -p paykit-sdk --lib` (367 passed)
- `cargo doc --no-deps` clean
