### PR TITLE
Cover invalid public Payment Endpoint data

### DIFF
--- a/paykit-lib/src/tests/payment_endpoint.rs
+++ b/paykit-lib/src/tests/payment_endpoint.rs
@@ -334,3 +334,50 @@ async fn removing_missing_endpoint_is_idempotent() {
 
     setup.raw_session.signout().await.unwrap();
 }
+
+#[tokio::test]
+async fn test_invalid_utf8_endpoint_returns_invalid_data() {
+    let setup = TestSetup::new().await;
+    let identifier = PaymentEndpointIdentifier::new("btc-lightning-bolt11").unwrap();
+    let path = crate::pubky_routing::payment_endpoint_path(&receiver_path(), &identifier);
+
+    setup
+        .session
+        .storage()
+        .put(path, vec![0xff])
+        .await
+        .expect("invalid UTF-8 fixture should be stored");
+
+    let result = get_payment_endpoint(
+        &setup.public_storage,
+        &setup.public_key,
+        &receiver_path(),
+        &identifier,
+    )
+    .await;
+    assert!(matches!(result, Err(PaykitError::InvalidData { .. })));
+
+    setup.raw_session.signout().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_invalid_payment_endpoint_listing_entry_returns_invalid_data() {
+    let setup = TestSetup::new().await;
+    let invalid_identifier = "a".repeat(65);
+    let path = format!(
+        "{}{invalid_identifier}",
+        crate::pubky_routing::payment_endpoint_path_prefix(&receiver_path())
+    );
+
+    setup
+        .session
+        .storage()
+        .put(path, "non-empty payload".to_string())
+        .await
+        .expect("invalid listing entry fixture should be stored");
+
+    let result = get_payment_list(&setup.public_storage, &setup.public_key, &receiver_path()).await;
+    assert!(matches!(result, Err(PaykitError::InvalidData { .. })));
+
+    setup.raw_session.signout().await.unwrap();
+}


### PR DESCRIPTION
## Problem

Public Payment Endpoint reads promise that corrupt network data is reported as `PaykitError::InvalidData`, but invalid UTF-8 payloads and invalid identifiers discovered through directory listings lacked direct regression coverage.

## Change

Add integration tests proving that:

- a non-empty invalid UTF-8 Payment Endpoint payload returns `InvalidData`;
- an invalid Payment Endpoint Identifier discovered in a public listing returns `InvalidData`.

The tests use Pubky Routing helpers and preserve the Payment List's all-or-nothing behavior.

## Protocol impact

None. This change pins existing network-data error semantics.

## Public API/bindings impact

None. Tests only.

## Verification

- Both new focused regression tests
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `git diff --check`

A fresh isolated Cargo target directory was used instead of `cargo clean` to avoid shared-worktree stale artifacts. Platform binding generation was not required because no binding source changed.
