### PR TITLE
Document state blob store callback contract

### DIFF
--- a/paykit-ffi/src/storage.rs
+++ b/paykit-ffi/src/storage.rs
@@ -27,8 +27,10 @@ pub struct FfiSdkStateBlobSnapshot {
 ///
 /// Each store instance is bound to one complete logical SDK state record.
 /// Callbacks receive no identity or Paykit Receiver Path key, so apps must use
-/// separately namespaced store instances for different identities or configured
-/// Paykit Receiver Paths. Share a store between handles only when they
+/// separately namespaced store instances when identities or configured Paykit
+/// Receiver Paths need to retain distinct state. A store may be reused after
+/// clearing the previous identity's data when intentionally switching the
+/// logical state it represents. Share a store between handles only when they
 /// intentionally operate on the same logical state.
 ///
 /// Callbacks execute synchronously on the thread executing or polling the SDK

--- a/paykit-ffi/src/storage.rs
+++ b/paykit-ffi/src/storage.rs
@@ -24,15 +24,45 @@ pub struct FfiSdkStateBlobSnapshot {
 }
 
 /// Platform-owned durable blob store for SDK state.
+///
+/// Callbacks execute synchronously on the thread executing or polling the SDK
+/// call. Each SDK handle owns a transaction mutex shared by that handle's
+/// storage clones. The mutex serializes callbacks made inside SDK storage
+/// transactions on that handle; it does not coordinate the revision-read API,
+/// other SDK handles, or other processes.
+///
+/// Callbacks must return promptly. Use bounded local durable persistence and
+/// bounded local coordination needed for atomic compare-and-swap. Do not use
+/// network or iCloud round trips, unbounded cross-process waits, or re-enter or
+/// depend on work from the same SDK handle.
+///
+/// A slow transactional callback blocks that foreign thread and queues other
+/// storage transactions on the same SDK handle. The revision-read API invokes
+/// the load callback outside the transaction mutex and can overlap transaction
+/// callbacks. Other SDK handles can also invoke callbacks concurrently.
+/// Implementations must be thread-safe. Store-level coordination may block
+/// across handles or processes and must remain bounded.
+///
+/// Paykit does not encrypt state blobs; they contain sensitive private runtime
+/// state and must not be logged. Store them in protected local storage with
+/// backup exclusion unless the app encrypts them, and encrypt them before cloud
+/// or cross-device transport. If the blob is lost, private runtime state cannot
+/// be safely reconstructed from homeserver data alone.
 #[uniffi::export(with_foreign)]
 pub trait FfiSdkStateBlobStore: Send + Sync {
     /// Load the current SDK state blob, when one exists.
+    ///
+    /// The blob and revision must be a coherent snapshot of the same committed
+    /// state.
     fn load_state_blob(&self) -> Result<Option<FfiSdkStateBlobSnapshot>, PaykitFfiError>;
 
-    /// Atomically save a new SDK state blob.
+    /// Atomically replace the complete SDK state blob.
     ///
-    /// `expected_revision` is `None` when no previous blob was loaded. The
-    /// platform store should reject the write if the stored revision changed.
+    /// `expected_revision` is `None` when no previous blob was loaded and
+    /// matches only an absent stored blob. Otherwise it must match the current
+    /// stored revision. Return a new opaque revision after a successful write.
+    /// On conflict or failure, leave the stored data intact and return the
+    /// binding's storage error variant; Paykit does not automatically retry.
     fn save_state_blob_atomically(
         &self,
         blob: Arc<FfiSdkStateBlob>,

--- a/paykit-ffi/src/storage.rs
+++ b/paykit-ffi/src/storage.rs
@@ -25,6 +25,12 @@ pub struct FfiSdkStateBlobSnapshot {
 
 /// Platform-owned durable blob store for SDK state.
 ///
+/// Each store instance is bound to one complete logical SDK state record.
+/// Callbacks receive no identity or Paykit Receiver Path key, so apps must use
+/// separately namespaced store instances for different identities or configured
+/// Paykit Receiver Paths. Share a store between handles only when they
+/// intentionally operate on the same logical state.
+///
 /// Callbacks execute synchronously on the thread executing or polling the SDK
 /// call. Each SDK handle owns a transaction mutex shared by that handle's
 /// storage clones. The mutex serializes callbacks made inside SDK storage


### PR DESCRIPTION
## Problem

Platform implementations of the SDK state blob store are synchronous foreign callbacks, but the public contract did not explain their blocking, concurrency, compare-and-swap, or sensitive-state requirements.

## Change

Document that:

- callbacks must perform prompt, bounded local persistence and must not depend on reentrant work from the same SDK handle;
- each SDK handle owns its transaction mutex, while revision reads and other handles can invoke callbacks concurrently;
- implementations must be thread-safe and any store-level coordination must remain bounded;
- loaded blobs and revisions must form a coherent snapshot;
- atomic saves use expected-revision semantics and leave stored data intact on failure;
- state blobs are not encrypted by Paykit and require protected storage, backup controls, and encryption before cloud or cross-device transport.

## Protocol impact

None. Documentation only.

## Public API/bindings impact

No UniFFI shape change. The documentation is carried into generated Swift and Kotlin bindings on the next release generation.

## Verification

- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p paykit-ffi --no-deps`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `cd paykit-ffi && ./build.sh all` for Swift and all four Android ABIs
- `git diff --check`

A fresh isolated Cargo target directory was used instead of `cargo clean` to avoid shared-worktree stale artifacts. Generated release bindings and native libraries were used only to verify propagation and remain outside this documentation-only change.
