### PR TITLE
Clarify Payment Amount validation boundaries

### DIFF
--- a/paykit-lib/src/payment_amount.rs
+++ b/paykit-lib/src/payment_amount.rs
@@ -1,11 +1,22 @@
 use crate::{PaykitError, Result};
 
 /// Amount of value in a payment flow, expressed as decimal text plus asset.
+///
+/// # Validation
+///
+/// [`PaymentAmount::new`] accepts a `value` consisting only of ASCII digits and
+/// at most one decimal point, with at least one digit. Leading `+` and `-` signs
+/// are rejected. Values such as `.5` and `10.` are accepted. The `asset` must be
+/// non-empty and contain no control characters. Beyond these checks, Paykit
+/// defines no range, precision, scale, normalization, or asset-registry policy.
+///
+/// [`PaymentAmount::new`] validates only during construction. Direct struct
+/// construction and later field mutation are unchecked.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PaymentAmount {
-    /// Decimal string, such as `10.00`.
+    /// Decimal string, such as `10.00`. Mutation is not revalidated.
     pub value: String,
-    /// Asset code or unit, such as `usd`, `btc`, or `usdt`.
+    /// Asset code or unit, such as `usd`, `btc`, or `usdt`. Mutation is not revalidated.
     pub asset: String,
 }
 

--- a/paykit-lib/src/payment_request/types.rs
+++ b/paykit-lib/src/payment_request/types.rs
@@ -139,6 +139,18 @@ impl fmt::Debug for PaymentRequestTerms {
 }
 
 /// Time interval a recurring Payment Proof applies to.
+///
+/// # Validation
+///
+/// `BillingPeriod` has no public validating constructor or standalone validator.
+/// Direct struct construction and later field mutation are unchecked. Payment
+/// Proof serialization and parsing, and Receipt preparation and parsing, require
+/// `starts_at` and `ends_at` to be RFC3339 timestamps with a `Z` suffix and
+/// `ends_at` to be strictly later than `starts_at`.
+///
+/// [`serialize_receipt_access_json`](crate::serialize_receipt_access_json) does
+/// not validate these fields. Callers must first use
+/// [`ReceiptAccess::validate`](crate::ReceiptAccess::validate).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BillingPeriod {
     /// RFC3339 UTC timestamp using `Z`.


### PR DESCRIPTION
## Problem

`PaymentAmount` and `BillingPeriod` expose public fields, but their documentation did not clearly distinguish constructor validation, unchecked direct construction or mutation, and validation performed by protocol boundaries.

## Change

- Document the exact `PaymentAmount::new` grammar, including accepted bare decimal points and rejected signs.
- Document that direct construction and later field mutation are unchecked.
- Document the Payment Proof and Receipt boundaries that validate `BillingPeriod`.
- Clarify that Receipt Access serialization does not validate and callers must validate first.

## Protocol impact

None. No validation behavior, wire format, migration, or stored-data validity changes.

## Public API/bindings impact

Public Rust documentation is clearer, but no type shape or behavior changes. Platform bindings are unaffected.

## Verification

- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p paykit-lib --no-deps`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `git diff --check`

A fresh isolated Cargo target directory was used instead of `cargo clean` to avoid shared-worktree stale artifacts. Platform binding generation was not required because no binding source changed.
