### PR TITLE
Deduplicate FFI identifier parsing

### DIFF
--- a/paykit-ffi/src/conversions_common.rs
+++ b/paykit-ffi/src/conversions_common.rs
@@ -1,0 +1,13 @@
+use paykit_lib::{PaymentEndpointIdentifier, PaymentRequestId};
+
+use crate::{errors::validation_error, PaykitFfiError};
+
+pub(crate) fn parse_payment_request_id(value: String) -> Result<PaymentRequestId, PaykitFfiError> {
+    PaymentRequestId::new(value).map_err(|err| validation_error(err.to_string()))
+}
+
+pub(crate) fn parse_endpoint_identifier(
+    value: String,
+) -> Result<PaymentEndpointIdentifier, PaykitFfiError> {
+    PaymentEndpointIdentifier::new(value).map_err(|err| validation_error(err.to_string()))
+}

--- a/paykit-ffi/src/lib.rs
+++ b/paykit-ffi/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = "UniFFI bindings for Paykit SDK."]
 
 mod config;
+mod conversions_common;
 mod errors;
 mod json;
 mod payment_adapter;

--- a/paykit-ffi/src/payment_requests/conversions.rs
+++ b/paykit-ffi/src/payment_requests/conversions.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use paykit_lib::{
-    BillingPeriod, PaymentAmount, PaymentEndpointIdentifier, PaymentReference, PaymentRequestId,
-    PaymentRequestTerms, Recurrence, RecurrenceUnit,
+    BillingPeriod, PaymentAmount, PaymentEndpointIdentifier, PaymentReference, PaymentRequestTerms,
+    Recurrence, RecurrenceUnit,
 };
 use paykit_sdk::{
     AmountRecord, BillingPeriodRecord, PaymentProofRecord, PaymentRequestFilter,
@@ -16,6 +16,9 @@ use crate::{
     session::{app_public_key, parse_public_key as parse_pubky_public_key, parse_receiver_path},
     PaykitFfiError,
 };
+
+use crate::conversions_common::parse_endpoint_identifier;
+pub(super) use crate::conversions_common::parse_payment_request_id;
 
 use super::{
     FfiBillingPeriod, FfiPaymentProofRecord, FfiPaymentProofSubmission, FfiPaymentReference,
@@ -287,14 +290,6 @@ pub(super) fn payment_request_records_to_ffi(
 
 pub(super) fn parse_public_key(value: String) -> Result<PubkyPublicKey, PaykitFfiError> {
     parse_pubky_public_key(value)
-}
-
-pub(super) fn parse_payment_request_id(value: String) -> Result<PaymentRequestId, PaykitFfiError> {
-    PaymentRequestId::new(value).map_err(|err| validation_error(err.to_string()))
-}
-
-fn parse_endpoint_identifier(value: String) -> Result<PaymentEndpointIdentifier, PaykitFfiError> {
-    PaymentEndpointIdentifier::new(value).map_err(|err| validation_error(err.to_string()))
 }
 
 fn parse_recurrence_unit(value: &str) -> Result<RecurrenceUnit, PaykitFfiError> {

--- a/paykit-ffi/src/receipts/conversions.rs
+++ b/paykit-ffi/src/receipts/conversions.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
-use paykit_lib::{
-    PaymentAmount, PaymentEndpointIdentifier, PaymentRequestId, ReceiptDraft, ReceiptId,
-};
+use paykit_lib::{PaymentAmount, ReceiptDraft, ReceiptId};
 use paykit_sdk::{
     AmountRecord, ReceiptAccessView, ReceiptDraftBuilder, ReceiptIssuanceStatus,
     ReceiptIssuanceView, ReceiptRecord, ReceiptRetrievalStatus,
@@ -15,6 +13,8 @@ use crate::{
     session::{app_public_key, parse_public_key as parse_pubky_public_key},
     PaykitFfiError,
 };
+
+use crate::conversions_common::{parse_endpoint_identifier, parse_payment_request_id};
 
 use super::{
     FfiReceiptAccessView, FfiReceiptAmount, FfiReceiptDraft, FfiReceiptIssuanceStatus,
@@ -183,12 +183,4 @@ pub(super) fn parse_public_key(
 
 fn parse_receipt_id(value: String) -> Result<ReceiptId, PaykitFfiError> {
     ReceiptId::new(value).map_err(|err| validation_error(err.to_string()))
-}
-
-fn parse_payment_request_id(value: String) -> Result<PaymentRequestId, PaykitFfiError> {
-    PaymentRequestId::new(value).map_err(|err| validation_error(err.to_string()))
-}
-
-fn parse_endpoint_identifier(value: String) -> Result<PaymentEndpointIdentifier, PaykitFfiError> {
-    PaymentEndpointIdentifier::new(value).map_err(|err| validation_error(err.to_string()))
 }


### PR DESCRIPTION
## Problem

Payment Request and Receipt FFI conversions carried byte-identical helpers for parsing Payment Request IDs and Payment Endpoint Identifiers, which allowed their validation and error mapping to drift independently.

## Change

Move both parsers into one private shared conversion module while preserving:

- every existing constructor call;
- validation error mapping;
- the Payment Request helper visibility required by its parent module;
- all UniFFI declarations and public behavior.

## Protocol impact

None. Internal refactor only.

## Public API/bindings impact

None. There is no Rust public API or UniFFI shape change.

## Verification

- Focused Payment Request conversion test
- Focused Receipt conversion test
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `cd paykit-ffi && ./build.sh all` for Swift and all four Android ABIs
- `git diff --check`

A fresh isolated Cargo target directory was used instead of `cargo clean` to avoid shared-worktree stale artifacts. Generated release bindings and native libraries remain unchanged in this interface-neutral refactor.
