### PR TITLE
fix: publish 16 KB-compatible Android library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -42,7 +42,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install native build deps
@@ -56,7 +56,7 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install native build deps
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.91.1"
@@ -88,7 +88,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -87,15 +87,24 @@ jobs:
         RELEASE_TAG: ${{ steps.version.outputs.tag }}
       shell: bash
       run: |
-        STATUS=$(
-          gh api --include "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" 2>/dev/null |
-            awk 'NR == 1 { print $2 }'
-        )
+        set +e
+        RESPONSE=$(gh api --include "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" 2>/dev/null)
+        API_EXIT=$?
+        set -e
+        STATUS=${RESPONSE%%$'\n'*}
+        STATUS=${STATUS#* }
+        STATUS=${STATUS%% *}
         case "$STATUS" in
-          200) echo "exists=true" >> "$GITHUB_OUTPUT" ;;
+          200)
+            if [ "$API_EXIT" -ne 0 ]; then
+              echo "Release lookup returned HTTP 200 with exit code $API_EXIT" >&2
+              exit 1
+            fi
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            ;;
           404) echo "exists=false" >> "$GITHUB_OUTPUT" ;;
           *)
-            echo "Unable to determine whether release $RELEASE_TAG exists (HTTP ${STATUS:-missing})" >&2
+            echo "Unable to determine whether release $RELEASE_TAG exists (HTTP ${STATUS:-missing}, exit $API_EXIT)" >&2
             exit 1
             ;;
         esac

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -29,11 +29,11 @@ jobs:
         echo "tag=$TAG" >> "$GITHUB_OUTPUT"
         echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         ref: ${{ steps.version.outputs.tag }}
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -41,13 +41,13 @@ jobs:
         settings-path: ${{ github.workspace }}
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Install native build dependencies
       run: sudo apt-get update && sudo apt-get install -y pkg-config protobuf-compiler
 
     - name: Set up Android SDK
-      uses: android-actions/setup-android@v3
+      uses: android-actions/setup-android@v4
 
     - name: Set up Android NDK
       id: setup-ndk
@@ -56,8 +56,14 @@ jobs:
         ndk-version: r28c
         add-to-path: true
 
-    - name: Export Android NDK root
-      run: echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
+    - name: Export Android NDK
+      shell: bash
+      run: |
+        NDK_PATH="${{ steps.setup-ndk.outputs.ndk-path }}"
+        echo "ANDROID_NDK_HOME=$NDK_PATH" >> "$GITHUB_ENV"
+        echo "ANDROID_NDK_ROOT=$NDK_PATH" >> "$GITHUB_ENV"
+        cat "$NDK_PATH/source.properties"
+        grep -Fx "Pkg.Revision = 28.2.13676358" "$NDK_PATH/source.properties"
 
     - name: Generate Android bindings
       working-directory: paykit-ffi
@@ -68,12 +74,13 @@ jobs:
       run: ./gradlew build -Pversion=${{ steps.version.outputs.version }}
 
     - name: Upload native debug symbols artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: paykit-native-debug-symbols-${{ steps.version.outputs.version }}
         path: paykit-ffi/bindings/android/native-debug-symbols.zip
 
     - name: Upload native debug symbols to release
+      if: github.event_name == 'release'
       env:
         GH_TOKEN: ${{ github.token }}
       run: gh release upload "${{ steps.version.outputs.tag }}" paykit-ffi/bindings/android/native-debug-symbols.zip --clobber

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -79,8 +79,31 @@ jobs:
         name: paykit-native-debug-symbols-${{ steps.version.outputs.version }}
         path: paykit-ffi/bindings/android/native-debug-symbols.zip
 
+    - name: Detect manual release target
+      if: github.event_name == 'workflow_dispatch'
+      id: release-target
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ steps.version.outputs.tag }}
+      shell: bash
+      run: |
+        STATUS=$(
+          gh api --include "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" 2>/dev/null |
+            awk 'NR == 1 { print $2 }'
+        )
+        case "$STATUS" in
+          200) echo "exists=true" >> "$GITHUB_OUTPUT" ;;
+          404) echo "exists=false" >> "$GITHUB_OUTPUT" ;;
+          *)
+            echo "Unable to determine whether release $RELEASE_TAG exists (HTTP ${STATUS:-missing})" >&2
+            exit 1
+            ;;
+        esac
+
     - name: Upload native debug symbols to release
-      if: github.event_name == 'release'
+      if: >-
+        github.event_name == 'release' ||
+        steps.release-target.outputs.exists == 'true'
       env:
         GH_TOKEN: ${{ github.token }}
       run: gh release upload "${{ steps.version.outputs.tag }}" paykit-ffi/bindings/android/native-debug-symbols.zip --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ paykit-ffi/bindings/android/native-debug-symbols.zip
 .DS_Store
 *.swp
 .swiftpm/
+.ai/logs/
 
 # iOS build artifacts (rebuilt by build_ios.sh; sources are committed)
 paykit-ffi/bindings/ios/Paykit.xcframework/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.1.1-rc1] - 2026-07-24
+
+### Fixed
+- The Android package now builds `libpaykit.so` for devices that use a 16 KB
+  runtime page size while preserving the `0.1.0-rc33` mobile API.
+
 ## [0.1.0-rc33] - 2026-07-08
 
 ### Changed
@@ -265,7 +271,9 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Crate metadata, README documentation, and MIT licensing to prepare the crate for
   publication on crates.io and docs.rs.
 
-[Unreleased]: https://github.com/pubky/paykit-rs/compare/v0.1.0-rc32...HEAD
+[Unreleased]: https://github.com/pubky/paykit-rs/compare/v0.1.1-rc1...HEAD
+[0.1.1-rc1]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.1-rc1
+[0.1.0-rc33]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc33
 [0.1.0-rc32]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc32
 [0.1.0-rc31]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc31
 [0.1.0-rc30]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3142,7 +3142,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "paykit-ffi"
-version = "0.1.0-rc33"
+version = "0.1.1-rc1"
 dependencies = [
  "android_logger",
  "anyhow",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "paykit-lib"
-version = "0.1.0-rc33"
+version = "0.1.1-rc1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "paykit-sdk"
-version = "0.1.0-rc33"
+version = "0.1.1-rc1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Package.swift
+++ b/Package.swift
@@ -2,8 +2,8 @@
 
 import PackageDescription
 
-let tag = "v0.1.0-rc33"
-let checksum = "19da0987d1cec4b40c96512e997adad6b146a4dac2ef78e6cc18b848e87564b8"
+let tag = "v0.1.1-rc1"
+let checksum = "dd313cd4a52ecc7baa21c739a5cb0739871232578965187ac57a022f8c8ed71f"
 let url = "https://github.com/pubky/paykit-rs/releases/download/\(tag)/Paykit.xcframework.zip"
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let tag = "v0.1.1-rc1"
-let checksum = "dd313cd4a52ecc7baa21c739a5cb0739871232578965187ac57a022f8c8ed71f"
+let checksum = "f0ba00de7bf873ce77d2ef58da0e8e2a1cc78baee4b95d2ab85e2ee9000e4feb"
 let url = "https://github.com/pubky/paykit-rs/releases/download/\(tag)/Paykit.xcframework.zip"
 
 let package = Package(

--- a/paykit-ffi/Cargo.toml
+++ b/paykit-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paykit-ffi"
-version = "0.1.0-rc33"
+version = "0.1.1-rc1"
 edition = "2021"
 rust-version = "1.91.1"
 description = "UniFFI bindings for Paykit SDK targeting iOS and Android"

--- a/paykit-ffi/README.md
+++ b/paykit-ffi/README.md
@@ -340,6 +340,16 @@ derivable from the Pubky public key alone.
 
 ## Building
 
+Android builds require NDK r28c revision `28.2.13676358`. Install that exact
+revision and select the same canonical directory through both NDK variables:
+
+```bash
+sdkmanager "ndk;28.2.13676358"
+export PAYKIT_ANDROID_NDK="$ANDROID_SDK_ROOT/ndk/28.2.13676358"
+export ANDROID_NDK_HOME="$PAYKIT_ANDROID_NDK"
+export ANDROID_NDK_ROOT="$PAYKIT_ANDROID_NDK"
+```
+
 Always build all platforms together:
 
 ```bash

--- a/paykit-ffi/RELEASE.md
+++ b/paykit-ffi/RELEASE.md
@@ -2,6 +2,16 @@
 
 ## 1. Build
 
+Install Android NDK r28c revision `28.2.13676358` and export both required NDK
+variables to its canonical directory before running a release build:
+
+```bash
+sdkmanager "ndk;28.2.13676358"
+export PAYKIT_ANDROID_NDK="$ANDROID_SDK_ROOT/ndk/28.2.13676358"
+export ANDROID_NDK_HOME="$PAYKIT_ANDROID_NDK"
+export ANDROID_NDK_ROOT="$PAYKIT_ANDROID_NDK"
+```
+
 From `paykit-ffi/`:
 
 ```bash

--- a/paykit-ffi/bindings/android/gradle.properties
+++ b/paykit-ffi/bindings/android/gradle.properties
@@ -3,4 +3,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
 group=com.synonym
-version=0.1.0-rc33
+version=0.1.1-rc1

--- a/paykit-ffi/bindings/android/lib/build.gradle.kts
+++ b/paykit-ffi/bindings/android/lib/build.gradle.kts
@@ -320,7 +320,12 @@ fun Project.validateAndroidNativeLibrary(
     )
 }
 
-fun kotlinContractVersion(): Int {
+data class KotlinUniffiIntegrity(
+    val contractVersion: Int,
+    val apiChecksums: Map<String, Int>
+)
+
+fun kotlinUniffiIntegrity(): KotlinUniffiIntegrity {
     val generatedBinding = layout.projectDirectory
         .file("src/main/kotlin/com/synonym/paykit/paykit.android.kt")
         .asFile
@@ -330,50 +335,87 @@ fun kotlinContractVersion(): Int {
         )
     }
 
-    val match = Regex(
+    val source = generatedBinding.readText()
+    val contractMatch = Regex(
         """(?m)^\s*val bindings_?[Cc]ontract_?[Vv]ersion = (\d+).*$"""
-    ).find(generatedBinding.readText())
+    ).find(source)
         ?: throw GradleException(
             "Unable to extract the UniFFI contract version from '${generatedBinding.path}'"
         )
+    val checksumMatches = Regex(
+        """if \((?:lib\.)?(uniffi_paykit_checksum_[A-Za-z0-9_]+)\(\) != (\d+)\.toShort\(\)\)"""
+    ).findAll(source).toList()
+    if (checksumMatches.isEmpty()) {
+        throw GradleException(
+            "Unable to extract UniFFI API checksums from '${generatedBinding.path}'"
+        )
+    }
+    val duplicateChecksums = checksumMatches
+        .groupBy { it.groupValues[1] }
+        .filterValues { it.size > 1 }
+        .keys
+    if (duplicateChecksums.isNotEmpty()) {
+        throw GradleException(
+            "Duplicate UniFFI API checksum expectations in '${generatedBinding.path}': " +
+                duplicateChecksums.sorted().joinToString()
+        )
+    }
 
-    return match.groupValues[1].toInt()
+    return KotlinUniffiIntegrity(
+        contractVersion = contractMatch.groupValues[1].toInt(),
+        apiChecksums = checksumMatches.associate {
+            it.groupValues[1] to it.groupValues[2].toInt()
+        }
+    )
 }
 
-fun Project.nativeContractVersion(
+data class NativeSymbol(
+    val address: Long,
+    val size: Long
+)
+
+fun Project.nativeDynamicSymbols(
     nm: String,
-    objdump: String,
     abi: String,
     lib: File,
     displayPath: String
-): Int {
-    val symbol = "ffi_paykit_uniffi_contract_version"
+): Map<String, NativeSymbol> {
     val (nmExit, symbols) = runTool(nm, "-D", "-S", lib.absolutePath)
     if (nmExit != 0) {
         throw GradleException(
-            "Unable to inspect UniFFI contract symbol: ABI='$abi' path='$displayPath'"
+            "Unable to inspect native symbols: ABI='$abi' path='$displayPath'"
         )
     }
 
-    val symbolFields = symbols.lineSequence()
+    return symbols.lineSequence()
         .map { it.trim().split(Regex("""\s+""")) }
-        .firstOrNull { it.lastOrNull() == symbol }
-        ?: throw GradleException(
-            "UniFFI contract symbol is missing: ABI='$abi' path='$displayPath'"
-        )
-    if (symbolFields.size < 4) {
-        throw GradleException(
-            "Unable to parse UniFFI contract symbol: ABI='$abi' path='$displayPath'"
-        )
-    }
+        .filter { it.size >= 4 }
+        .associate { fields ->
+            fields.last() to NativeSymbol(
+                address = fields[0].toLong(16),
+                size = fields[1].toLong(16)
+            )
+        }
+}
 
-    val start = symbolFields[0].toLong(16)
-    val size = symbolFields[1].toLong(16)
+fun Project.nativeConstantValue(
+    objdump: String,
+    abi: String,
+    lib: File,
+    displayPath: String,
+    symbols: Map<String, NativeSymbol>,
+    symbolName: String
+): Int {
+    val symbol = symbols[symbolName]
+        ?: throw GradleException(
+            "UniFFI integrity symbol is missing: ABI='$abi' symbol='$symbolName' path='$displayPath'"
+        )
+
     val objdumpArgs = buildList {
         add("-d")
         add("--no-show-raw-insn")
-        add("--start-address=$start")
-        add("--stop-address=${start + size}")
+        add("--start-address=${symbol.address}")
+        add("--stop-address=${symbol.address + symbol.size}")
         if (abi == "armeabi-v7a") {
             add("--triple=thumbv7-none-linux-android")
         }
@@ -382,48 +424,127 @@ fun Project.nativeContractVersion(
     val (objdumpExit, disassembly) = runTool(objdump, *objdumpArgs.toTypedArray())
     if (objdumpExit != 0) {
         throw GradleException(
-            "Unable to disassemble UniFFI contract symbol: ABI='$abi' path='$displayPath'"
+            "Unable to disassemble UniFFI integrity symbol: " +
+                "ABI='$abi' symbol='$symbolName' path='$displayPath'"
         )
     }
 
     val immediate = sequenceOf(
         Regex("""\bmovs?\s+r0,\s*#0x([0-9a-fA-F]+)"""),
+        Regex("""\bmovw\s+r0,\s*#0x([0-9a-fA-F]+)"""),
+        Regex("""\bmov\.w\s+r0,\s*#0x([0-9a-fA-F]+)"""),
         Regex("""\bmov\s+w0,\s*#0x([0-9a-fA-F]+)"""),
-        Regex("""\bmovl\s+\$0x([0-9a-fA-F]+),\s*%eax""")
+        Regex("""\bmov[wl]\s+\$0x([0-9a-fA-F]+),\s*%e?ax""")
     ).mapNotNull { it.find(disassembly)?.groupValues?.get(1) }
         .firstOrNull()
         ?: throw GradleException(
-            "Unable to decode UniFFI contract version: ABI='$abi' path='$displayPath'\n$disassembly"
+            "Unable to decode UniFFI integrity symbol: " +
+                "ABI='$abi' symbol='$symbolName' path='$displayPath'\n$disassembly"
         )
 
     return immediate.toInt(16)
 }
 
+fun Project.validateUniffiIntegrity(
+    nm: String,
+    objdump: String,
+    expected: KotlinUniffiIntegrity,
+    abi: String,
+    lib: File,
+    displayPath: String
+) {
+    val symbols = nativeDynamicSymbols(nm, abi, lib, displayPath)
+    val nativeChecksumSymbols = symbols.keys.filter {
+        it.startsWith("uniffi_paykit_checksum_")
+    }.toSet()
+    val expectedChecksumSymbols = expected.apiChecksums.keys
+    if (nativeChecksumSymbols != expectedChecksumSymbols) {
+        val missing = expectedChecksumSymbols - nativeChecksumSymbols
+        val extra = nativeChecksumSymbols - expectedChecksumSymbols
+        throw GradleException(
+            "UniFFI API checksum symbol set mismatch: ABI='$abi' path='$displayPath' " +
+                "missing=${missing.sorted()} extra=${extra.sorted()}"
+        )
+    }
+
+    val nativeContract = nativeConstantValue(
+        objdump,
+        abi,
+        lib,
+        displayPath,
+        symbols,
+        "ffi_paykit_uniffi_contract_version"
+    )
+    if (nativeContract != expected.contractVersion) {
+        throw GradleException(
+            "UniFFI Kotlin/native contract mismatch: ABI='$abi' " +
+                "Kotlin=${expected.contractVersion} native=$nativeContract path='$displayPath'"
+        )
+    }
+
+    expected.apiChecksums.toSortedMap().forEach { (symbolName, expectedChecksum) ->
+        val nativeChecksum = nativeConstantValue(
+            objdump,
+            abi,
+            lib,
+            displayPath,
+            symbols,
+            symbolName
+        )
+        if (nativeChecksum != expectedChecksum) {
+            throw GradleException(
+                "UniFFI API checksum mismatch: ABI='$abi' symbol='$symbolName' " +
+                    "Kotlin=$expectedChecksum native=$nativeChecksum path='$displayPath'"
+            )
+        }
+    }
+
+    logger.lifecycle(
+        "UniFFI Kotlin/native integrity validation passed: ABI='$abi' " +
+            "contract=${expected.contractVersion} checksums=${expected.apiChecksums.size} " +
+            "path='$displayPath'"
+    )
+}
+
 val validateReleaseNativeLibraries by tasks.registering {
     group = "verification"
-    description = "Validates source release JNI libraries are stripped and 16 KB compatible."
+    description = "Validates source release JNI libraries for 16 KB and UniFFI integrity."
 
     doLast {
         val readelf = findReadelf()
+        val nm = findLlvmTool("llvm-nm")
+        val objdump = findLlvmTool("llvm-objdump")
+        val kotlinIntegrity = kotlinUniffiIntegrity()
 
         androidNativeAbis.forEach { abi ->
             val lib = layout.projectDirectory.file("src/main/jniLibs/$abi/libpaykit.so").asFile
             validateAndroidNativeLibrary(readelf, abi, lib)
+            validateUniffiIntegrity(
+                nm,
+                objdump,
+                kotlinIntegrity,
+                abi,
+                lib,
+                lib.path
+            )
         }
     }
 }
 
 val validateReleaseAarNativeLibraries by tasks.registering {
     group = "verification"
-    description = "Validates every native library in the final release AAR for 16 KB compatibility."
+    description = "Validates every final-AAR native library for 16 KB and UniFFI integrity."
     dependsOn("bundleReleaseAar")
 
     doLast {
         val readelf = findReadelf()
         val nm = findLlvmTool("llvm-nm")
         val objdump = findLlvmTool("llvm-objdump")
-        val kotlinContract = kotlinContractVersion()
-        logger.lifecycle("UniFFI Kotlin contract version: $kotlinContract")
+        val kotlinIntegrity = kotlinUniffiIntegrity()
+        logger.lifecycle(
+            "UniFFI Kotlin integrity manifest: contract=${kotlinIntegrity.contractVersion} " +
+                "checksums=${kotlinIntegrity.apiChecksums.size}"
+        )
         val aar = layout.buildDirectory.file("outputs/aar/lib-release.aar").get().asFile
         if (!aar.isFile) {
             throw GradleException("Android release AAR missing at '${aar.path}'")
@@ -444,24 +565,13 @@ val validateReleaseAarNativeLibraries by tasks.registering {
                         extracted.outputStream().use { output -> input.copyTo(output) }
                     }
                     validateAndroidNativeLibrary(readelf, abi, extracted, "${aar.path}!/$entryPath")
-                    val nativeContract = nativeContractVersion(
+                    validateUniffiIntegrity(
                         nm,
                         objdump,
+                        kotlinIntegrity,
                         abi,
                         extracted,
                         "${aar.path}!/$entryPath"
-                    )
-                    if (nativeContract != kotlinContract) {
-                        throw GradleException(
-                            "UniFFI Kotlin/native contract mismatch: ABI='$abi' " +
-                                "Kotlin=$kotlinContract native=$nativeContract " +
-                                "path='${aar.path}!/$entryPath'"
-                        )
-                    }
-                    logger.lifecycle(
-                        "UniFFI Kotlin/native contract validation passed: ABI='$abi' " +
-                            "Kotlin=$kotlinContract native=$nativeContract " +
-                            "path='${aar.path}!/$entryPath'"
                     )
                 }
             }

--- a/paykit-ffi/bindings/android/lib/build.gradle.kts
+++ b/paykit-ffi/bindings/android/lib/build.gradle.kts
@@ -133,6 +133,18 @@ dependencies {
 
 val androidNativeAbis = listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
 
+data class ExpectedElfIdentity(
+    val elfClass: String,
+    val machine: String
+)
+
+val expectedAndroidElfIdentities = mapOf(
+    "armeabi-v7a" to ExpectedElfIdentity("ELF32", "ARM"),
+    "arm64-v8a" to ExpectedElfIdentity("ELF64", "AArch64"),
+    "x86" to ExpectedElfIdentity("ELF32", "Intel 80386"),
+    "x86_64" to ExpectedElfIdentity("ELF64", "Advanced Micro Devices X86-64")
+)
+
 fun executableFromPath(name: String): String? {
     return System.getenv("PATH")
         ?.split(File.pathSeparator)
@@ -269,6 +281,33 @@ fun Project.validateAndroidNativeLibrary(
         throw GradleException("Android native library missing: ABI='$abi' path='$displayPath'")
     }
 
+    val expectedIdentity = expectedAndroidElfIdentities[abi]
+        ?: throw GradleException(
+            "Unsupported Android ABI for ELF validation: ABI='$abi' path='$displayPath'"
+        )
+    val (headerExit, elfHeader) = runReadelf(readelf, "-h", lib.absolutePath)
+    if (headerExit != 0) {
+        throw GradleException(
+            "Unable to inspect Android ELF identity: ABI='$abi' path='$displayPath'"
+        )
+    }
+    val elfClass = Regex("""(?m)^\s*Class:\s*(\S+).*$""")
+        .find(elfHeader)
+        ?.groupValues
+        ?.get(1)
+    val elfMachine = Regex("""(?m)^\s*Machine:\s*(.*?)\s*$""")
+        .find(elfHeader)
+        ?.groupValues
+        ?.get(1)
+    if (elfClass != expectedIdentity.elfClass || elfMachine != expectedIdentity.machine) {
+        throw GradleException(
+            "Android ELF ABI mismatch: ABI='$abi' path='$displayPath' " +
+                "expectedClass=${expectedIdentity.elfClass} actualClass=${elfClass ?: "missing"} " +
+                "expectedMachine='${expectedIdentity.machine}' " +
+                "actualMachine='${elfMachine ?: "missing"}'"
+        )
+    }
+
     val (sectionsExit, sections) = runReadelf(readelf, "-S", lib.absolutePath)
     if (sectionsExit != 0) {
         throw GradleException("Unable to inspect Android native library sections: ABI='$abi' path='$displayPath'")
@@ -316,7 +355,32 @@ fun Project.validateAndroidNativeLibrary(
     }
 
     logger.lifecycle(
-        "Android 16 KB ELF validation passed: ABI='$abi' path='$displayPath' ${info.detectedValues()}"
+        "Android 16 KB ELF validation passed: ABI='$abi' path='$displayPath' " +
+            "ELF_CLASS=$elfClass ELF_MACHINE='$elfMachine' ${info.detectedValues()}"
+    )
+}
+
+fun Project.validateAndroidAbiMismatchFixture(
+    readelf: String,
+    labeledAbi: String,
+    lib: File,
+    actualAbi: String
+) {
+    val displayPath = "negative-fixture: $actualAbi/libpaykit.so labeled $labeledAbi"
+    val failure = runCatching {
+        validateAndroidNativeLibrary(readelf, labeledAbi, lib, displayPath)
+    }.exceptionOrNull()
+    if (failure !is GradleException ||
+        failure.message?.startsWith("Android ELF ABI mismatch:") != true
+    ) {
+        throw GradleException(
+            "Android ELF ABI mismatch fixture failed for an unexpected reason: " +
+                "actualABI='$actualAbi' labeledABI='$labeledAbi'",
+            failure
+        )
+    }
+    logger.lifecycle(
+        "Android ELF ABI mismatch fixture passed: actualABI='$actualAbi' labeledABI='$labeledAbi'"
     )
 }
 
@@ -515,6 +579,23 @@ val validateReleaseNativeLibraries by tasks.registering {
         val nm = findLlvmTool("llvm-nm")
         val objdump = findLlvmTool("llvm-objdump")
         val kotlinIntegrity = kotlinUniffiIntegrity()
+
+        validateAndroidAbiMismatchFixture(
+            readelf,
+            "x86_64",
+            layout.projectDirectory.file(
+                "src/main/jniLibs/arm64-v8a/libpaykit.so"
+            ).asFile,
+            "arm64-v8a"
+        )
+        validateAndroidAbiMismatchFixture(
+            readelf,
+            "arm64-v8a",
+            layout.projectDirectory.file(
+                "src/main/jniLibs/x86_64/libpaykit.so"
+            ).asFile,
+            "x86_64"
+        )
 
         androidNativeAbis.forEach { abi ->
             val lib = layout.projectDirectory.file("src/main/jniLibs/$abi/libpaykit.so").asFile

--- a/paykit-ffi/bindings/android/lib/build.gradle.kts
+++ b/paykit-ffi/bindings/android/lib/build.gradle.kts
@@ -145,53 +145,62 @@ val expectedAndroidElfIdentities = mapOf(
     "x86_64" to ExpectedElfIdentity("ELF64", "Advanced Micro Devices X86-64")
 )
 
-fun executableFromPath(name: String): String? {
-    return System.getenv("PATH")
-        ?.split(File.pathSeparator)
-        ?.asSequence()
-        ?.map { File(it, name) }
-        ?.firstOrNull { it.canExecute() }
+val expectedAndroidNdkRevision = "28.2.13676358"
+
+fun selectedAndroidNdkRoot(): File {
+    val ndkHome = System.getenv("ANDROID_NDK_HOME")
+        ?.takeIf { it.isNotBlank() }
+        ?.let(::File)
+        ?: throw GradleException(
+            "ANDROID_NDK_HOME must select Android NDK $expectedAndroidNdkRevision"
+        )
+    val ndkRoot = System.getenv("ANDROID_NDK_ROOT")
+        ?.takeIf { it.isNotBlank() }
+        ?.let(::File)
+        ?: throw GradleException(
+            "ANDROID_NDK_ROOT must select Android NDK $expectedAndroidNdkRevision"
+        )
+    val canonicalHome = ndkHome.canonicalFile
+    val canonicalRoot = ndkRoot.canonicalFile
+    if (canonicalHome != canonicalRoot) {
+        throw GradleException(
+            "ANDROID_NDK_HOME and ANDROID_NDK_ROOT select different NDKs: " +
+                "HOME='${canonicalHome.path}' ROOT='${canonicalRoot.path}'"
+        )
+    }
+
+    val sourceProperties = File(canonicalHome, "source.properties")
+    if (!sourceProperties.isFile) {
+        throw GradleException(
+            "Android NDK source.properties is missing at '${canonicalHome.path}'"
+        )
+    }
+    val expectedRevision = "Pkg.Revision = $expectedAndroidNdkRevision"
+    if (sourceProperties.readLines().none { it == expectedRevision }) {
+        throw GradleException(
+            "Android NDK $expectedAndroidNdkRevision is required: " +
+                "path='${canonicalHome.path}'"
+        )
+    }
+
+    return canonicalHome
+}
+
+fun findSelectedAndroidNdkLlvmTool(name: String): String {
+    val ndkRoot = selectedAndroidNdkRoot()
+    return File(ndkRoot, "toolchains/llvm/prebuilt")
+        .walkTopDown()
+        .firstOrNull { it.name == name && it.canExecute() }
         ?.absolutePath
-}
-
-fun findReadelf(): String {
-    executableFromPath("llvm-readelf")?.let { return it }
-    executableFromPath("readelf")?.let { return it }
-
-    return listOf("ANDROID_NDK_ROOT", "ANDROID_NDK_HOME", "NDK_HOME")
-        .mapNotNull { System.getenv(it) }
-        .map { File(it, "toolchains/llvm/prebuilt") }
-        .firstNotNullOfOrNull { prebuiltDir ->
-            if (!prebuiltDir.isDirectory) return@firstNotNullOfOrNull null
-
-            prebuiltDir
-                .walkTopDown()
-                .firstOrNull { it.name == "llvm-readelf" && it.canExecute() }
-                ?.absolutePath
-        }
         ?: throw GradleException(
-            "llvm-readelf or readelf is required to validate Android native debug symbols"
+            "$name is missing from Android NDK $expectedAndroidNdkRevision " +
+                "at '${ndkRoot.path}'"
         )
 }
 
-fun findLlvmTool(name: String): String {
-    executableFromPath(name)?.let { return it }
+fun findReadelf(): String = findSelectedAndroidNdkLlvmTool("llvm-readelf")
 
-    return listOf("ANDROID_NDK_ROOT", "ANDROID_NDK_HOME", "NDK_HOME")
-        .mapNotNull { System.getenv(it) }
-        .map { File(it, "toolchains/llvm/prebuilt") }
-        .firstNotNullOfOrNull { prebuiltDir ->
-            if (!prebuiltDir.isDirectory) return@firstNotNullOfOrNull null
-
-            prebuiltDir
-                .walkTopDown()
-                .firstOrNull { it.name == name && it.canExecute() }
-                ?.absolutePath
-        }
-        ?: throw GradleException(
-            "$name is required to validate the UniFFI Kotlin/native contract"
-        )
-}
+fun findLlvmTool(name: String): String = findSelectedAndroidNdkLlvmTool(name)
 
 fun Project.runReadelf(readelf: String, vararg args: String): Pair<Int, String> {
     val stdout = ByteArrayOutputStream()
@@ -579,6 +588,10 @@ val validateReleaseNativeLibraries by tasks.registering {
         val nm = findLlvmTool("llvm-nm")
         val objdump = findLlvmTool("llvm-objdump")
         val kotlinIntegrity = kotlinUniffiIntegrity()
+        logger.lifecycle(
+            "Using Android NDK $expectedAndroidNdkRevision LLVM tools: " +
+                "readelf='$readelf' nm='$nm' objdump='$objdump'"
+        )
 
         validateAndroidAbiMismatchFixture(
             readelf,
@@ -622,6 +635,10 @@ val validateReleaseAarNativeLibraries by tasks.registering {
         val nm = findLlvmTool("llvm-nm")
         val objdump = findLlvmTool("llvm-objdump")
         val kotlinIntegrity = kotlinUniffiIntegrity()
+        logger.lifecycle(
+            "Using Android NDK $expectedAndroidNdkRevision LLVM tools: " +
+                "readelf='$readelf' nm='$nm' objdump='$objdump'"
+        )
         logger.lifecycle(
             "UniFFI Kotlin integrity manifest: contract=${kotlinIntegrity.contractVersion} " +
                 "checksums=${kotlinIntegrity.apiChecksums.size}"

--- a/paykit-ffi/bindings/android/lib/build.gradle.kts
+++ b/paykit-ffi/bindings/android/lib/build.gradle.kts
@@ -1,6 +1,7 @@
 import groovy.json.JsonSlurper
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.Files
 import java.util.zip.ZipFile
 
 plugins {
@@ -161,6 +162,25 @@ fun findReadelf(): String {
         )
 }
 
+fun findLlvmTool(name: String): String {
+    executableFromPath(name)?.let { return it }
+
+    return listOf("ANDROID_NDK_ROOT", "ANDROID_NDK_HOME", "NDK_HOME")
+        .mapNotNull { System.getenv(it) }
+        .map { File(it, "toolchains/llvm/prebuilt") }
+        .firstNotNullOfOrNull { prebuiltDir ->
+            if (!prebuiltDir.isDirectory) return@firstNotNullOfOrNull null
+
+            prebuiltDir
+                .walkTopDown()
+                .firstOrNull { it.name == name && it.canExecute() }
+                ?.absolutePath
+        }
+        ?: throw GradleException(
+            "$name is required to validate the UniFFI Kotlin/native contract"
+        )
+}
+
 fun Project.runReadelf(readelf: String, vararg args: String): Pair<Int, String> {
     val stdout = ByteArrayOutputStream()
     val stderr = ByteArrayOutputStream()
@@ -174,7 +194,20 @@ fun Project.runReadelf(readelf: String, vararg args: String): Pair<Int, String> 
     return result.exitValue to stdout.toString().ifBlank { stderr.toString() }
 }
 
-fun String.parseElfAlignment(): Long {
+fun Project.runTool(tool: String, vararg args: String): Pair<Int, String> {
+    val stdout = ByteArrayOutputStream()
+    val stderr = ByteArrayOutputStream()
+    val result = exec {
+        commandLine(tool, *args)
+        standardOutput = stdout
+        errorOutput = stderr
+        isIgnoreExitValue = true
+    }
+
+    return result.exitValue to stdout.toString().ifBlank { stderr.toString() }
+}
+
+fun String.parseElfNumber(): Long {
     return if (startsWith("0x")) {
         removePrefix("0x").toLong(16)
     } else {
@@ -182,54 +215,270 @@ fun String.parseElfAlignment(): Long {
     }
 }
 
+fun Long.toElfHex(): String = "0x${toString(16)}"
+
+data class ElfPageSizeInfo(
+    val loadAlignments: List<Long>,
+    val relroStart: Long?,
+    val relroSize: Long?
+) {
+    val relroEnd: Long?
+        get() = if (relroStart != null && relroSize != null) relroStart + relroSize else null
+
+    fun detectedValues(): String {
+        val loads = if (loadAlignments.isEmpty()) {
+            "missing"
+        } else {
+            loadAlignments.joinToString(",") { it.toElfHex() }
+        }
+        return "LOAD_ALIGNMENTS=[$loads] " +
+            "GNU_RELRO_START=${relroStart?.toElfHex() ?: "missing"} " +
+            "GNU_RELRO_MEMSZ=${relroSize?.toElfHex() ?: "missing"} " +
+            "GNU_RELRO_END=${relroEnd?.toElfHex() ?: "missing"}"
+    }
+}
+
+fun parseElfPageSizeInfo(headers: String): ElfPageSizeInfo {
+    val loadAlignments = mutableListOf<Long>()
+    var relroStart: Long? = null
+    var relroSize: Long? = null
+
+    headers.lineSequence().forEach { line ->
+        val columns = line.trim().split(Regex("""\s+"""))
+        when (columns.firstOrNull()) {
+            "LOAD" -> columns.lastOrNull()?.let { loadAlignments += it.parseElfNumber() }
+            "GNU_RELRO" -> {
+                if (columns.size >= 6) {
+                    relroStart = columns[2].parseElfNumber()
+                    relroSize = columns[5].parseElfNumber()
+                }
+            }
+        }
+    }
+
+    return ElfPageSizeInfo(loadAlignments, relroStart, relroSize)
+}
+
+fun Project.validateAndroidNativeLibrary(
+    readelf: String,
+    abi: String,
+    lib: File,
+    displayPath: String = lib.path
+) {
+    if (!lib.isFile) {
+        throw GradleException("Android native library missing: ABI='$abi' path='$displayPath'")
+    }
+
+    val (sectionsExit, sections) = runReadelf(readelf, "-S", lib.absolutePath)
+    if (sectionsExit != 0) {
+        throw GradleException("Unable to inspect Android native library sections: ABI='$abi' path='$displayPath'")
+    }
+    if (Regex("""\.debug_""").containsMatchIn(sections)) {
+        throw GradleException(
+            "Android release native library still contains .debug_* sections: ABI='$abi' path='$displayPath'"
+        )
+    }
+
+    val wideHeaders = runReadelf(readelf, "-W", "-l", lib.absolutePath)
+    val headers = if (wideHeaders.first == 0) {
+        wideHeaders.second
+    } else {
+        val fallbackHeaders = runReadelf(readelf, "-l", lib.absolutePath)
+        if (fallbackHeaders.first != 0) {
+            throw GradleException(
+                "Unable to inspect Android native library headers: ABI='$abi' path='$displayPath'"
+            )
+        }
+        fallbackHeaders.second
+    }
+
+    val pageSize = 16_384L
+    val info = parseElfPageSizeInfo(headers)
+    val relroEnd = info.relroEnd
+    val failures = buildList {
+        if (info.loadAlignments.isEmpty()) {
+            add("PT_LOAD is missing")
+        } else if (info.loadAlignments.any { it < pageSize }) {
+            add("PT_LOAD alignment is below 0x4000")
+        }
+        if (relroEnd == null) {
+            add("PT_GNU_RELRO is missing")
+        } else if (relroEnd % pageSize != 0L) {
+            add("PT_GNU_RELRO end is not aligned to 0x4000")
+        }
+    }
+
+    if (failures.isNotEmpty()) {
+        throw GradleException(
+            "Android 16 KB ELF validation failed: ABI='$abi' path='$displayPath' " +
+                "${info.detectedValues()} failures=${failures.joinToString("; ")}"
+        )
+    }
+
+    logger.lifecycle(
+        "Android 16 KB ELF validation passed: ABI='$abi' path='$displayPath' ${info.detectedValues()}"
+    )
+}
+
+fun kotlinContractVersion(): Int {
+    val generatedBinding = layout.projectDirectory
+        .file("src/main/kotlin/com/synonym/paykit/paykit.android.kt")
+        .asFile
+    if (!generatedBinding.isFile) {
+        throw GradleException(
+            "Generated Kotlin binding is missing at '${generatedBinding.path}'"
+        )
+    }
+
+    val match = Regex(
+        """(?m)^\s*val bindings_?[Cc]ontract_?[Vv]ersion = (\d+).*$"""
+    ).find(generatedBinding.readText())
+        ?: throw GradleException(
+            "Unable to extract the UniFFI contract version from '${generatedBinding.path}'"
+        )
+
+    return match.groupValues[1].toInt()
+}
+
+fun Project.nativeContractVersion(
+    nm: String,
+    objdump: String,
+    abi: String,
+    lib: File,
+    displayPath: String
+): Int {
+    val symbol = "ffi_paykit_uniffi_contract_version"
+    val (nmExit, symbols) = runTool(nm, "-D", "-S", lib.absolutePath)
+    if (nmExit != 0) {
+        throw GradleException(
+            "Unable to inspect UniFFI contract symbol: ABI='$abi' path='$displayPath'"
+        )
+    }
+
+    val symbolFields = symbols.lineSequence()
+        .map { it.trim().split(Regex("""\s+""")) }
+        .firstOrNull { it.lastOrNull() == symbol }
+        ?: throw GradleException(
+            "UniFFI contract symbol is missing: ABI='$abi' path='$displayPath'"
+        )
+    if (symbolFields.size < 4) {
+        throw GradleException(
+            "Unable to parse UniFFI contract symbol: ABI='$abi' path='$displayPath'"
+        )
+    }
+
+    val start = symbolFields[0].toLong(16)
+    val size = symbolFields[1].toLong(16)
+    val objdumpArgs = buildList {
+        add("-d")
+        add("--no-show-raw-insn")
+        add("--start-address=$start")
+        add("--stop-address=${start + size}")
+        if (abi == "armeabi-v7a") {
+            add("--triple=thumbv7-none-linux-android")
+        }
+        add(lib.absolutePath)
+    }
+    val (objdumpExit, disassembly) = runTool(objdump, *objdumpArgs.toTypedArray())
+    if (objdumpExit != 0) {
+        throw GradleException(
+            "Unable to disassemble UniFFI contract symbol: ABI='$abi' path='$displayPath'"
+        )
+    }
+
+    val immediate = sequenceOf(
+        Regex("""\bmovs?\s+r0,\s*#0x([0-9a-fA-F]+)"""),
+        Regex("""\bmov\s+w0,\s*#0x([0-9a-fA-F]+)"""),
+        Regex("""\bmovl\s+\$0x([0-9a-fA-F]+),\s*%eax""")
+    ).mapNotNull { it.find(disassembly)?.groupValues?.get(1) }
+        .firstOrNull()
+        ?: throw GradleException(
+            "Unable to decode UniFFI contract version: ABI='$abi' path='$displayPath'\n$disassembly"
+        )
+
+    return immediate.toInt(16)
+}
+
 val validateReleaseNativeLibraries by tasks.registering {
     group = "verification"
-    description = "Validates release JNI libraries are stripped and keep 16 KB LOAD alignment."
+    description = "Validates source release JNI libraries are stripped and 16 KB compatible."
 
     doLast {
         val readelf = findReadelf()
-        val loadAlignmentRegex = Regex("""^\s*LOAD\s+.*\s+(0x[0-9a-fA-F]+|\d+)\s*$""")
 
         androidNativeAbis.forEach { abi ->
             val lib = layout.projectDirectory.file("src/main/jniLibs/$abi/libpaykit.so").asFile
-            if (!lib.isFile) {
-                throw GradleException("Android native library missing at '${lib.path}'")
-            }
-
-            val (sectionsExit, sections) = runReadelf(readelf, "-S", lib.absolutePath)
-            if (sectionsExit != 0) {
-                throw GradleException("Unable to inspect Android native library sections: '${lib.path}'")
-            }
-            if (Regex("""\.debug_""").containsMatchIn(sections)) {
-                throw GradleException("Android release native library still contains .debug_* sections: '${lib.path}'")
-            }
-
-            val wideHeaders = runReadelf(readelf, "-W", "-l", lib.absolutePath)
-            val headers = if (wideHeaders.first == 0) {
-                wideHeaders.second
-            } else {
-                val fallbackHeaders = runReadelf(readelf, "-l", lib.absolutePath)
-                if (fallbackHeaders.first != 0) {
-                    throw GradleException("Unable to inspect Android native library headers: '${lib.path}'")
-                }
-                fallbackHeaders.second
-            }
-
-            val alignments = headers
-                .lineSequence()
-                .mapNotNull { loadAlignmentRegex.matchEntire(it)?.groupValues?.get(1)?.parseElfAlignment() }
-                .toList()
-
-            if (alignments.isEmpty() || alignments.any { it < 16_384 }) {
-                throw GradleException("Android native library is not 16 KB page-size aligned: '${lib.path}'")
-            }
+            validateAndroidNativeLibrary(readelf, abi, lib)
         }
     }
 }
 
-tasks.matching { it.name == "bundleReleaseAar" || it.name.startsWith("publish") }.configureEach {
+val validateReleaseAarNativeLibraries by tasks.registering {
+    group = "verification"
+    description = "Validates every native library in the final release AAR for 16 KB compatibility."
+    dependsOn("bundleReleaseAar")
+
+    doLast {
+        val readelf = findReadelf()
+        val nm = findLlvmTool("llvm-nm")
+        val objdump = findLlvmTool("llvm-objdump")
+        val kotlinContract = kotlinContractVersion()
+        logger.lifecycle("UniFFI Kotlin contract version: $kotlinContract")
+        val aar = layout.buildDirectory.file("outputs/aar/lib-release.aar").get().asFile
+        if (!aar.isFile) {
+            throw GradleException("Android release AAR missing at '${aar.path}'")
+        }
+
+        val tempDir = Files.createTempDirectory("paykit-release-aar-").toFile()
+        try {
+            ZipFile(aar).use { zip ->
+                androidNativeAbis.forEach { abi ->
+                    val entryPath = "jni/$abi/libpaykit.so"
+                    val entry = zip.getEntry(entryPath)
+                        ?: throw GradleException(
+                            "Android release AAR native library missing: ABI='$abi' path='$entryPath' AAR='${aar.path}'"
+                        )
+                    val extracted = File(tempDir, entryPath)
+                    extracted.parentFile.mkdirs()
+                    zip.getInputStream(entry).use { input ->
+                        extracted.outputStream().use { output -> input.copyTo(output) }
+                    }
+                    validateAndroidNativeLibrary(readelf, abi, extracted, "${aar.path}!/$entryPath")
+                    val nativeContract = nativeContractVersion(
+                        nm,
+                        objdump,
+                        abi,
+                        extracted,
+                        "${aar.path}!/$entryPath"
+                    )
+                    if (nativeContract != kotlinContract) {
+                        throw GradleException(
+                            "UniFFI Kotlin/native contract mismatch: ABI='$abi' " +
+                                "Kotlin=$kotlinContract native=$nativeContract " +
+                                "path='${aar.path}!/$entryPath'"
+                        )
+                    }
+                    logger.lifecycle(
+                        "UniFFI Kotlin/native contract validation passed: ABI='$abi' " +
+                            "Kotlin=$kotlinContract native=$nativeContract " +
+                            "path='${aar.path}!/$entryPath'"
+                    )
+                }
+            }
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+}
+
+tasks.matching { it.name == "bundleReleaseAar" }.configureEach {
     dependsOn(validateReleaseNativeLibraries)
 }
+
+tasks.matching { it.name == "build" || it.name == "assembleRelease" || it.name.startsWith("publish") }
+    .configureEach {
+        dependsOn(validateReleaseAarNativeLibraries)
+    }
 
 afterEvaluate {
     publishing {

--- a/paykit-ffi/bindings/android/lib/src/main/jniLibs/arm64-v8a/libpaykit.so
+++ b/paykit-ffi/bindings/android/lib/src/main/jniLibs/arm64-v8a/libpaykit.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ea4cf7a6067818b9958f2a672ea4a39f9f7a23d020de7bc0236e540560c5fed
+oid sha256:a2c617c089806c99e01c822c580defc4c97304ab554dacfacebb1cdb8c2bde05
 size 12115968

--- a/paykit-ffi/bindings/android/lib/src/main/jniLibs/arm64-v8a/libpaykit.so
+++ b/paykit-ffi/bindings/android/lib/src/main/jniLibs/arm64-v8a/libpaykit.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b6fcbe4763f55f5127323ddda787752f6a8f776788a5afe68fd235286533d70
-size 12236512
+oid sha256:1ea4cf7a6067818b9958f2a672ea4a39f9f7a23d020de7bc0236e540560c5fed
+size 12115968

--- a/paykit-ffi/bindings/android/lib/src/main/jniLibs/armeabi-v7a/libpaykit.so
+++ b/paykit-ffi/bindings/android/lib/src/main/jniLibs/armeabi-v7a/libpaykit.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7584451e9fbd104151b9db2bde7e6b866951a5e2040135da268f119ca873184
+oid sha256:8bcae951e62e6f681a7bf17a1baaf3261a8d6731665a49c0c4a5e3e098bf0ad0
 size 7757052

--- a/paykit-ffi/bindings/android/lib/src/main/jniLibs/armeabi-v7a/libpaykit.so
+++ b/paykit-ffi/bindings/android/lib/src/main/jniLibs/armeabi-v7a/libpaykit.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:776162560b8f4f0a494a65b11d1bafddb456c50bcebb9a5055ef9e63487bbb9f
-size 7822432
+oid sha256:a7584451e9fbd104151b9db2bde7e6b866951a5e2040135da268f119ca873184
+size 7757052

--- a/paykit-ffi/bindings/android/lib/src/main/jniLibs/x86/libpaykit.so
+++ b/paykit-ffi/bindings/android/lib/src/main/jniLibs/x86/libpaykit.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85b63efa27b55d156c6683388d9d600cfad21d9fc18e52a3b2792d143916be39
-size 14180660
+oid sha256:6913b414b6e06a8bb3d6c0acdf97389fbbc13a56571c1756f72db131fcbc346b
+size 14161880

--- a/paykit-ffi/bindings/android/lib/src/main/jniLibs/x86/libpaykit.so
+++ b/paykit-ffi/bindings/android/lib/src/main/jniLibs/x86/libpaykit.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6913b414b6e06a8bb3d6c0acdf97389fbbc13a56571c1756f72db131fcbc346b
+oid sha256:fa3729c2762470ffa774017188708a426cfd1c525b269d2a19ce9a4f9008735b
 size 14161880

--- a/paykit-ffi/bindings/android/lib/src/main/jniLibs/x86_64/libpaykit.so
+++ b/paykit-ffi/bindings/android/lib/src/main/jniLibs/x86_64/libpaykit.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a1690fe7c4f09ae16e7ee1bf9700e001473fbb7a47c957884e04036f5a30a36
-size 14405232
+oid sha256:47067968d256f760be0d2cdd6b10af70550e4ae75fadc30cc0295ec0c844e973
+size 14534648

--- a/paykit-ffi/bindings/android/lib/src/main/jniLibs/x86_64/libpaykit.so
+++ b/paykit-ffi/bindings/android/lib/src/main/jniLibs/x86_64/libpaykit.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47067968d256f760be0d2cdd6b10af70550e4ae75fadc30cc0295ec0c844e973
+oid sha256:3cd8d01b370e353393588fb1c390c232f5bdee0f3fda45cfbfb44f98351f1d04
 size 14534648

--- a/paykit-ffi/build_android.sh
+++ b/paykit-ffi/build_android.sh
@@ -13,12 +13,23 @@ BASE_DIR="$ANDROID_LIB_DIR/lib/src/main/kotlin/com/synonym/paykit"
 JNILIBS_DIR="$ANDROID_LIB_DIR/lib/src/main/jniLibs"
 NATIVE_DEBUG_SYMBOLS_ZIP="$ANDROID_LIB_DIR/native-debug-symbols.zip"
 
-echo "Installing gobley-uniffi-bindgen fork..."
 GOBLEY_REV="82a0f93ad552d0c45e185f728f14c3c60b1ed707"
-cargo install --git https://github.com/ovitrif/gobley.git --rev "$GOBLEY_REV" gobley-uniffi-bindgen --force
+GOBLEY_INSTALL_ROOT="$TARGET_DIR/build-tools/gobley-$GOBLEY_REV"
+GOBLEY_BINDGEN_BIN="$GOBLEY_INSTALL_ROOT/bin/gobley-uniffi-bindgen"
+
+echo "Installing pinned gobley-uniffi-bindgen fork into $GOBLEY_INSTALL_ROOT..."
+cargo install \
+    --git https://github.com/ovitrif/gobley.git \
+    --rev "$GOBLEY_REV" \
+    --root "$GOBLEY_INSTALL_ROOT" \
+    --locked \
+    --force \
+    gobley-uniffi-bindgen
+"$GOBLEY_BINDGEN_BIN" --version
 
 # Install the cargo-ndk version used by the mobile release scripts.
 CARGO_NDK_VERSION="3.5.4"
+echo "Checking cargo-ndk $CARGO_NDK_VERSION..."
 if ! command -v cargo-ndk &> /dev/null || ! cargo ndk --version | grep -q "cargo-ndk $CARGO_NDK_VERSION"; then
     echo "Installing cargo-ndk $CARGO_NDK_VERSION..."
     cargo install cargo-ndk --version "$CARGO_NDK_VERSION" --locked --force
@@ -86,6 +97,30 @@ find_strip() {
     exit 1
 }
 
+find_llvm_tool() {
+    local tool_name="$1"
+
+    if command -v "$tool_name" >/dev/null 2>&1; then
+        command -v "$tool_name"
+        return
+    fi
+
+    for ndk_dir in "${ANDROID_NDK_ROOT:-}" "${ANDROID_NDK_HOME:-}" "${NDK_HOME:-}"; do
+        if [ -z "$ndk_dir" ] || [ ! -d "$ndk_dir/toolchains/llvm/prebuilt" ]; then
+            continue
+        fi
+
+        tool_path=$(find "$ndk_dir/toolchains/llvm/prebuilt" -path "*/bin/$tool_name" | head -n 1)
+        if [ -n "$tool_path" ]; then
+            echo "$tool_path"
+            return
+        fi
+    done
+
+    echo "Error: $tool_name is required to validate the UniFFI Kotlin/native contract"
+    exit 1
+}
+
 has_dwarf_debug_metadata() {
     "$READELF_BIN" -S "$1" | grep -Eq '\.debug_'
 }
@@ -103,49 +138,101 @@ readelf_program_headers() {
     "$READELF_BIN" -l "$1"
 }
 
-has_16kb_load_alignment() {
-    alignments=$(readelf_program_headers "$1" | awk '$1 == "LOAD" { print $NF }')
-    if [ -z "$alignments" ]; then
+validate_16kb_segments() {
+    local abi="$1"
+    local lib="$2"
+    local display_path="${3:-$lib}"
+    local headers
+    local load_alignments
+    local load_summary=""
+    local relro_fields
+    local relro_start="missing"
+    local relro_memsz="missing"
+    local relro_end="missing"
+    local alignment
+    local alignment_value
+    local alignment_hex
+    local relro_start_value
+    local relro_memsz_value
+    local relro_end_value
+    local invalid=false
+
+    headers=$(readelf_program_headers "$lib")
+    load_alignments=$(printf '%s\n' "$headers" | awk '$1 == "LOAD" { print $NF }')
+    if [ -z "$load_alignments" ]; then
+        invalid=true
+        load_summary="missing"
+    else
+        while read -r alignment; do
+            if [ -z "$alignment" ]; then
+                continue
+            fi
+
+            alignment_value=$((alignment))
+            printf -v alignment_hex '0x%x' "$alignment_value"
+            if [ -n "$load_summary" ]; then
+                load_summary="$load_summary,"
+            fi
+            load_summary="$load_summary$alignment_hex"
+
+            if [ "$alignment_value" -lt 16384 ]; then
+                invalid=true
+            fi
+        done <<EOF
+$load_alignments
+EOF
+    fi
+
+    relro_fields=$(printf '%s\n' "$headers" | awk '$1 == "GNU_RELRO" { print $3, $6; exit }')
+    if [ -z "$relro_fields" ]; then
+        invalid=true
+    else
+        read -r relro_start_value relro_memsz_value <<EOF
+$relro_fields
+EOF
+        relro_end_value=$((relro_start_value + relro_memsz_value))
+        printf -v relro_start '0x%x' "$((relro_start_value))"
+        printf -v relro_memsz '0x%x' "$((relro_memsz_value))"
+        printf -v relro_end '0x%x' "$relro_end_value"
+
+        if [ "$((relro_end_value % 16384))" -ne 0 ]; then
+            invalid=true
+        fi
+    fi
+
+    if [ "$invalid" = true ]; then
+        echo "Error: Android 16 KB ELF validation failed: abi=$abi path=$display_path LOAD_ALIGNMENTS=[$load_summary] GNU_RELRO_START=$relro_start GNU_RELRO_MEMSZ=$relro_memsz GNU_RELRO_END=$relro_end required_LOAD_min=0x4000 required_GNU_RELRO_end_alignment=0x4000"
+        printf '%s\n' "$headers" | grep -E '(^|[[:space:]])(LOAD|GNU_RELRO)[[:space:]]' || true
         return 1
     fi
 
-    while read -r alignment; do
-        if [ -z "$alignment" ]; then
-            continue
-        fi
-
-        if [ "$((alignment))" -lt 16384 ]; then
-            return 1
-        fi
-    done <<EOF
-$alignments
-EOF
+    echo "Android 16 KB ELF validation passed: abi=$abi path=$display_path LOAD_ALIGNMENTS=[$load_summary] GNU_RELRO_START=$relro_start GNU_RELRO_MEMSZ=$relro_memsz GNU_RELRO_END=$relro_end"
 }
 
 validate_android_library() {
-    lib="$1"
+    local abi="$1"
+    local lib="$2"
+    local display_path="${3:-$lib}"
     if ! has_dwarf_debug_metadata "$lib"; then
-        echo "Error: Android native library has no full DWARF debug metadata: $lib"
+        echo "Error: Android native library has no full DWARF debug metadata: abi=$abi path=$display_path"
         exit 1
     fi
 
-    if ! has_16kb_load_alignment "$lib"; then
-        echo "Error: Android native library is not 16 KB page-size aligned: $lib"
-        readelf_program_headers "$lib" | grep LOAD || true
+    if ! validate_16kb_segments "$abi" "$lib" "$display_path"; then
         exit 1
     fi
 }
 
 validate_stripped_android_library() {
-    lib="$1"
+    local abi="$1"
+    local lib="$2"
+    local display_path="${3:-$lib}"
     if has_dwarf_sections "$lib"; then
-        echo "Error: Android release native library still contains .debug_* sections: $lib"
+        echo "Error: Android release native library still contains .debug_* sections: abi=$abi path=$display_path"
         exit 1
     fi
 
-    if ! has_16kb_load_alignment "$lib"; then
-        echo "Error: Android native library is not 16 KB page-size aligned: $lib"
-        readelf_program_headers "$lib" | grep LOAD || true
+    if ! validate_16kb_segments "$abi" "$lib" "$display_path"; then
         exit 1
     fi
 }
@@ -160,7 +247,7 @@ validate_android_symbols() {
             exit 1
         fi
 
-        validate_android_library "$lib"
+        validate_android_library "$abi" "$lib"
     done
 }
 
@@ -194,7 +281,7 @@ validate_stripped_android_symbols() {
     READELF_BIN=$(find_readelf)
 
     for abi in armeabi-v7a arm64-v8a x86 x86_64; do
-        validate_stripped_android_library "$JNILIBS_DIR/$abi/libpaykit.so"
+        validate_stripped_android_library "$abi" "$JNILIBS_DIR/$abi/libpaykit.so"
     done
 }
 
@@ -217,10 +304,94 @@ validate_android_aar_symbols() {
             exit 1
         fi
 
-        validate_stripped_android_library "$lib"
+        validate_stripped_android_library "$abi" "$lib" "$aar!/jni/$abi/libpaykit.so"
     done
 
     rm -rf "$tmp_dir"
+}
+
+extract_kotlin_contract_version() {
+    local kotlin_file="$BASE_DIR/paykit.android.kt"
+    local contract_version
+
+    contract_version=$(sed -nE \
+        's/^[[:space:]]*val bindings_?[Cc]ontract_?[Vv]ersion = ([0-9]+).*$/\1/p' \
+        "$kotlin_file" | head -n 1)
+    if [ -z "$contract_version" ]; then
+        echo "Error: Unable to extract the UniFFI contract version from $kotlin_file"
+        exit 1
+    fi
+
+    echo "$contract_version"
+}
+
+extract_native_contract_version() {
+    local abi="$1"
+    local lib="$2"
+    local symbol="ffi_paykit_uniffi_contract_version"
+    local symbol_fields
+    local symbol_address
+    local symbol_size
+    local start_address
+    local stop_address
+    local disassembly
+    local immediate
+    local objdump_args=()
+
+    symbol_fields=$("$LLVM_NM_BIN" -D -S "$lib" | awk -v symbol="$symbol" '$NF == symbol { print $1, $2; exit }')
+    if [ -z "$symbol_fields" ]; then
+        echo "Error: UniFFI contract symbol missing: abi=$abi path=$lib"
+        exit 1
+    fi
+
+    read -r symbol_address symbol_size <<EOF
+$symbol_fields
+EOF
+    start_address=$((16#$symbol_address))
+    stop_address=$((start_address + 16#$symbol_size))
+    if [ "$abi" = "armeabi-v7a" ]; then
+        objdump_args+=(--triple=thumbv7-none-linux-android)
+    fi
+
+    disassembly=$("$LLVM_OBJDUMP_BIN" \
+        -d \
+        --no-show-raw-insn \
+        "--start-address=$start_address" \
+        "--stop-address=$stop_address" \
+        "${objdump_args[@]}" \
+        "$lib")
+    immediate=$(printf '%s\n' "$disassembly" \
+        | grep -E 'movs?[[:space:]]+r0,[[:space:]]*#0x|mov[[:space:]]+w0,[[:space:]]*#0x|movl[[:space:]]+\$0x[0-9a-fA-F]+,[[:space:]]*%eax' \
+        | grep -Eo '[#$]0x[0-9a-fA-F]+' \
+        | head -n 1 \
+        | sed -E 's/^[#$]//')
+    if [ -z "$immediate" ]; then
+        echo "Error: Unable to decode the UniFFI contract version: abi=$abi path=$lib"
+        printf '%s\n' "$disassembly"
+        exit 1
+    fi
+
+    echo "$((immediate))"
+}
+
+validate_uniffi_contract() {
+    local kotlin_contract_version
+    local native_contract_version
+
+    LLVM_NM_BIN=$(find_llvm_tool llvm-nm)
+    LLVM_OBJDUMP_BIN=$(find_llvm_tool llvm-objdump)
+    kotlin_contract_version=$(extract_kotlin_contract_version)
+    echo "UniFFI Kotlin contract version: $kotlin_contract_version"
+
+    for abi in armeabi-v7a arm64-v8a x86 x86_64; do
+        lib="$JNILIBS_DIR/$abi/libpaykit.so"
+        native_contract_version=$(extract_native_contract_version "$abi" "$lib")
+        if [ "$kotlin_contract_version" -ne "$native_contract_version" ]; then
+            echo "Error: UniFFI Kotlin/native contract mismatch: abi=$abi Kotlin=$kotlin_contract_version native=$native_contract_version path=$lib"
+            exit 1
+        fi
+        echo "UniFFI Kotlin/native contract validation passed: abi=$abi Kotlin=$kotlin_contract_version native=$native_contract_version path=$lib"
+    done
 }
 
 echo "Building for Android architectures..."
@@ -258,7 +429,7 @@ fi
 echo "Generating Kotlin bindings..."
 TMP_DIR=$(mktemp -d)
 
-gobley-uniffi-bindgen \
+"$GOBLEY_BINDGEN_BIN" \
     --library "$LIBRARY_PATH" \
     --config ./uniffi-android.toml \
     --out-dir "$TMP_DIR"
@@ -284,6 +455,7 @@ fi
 
 echo "Generated $KT_COUNT Kotlin binding file(s):"
 ls -la "$BASE_DIR"
+validate_uniffi_contract
 
 echo "Syncing version from Cargo.toml..."
 CARGO_VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/' | head -1)

--- a/paykit-ffi/build_android.sh
+++ b/paykit-ffi/build_android.sh
@@ -35,6 +35,35 @@ if ! command -v cargo-ndk &> /dev/null || ! cargo ndk --version | grep -q "cargo
     cargo install cargo-ndk --version "$CARGO_NDK_VERSION" --locked --force
 fi
 
+EXPECTED_ANDROID_NDK_REVISION="28.2.13676358"
+if [ -z "${ANDROID_NDK_HOME:-}" ] || [ -z "${ANDROID_NDK_ROOT:-}" ]; then
+    echo "Error: ANDROID_NDK_HOME and ANDROID_NDK_ROOT must both select Android NDK $EXPECTED_ANDROID_NDK_REVISION"
+    exit 1
+fi
+ANDROID_NDK_HOME_PATH=$(cd "$ANDROID_NDK_HOME" && pwd -P)
+ANDROID_NDK_ROOT_PATH=$(cd "$ANDROID_NDK_ROOT" && pwd -P)
+if [ "$ANDROID_NDK_HOME_PATH" != "$ANDROID_NDK_ROOT_PATH" ]; then
+    echo "Error: ANDROID_NDK_HOME and ANDROID_NDK_ROOT select different NDKs: HOME=$ANDROID_NDK_HOME_PATH ROOT=$ANDROID_NDK_ROOT_PATH"
+    exit 1
+fi
+if [ ! -f "$ANDROID_NDK_HOME_PATH/source.properties" ]; then
+    echo "Error: Android NDK source.properties is missing at $ANDROID_NDK_HOME_PATH"
+    exit 1
+fi
+cat "$ANDROID_NDK_HOME_PATH/source.properties"
+if ! grep -Fx "Pkg.Revision = $EXPECTED_ANDROID_NDK_REVISION" "$ANDROID_NDK_HOME_PATH/source.properties"; then
+    echo "Error: Android NDK $EXPECTED_ANDROID_NDK_REVISION is required: path=$ANDROID_NDK_HOME_PATH"
+    exit 1
+fi
+echo "Using Android NDK $EXPECTED_ANDROID_NDK_REVISION at $ANDROID_NDK_HOME_PATH"
+ANDROID_NDK_LLVM_READELF=$(find "$ANDROID_NDK_HOME_PATH/toolchains/llvm/prebuilt" -path '*/bin/llvm-readelf' -print -quit)
+if [ -z "$ANDROID_NDK_LLVM_READELF" ]; then
+    echo "Error: llvm-readelf is missing from Android NDK $EXPECTED_ANDROID_NDK_REVISION at $ANDROID_NDK_HOME_PATH"
+    exit 1
+fi
+ANDROID_NDK_LLVM_BIN=$(dirname "$ANDROID_NDK_LLVM_READELF")
+echo "Using Android NDK LLVM tools from $ANDROID_NDK_LLVM_BIN"
+
 mkdir -p "$BASE_DIR"
 mkdir -p "$JNILIBS_DIR"
 
@@ -49,75 +78,36 @@ echo "Adding Rust Android targets..."
 rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 
 find_readelf() {
-    if command -v llvm-readelf >/dev/null 2>&1; then
-        command -v llvm-readelf
+    if [ -x "$ANDROID_NDK_LLVM_BIN/llvm-readelf" ]; then
+        echo "$ANDROID_NDK_LLVM_BIN/llvm-readelf"
         return
     fi
 
-    if command -v readelf >/dev/null 2>&1; then
-        command -v readelf
-        return
-    fi
-
-    for ndk_dir in "${ANDROID_NDK_ROOT:-}" "${ANDROID_NDK_HOME:-}" "${NDK_HOME:-}"; do
-        if [ -z "$ndk_dir" ] || [ ! -d "$ndk_dir/toolchains/llvm/prebuilt" ]; then
-            continue
-        fi
-
-        ndk_readelf=$(find "$ndk_dir/toolchains/llvm/prebuilt" -path '*/bin/llvm-readelf' | head -n 1)
-        if [ -n "$ndk_readelf" ]; then
-            echo "$ndk_readelf"
-            return
-        fi
-    done
-
-    echo "Error: llvm-readelf or readelf is required to validate Android native debug symbols"
+    echo "Error: llvm-readelf is missing from Android NDK $EXPECTED_ANDROID_NDK_REVISION at $ANDROID_NDK_HOME_PATH"
     exit 1
 }
 
 find_strip() {
-    if command -v llvm-strip >/dev/null 2>&1; then
-        command -v llvm-strip
+    if [ -x "$ANDROID_NDK_LLVM_BIN/llvm-strip" ]; then
+        echo "$ANDROID_NDK_LLVM_BIN/llvm-strip"
         return
     fi
 
-    for ndk_dir in "${ANDROID_NDK_ROOT:-}" "${ANDROID_NDK_HOME:-}" "${NDK_HOME:-}"; do
-        if [ -z "$ndk_dir" ] || [ ! -d "$ndk_dir/toolchains/llvm/prebuilt" ]; then
-            continue
-        fi
-
-        ndk_strip=$(find "$ndk_dir/toolchains/llvm/prebuilt" -path '*/bin/llvm-strip' | head -n 1)
-        if [ -n "$ndk_strip" ]; then
-            echo "$ndk_strip"
-            return
-        fi
-    done
-
-    echo "Error: llvm-strip is required to strip Android native release libraries"
+    echo "Error: llvm-strip is missing from Android NDK $EXPECTED_ANDROID_NDK_REVISION at $ANDROID_NDK_HOME_PATH"
     exit 1
 }
 
 find_llvm_tool() {
     local tool_name="$1"
+    local tool_path
 
-    if command -v "$tool_name" >/dev/null 2>&1; then
-        command -v "$tool_name"
+    tool_path="$ANDROID_NDK_LLVM_BIN/$tool_name"
+    if [ -x "$tool_path" ]; then
+        echo "$tool_path"
         return
     fi
 
-    for ndk_dir in "${ANDROID_NDK_ROOT:-}" "${ANDROID_NDK_HOME:-}" "${NDK_HOME:-}"; do
-        if [ -z "$ndk_dir" ] || [ ! -d "$ndk_dir/toolchains/llvm/prebuilt" ]; then
-            continue
-        fi
-
-        tool_path=$(find "$ndk_dir/toolchains/llvm/prebuilt" -path "*/bin/$tool_name" | head -n 1)
-        if [ -n "$tool_path" ]; then
-            echo "$tool_path"
-            return
-        fi
-    done
-
-    echo "Error: $tool_name is required to validate the UniFFI Kotlin/native contract"
+    echo "Error: $tool_name is missing from Android NDK $EXPECTED_ANDROID_NDK_REVISION at $ANDROID_NDK_HOME_PATH"
     exit 1
 }
 
@@ -287,6 +277,8 @@ validate_stripped_android_symbols() {
 
 validate_android_aar_symbols() {
     READELF_BIN=$(find_readelf)
+    LLVM_NM_BIN=$(find_llvm_tool llvm-nm)
+    LLVM_OBJDUMP_BIN=$(find_llvm_tool llvm-objdump)
     aar=$(find "$ANDROID_LIB_DIR" -path '*/build/outputs/aar/*release.aar' -print | head -n 1)
     if [ -z "$aar" ]; then
         echo "Error: Android release AAR missing under $ANDROID_LIB_DIR"
@@ -305,6 +297,7 @@ validate_android_aar_symbols() {
         fi
 
         validate_stripped_android_library "$abi" "$lib" "$aar!/jni/$abi/libpaykit.so"
+        validate_uniffi_integrity_library "$abi" "$lib" "$aar!/jni/$abi/libpaykit.so"
     done
 
     rm -rf "$tmp_dir"
@@ -325,10 +318,25 @@ extract_kotlin_contract_version() {
     echo "$contract_version"
 }
 
-extract_native_contract_version() {
+extract_kotlin_checksum_manifest() {
+    local kotlin_file="$BASE_DIR/paykit.android.kt"
+    local manifest
+
+    manifest=$(perl -ne \
+        'print "$1 $2\n" if /if \((?:lib\.)?(uniffi_paykit_checksum_[A-Za-z0-9_]+)\(\) != ([0-9]+)\.toShort\(\)\)/' \
+        "$kotlin_file")
+    if [ -z "$manifest" ]; then
+        echo "Error: Unable to extract UniFFI API checksums from $kotlin_file"
+        exit 1
+    fi
+
+    echo "$manifest"
+}
+
+extract_native_constant() {
     local abi="$1"
     local lib="$2"
-    local symbol="ffi_paykit_uniffi_contract_version"
+    local symbol="$3"
     local symbol_fields
     local symbol_address
     local symbol_size
@@ -340,7 +348,7 @@ extract_native_contract_version() {
 
     symbol_fields=$("$LLVM_NM_BIN" -D -S "$lib" | awk -v symbol="$symbol" '$NF == symbol { print $1, $2; exit }')
     if [ -z "$symbol_fields" ]; then
-        echo "Error: UniFFI contract symbol missing: abi=$abi path=$lib"
+        echo "Error: UniFFI integrity symbol missing: abi=$abi symbol=$symbol path=$lib"
         exit 1
     fi
 
@@ -361,12 +369,12 @@ EOF
         "${objdump_args[@]}" \
         "$lib")
     immediate=$(printf '%s\n' "$disassembly" \
-        | grep -E 'movs?[[:space:]]+r0,[[:space:]]*#0x|mov[[:space:]]+w0,[[:space:]]*#0x|movl[[:space:]]+\$0x[0-9a-fA-F]+,[[:space:]]*%eax' \
+        | grep -E 'movs?[[:space:]]+r0,[[:space:]]*#0x|movw[[:space:]]+r0,[[:space:]]*#0x|mov\.w[[:space:]]+r0,[[:space:]]*#0x|mov[[:space:]]+w0,[[:space:]]*#0x|mov[wl][[:space:]]+\$0x[0-9a-fA-F]+,[[:space:]]*%e?ax' \
         | grep -Eo '[#$]0x[0-9a-fA-F]+' \
         | head -n 1 \
         | sed -E 's/^[#$]//')
     if [ -z "$immediate" ]; then
-        echo "Error: Unable to decode the UniFFI contract version: abi=$abi path=$lib"
+        echo "Error: Unable to decode UniFFI integrity symbol: abi=$abi symbol=$symbol path=$lib"
         printf '%s\n' "$disassembly"
         exit 1
     fi
@@ -374,23 +382,63 @@ EOF
     echo "$((immediate))"
 }
 
-validate_uniffi_contract() {
-    local kotlin_contract_version
+validate_uniffi_integrity_library() {
+    local abi="$1"
+    local lib="$2"
+    local display_path="${3:-$lib}"
     local native_contract_version
+    local checksum_symbol
+    local expected_checksum
+    local native_checksum
+    local expected_checksum_symbols
+    local native_checksum_symbols
+    local checksum_count
 
-    LLVM_NM_BIN=$(find_llvm_tool llvm-nm)
-    LLVM_OBJDUMP_BIN=$(find_llvm_tool llvm-objdump)
-    kotlin_contract_version=$(extract_kotlin_contract_version)
-    echo "UniFFI Kotlin contract version: $kotlin_contract_version"
+    native_contract_version=$(extract_native_constant "$abi" "$lib" "ffi_paykit_uniffi_contract_version")
+    if [ "$KOTLIN_CONTRACT_VERSION" -ne "$native_contract_version" ]; then
+        echo "Error: UniFFI Kotlin/native contract mismatch: abi=$abi Kotlin=$KOTLIN_CONTRACT_VERSION native=$native_contract_version path=$display_path"
+        exit 1
+    fi
 
-    for abi in armeabi-v7a arm64-v8a x86 x86_64; do
-        lib="$JNILIBS_DIR/$abi/libpaykit.so"
-        native_contract_version=$(extract_native_contract_version "$abi" "$lib")
-        if [ "$kotlin_contract_version" -ne "$native_contract_version" ]; then
-            echo "Error: UniFFI Kotlin/native contract mismatch: abi=$abi Kotlin=$kotlin_contract_version native=$native_contract_version path=$lib"
+    expected_checksum_symbols=$(printf '%s\n' "$KOTLIN_CHECKSUM_MANIFEST" | awk '{print $1}' | sort)
+    native_checksum_symbols=$("$LLVM_NM_BIN" -D "$lib" \
+        | awk '$NF ~ /^uniffi_paykit_checksum_/ {print $NF}' \
+        | sort)
+    if [ "$expected_checksum_symbols" != "$native_checksum_symbols" ]; then
+        echo "Error: UniFFI checksum symbol set mismatch: abi=$abi path=$display_path"
+        diff -u \
+            <(printf '%s\n' "$expected_checksum_symbols") \
+            <(printf '%s\n' "$native_checksum_symbols") || true
+        exit 1
+    fi
+
+    checksum_count=0
+    while read -r checksum_symbol expected_checksum; do
+        if [ -z "$checksum_symbol" ]; then
+            continue
+        fi
+        native_checksum=$(extract_native_constant "$abi" "$lib" "$checksum_symbol")
+        if [ "$expected_checksum" -ne "$native_checksum" ]; then
+            echo "Error: UniFFI API checksum mismatch: abi=$abi symbol=$checksum_symbol Kotlin=$expected_checksum native=$native_checksum path=$display_path"
             exit 1
         fi
-        echo "UniFFI Kotlin/native contract validation passed: abi=$abi Kotlin=$kotlin_contract_version native=$native_contract_version path=$lib"
+        checksum_count=$((checksum_count + 1))
+    done <<EOF
+$KOTLIN_CHECKSUM_MANIFEST
+EOF
+
+    echo "UniFFI Kotlin/native integrity validation passed: abi=$abi contract=$KOTLIN_CONTRACT_VERSION checksums=$checksum_count path=$display_path"
+}
+
+validate_uniffi_integrity() {
+    LLVM_NM_BIN=$(find_llvm_tool llvm-nm)
+    LLVM_OBJDUMP_BIN=$(find_llvm_tool llvm-objdump)
+    KOTLIN_CONTRACT_VERSION=$(extract_kotlin_contract_version)
+    KOTLIN_CHECKSUM_MANIFEST=$(extract_kotlin_checksum_manifest)
+    echo "UniFFI Kotlin integrity manifest: contract=$KOTLIN_CONTRACT_VERSION checksums=$(printf '%s\n' "$KOTLIN_CHECKSUM_MANIFEST" | wc -l | tr -d ' ')"
+
+    for abi in armeabi-v7a arm64-v8a x86 x86_64; do
+        validate_uniffi_integrity_library "$abi" "$JNILIBS_DIR/$abi/libpaykit.so"
     done
 }
 
@@ -455,7 +503,7 @@ fi
 
 echo "Generated $KT_COUNT Kotlin binding file(s):"
 ls -la "$BASE_DIR"
-validate_uniffi_contract
+validate_uniffi_integrity
 
 echo "Syncing version from Cargo.toml..."
 CARGO_VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/' | head -1)

--- a/paykit-ffi/build_android.sh
+++ b/paykit-ffi/build_android.sh
@@ -132,6 +132,11 @@ validate_16kb_segments() {
     local abi="$1"
     local lib="$2"
     local display_path="${3:-$lib}"
+    local elf_header
+    local elf_class
+    local elf_machine
+    local expected_elf_class
+    local expected_elf_machine
     local headers
     local load_alignments
     local load_summary=""
@@ -146,6 +151,40 @@ validate_16kb_segments() {
     local relro_memsz_value
     local relro_end_value
     local invalid=false
+
+    elf_header=$("$READELF_BIN" -h "$lib")
+    elf_class=$(printf '%s\n' "$elf_header" \
+        | sed -n -E 's/^[[:space:]]*Class:[[:space:]]*([^[:space:]]+).*$/\1/p' \
+        | head -n 1)
+    elf_machine=$(printf '%s\n' "$elf_header" \
+        | sed -n -E 's/^[[:space:]]*Machine:[[:space:]]*(.*[^[:space:]])[[:space:]]*$/\1/p' \
+        | head -n 1)
+    case "$abi" in
+        armeabi-v7a)
+            expected_elf_class="ELF32"
+            expected_elf_machine="ARM"
+            ;;
+        arm64-v8a)
+            expected_elf_class="ELF64"
+            expected_elf_machine="AArch64"
+            ;;
+        x86)
+            expected_elf_class="ELF32"
+            expected_elf_machine="Intel 80386"
+            ;;
+        x86_64)
+            expected_elf_class="ELF64"
+            expected_elf_machine="Advanced Micro Devices X86-64"
+            ;;
+        *)
+            echo "Error: Unsupported Android ABI for ELF validation: abi=$abi path=$display_path"
+            return 1
+            ;;
+    esac
+    if [ "$elf_class" != "$expected_elf_class" ] || [ "$elf_machine" != "$expected_elf_machine" ]; then
+        echo "Error: Android ELF ABI mismatch: abi=$abi path=$display_path expected_class=$expected_elf_class actual_class=${elf_class:-missing} expected_machine='$expected_elf_machine' actual_machine='${elf_machine:-missing}'"
+        return 1
+    fi
 
     headers=$(readelf_program_headers "$lib")
     load_alignments=$(printf '%s\n' "$headers" | awk '$1 == "LOAD" { print $NF }')
@@ -196,7 +235,7 @@ EOF
         return 1
     fi
 
-    echo "Android 16 KB ELF validation passed: abi=$abi path=$display_path LOAD_ALIGNMENTS=[$load_summary] GNU_RELRO_START=$relro_start GNU_RELRO_MEMSZ=$relro_memsz GNU_RELRO_END=$relro_end"
+    echo "Android 16 KB ELF validation passed: abi=$abi path=$display_path ELF_CLASS=$elf_class ELF_MACHINE='$elf_machine' LOAD_ALIGNMENTS=[$load_summary] GNU_RELRO_START=$relro_start GNU_RELRO_MEMSZ=$relro_memsz GNU_RELRO_END=$relro_end"
 }
 
 validate_android_library() {
@@ -239,6 +278,38 @@ validate_android_symbols() {
 
         validate_android_library "$abi" "$lib"
     done
+}
+
+validate_android_abi_mismatch_fixtures() {
+    local fixture_output
+
+    if fixture_output=$(validate_16kb_segments \
+        "x86_64" \
+        "$JNILIBS_DIR/arm64-v8a/libpaykit.so" \
+        "negative-fixture: arm64-v8a/libpaykit.so labeled x86_64" 2>&1); then
+        echo "Error: Android ELF ABI mismatch fixture unexpectedly passed: arm64-v8a labeled x86_64"
+        exit 1
+    fi
+    if ! printf '%s\n' "$fixture_output" | grep -Fq "Android ELF ABI mismatch"; then
+        printf '%s\n' "$fixture_output"
+        echo "Error: Android ELF ABI mismatch fixture failed for an unexpected reason: arm64-v8a labeled x86_64"
+        exit 1
+    fi
+    echo "Android ELF ABI mismatch fixture passed: arm64-v8a labeled x86_64"
+
+    if fixture_output=$(validate_16kb_segments \
+        "arm64-v8a" \
+        "$JNILIBS_DIR/x86_64/libpaykit.so" \
+        "negative-fixture: x86_64/libpaykit.so labeled arm64-v8a" 2>&1); then
+        echo "Error: Android ELF ABI mismatch fixture unexpectedly passed: x86_64 labeled arm64-v8a"
+        exit 1
+    fi
+    if ! printf '%s\n' "$fixture_output" | grep -Fq "Android ELF ABI mismatch"; then
+        printf '%s\n' "$fixture_output"
+        echo "Error: Android ELF ABI mismatch fixture failed for an unexpected reason: x86_64 labeled arm64-v8a"
+        exit 1
+    fi
+    echo "Android ELF ABI mismatch fixture passed: x86_64 labeled arm64-v8a"
 }
 
 create_native_debug_symbols_archive() {
@@ -454,6 +525,7 @@ cargo ndk \
     -t x86_64 \
     build --release
 validate_android_symbols
+validate_android_abi_mismatch_fixtures
 create_native_debug_symbols_archive
 strip_android_libraries
 validate_stripped_android_symbols

--- a/paykit-lib/Cargo.toml
+++ b/paykit-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paykit-lib"
-version = "0.1.0-rc33"
+version = "0.1.1-rc1"
 authors = ["denys@synonym.to"]
 description = "Paykit library implementation"
 license = "MIT"

--- a/paykit-sdk/Cargo.toml
+++ b/paykit-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paykit-sdk"
-version = "0.1.0-rc33"
+version = "0.1.1-rc1"
 authors = ["ben@synonym.to", "denys@synonym.to"]
 description = "Stateful Paykit SDK runtime"
 license = "MIT"
@@ -19,7 +19,7 @@ async-trait = "0.1"
 bip39 = { version = "2.2.0", features = ["zeroize"] }
 chrono = { version = "0.4.44", default-features = false, features = ["clock", "serde", "std"] }
 hex = "0.4"
-paykit-lib = { path = "../paykit-lib", version = "0.1.0-rc33" }
+paykit-lib = { path = "../paykit-lib", version = "0.1.1-rc1" }
 pubky = "0.8.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary

- Publishes `0.1.1-rc1` from the `v0.1.0-rc33` release line so Bitkit Android receives the 16 KB compatibility fix with its current Paykit API.
- Requires Android NDK r28c revision `28.2.13676358` through matching `ANDROID_NDK_HOME` and `ANDROID_NDK_ROOT` paths, prints `source.properties`, and selects every LLVM build, strip, and inspection tool from that validated NDK.
- Documents the exact r28c installation and dual-variable setup in the developer build guide and release procedure.
- Builds and validates every Android ABI before stripping, after stripping, and inside the final release AAR, including the required ELF class and machine for each ABI path.
- Requires `PT_LOAD` alignment of at least `0x4000`, a `PT_GNU_RELRO` end aligned to `0x4000`, UniFFI contract `29`, the exact set of 149 generated API checksum symbols, and every checksum value.
- Invokes the pinned Gobley generator from an isolated revision-specific path so concurrent builds cannot replace the generator used for this package.
- Uses the Node.js 24 action majors in CI and the hosted Android publisher, while preserving native debug-symbol uploads for documented manual release recovery.

Closes #120

Parent: synonymdev/bitkit-android#1047

## Protocol impact

None.

## Downstream bindings

The Android and iOS release artifacts were rebuilt for `0.1.1-rc1`. The generated Kotlin source and public JVM API remain identical to `v0.1.0-rc33`.

The final r28c Maven Local package is `com.synonym:paykit-android:0.1.1-rc1`.

- AAR SHA-256: `b0584c29fbdc43356c8340b9142e9c6de835094ecbf30b46e0bb7779f5e787e9`
- `arm64-v8a/libpaykit.so` SHA-256: `a2c617c089806c99e01c822c580defc4c97304ab554dacfacebb1cdb8c2bde05`
- `classes.jar` SHA-256: `7d8cfca23b08bc3a10de74e51125d5c636f6d75200b624461a73089c8b6976e3`
- `Paykit.xcframework.zip` checksum: `f0ba00de7bf873ce77d2ef58da0e8e2a1cc78baee4b95d2ab85e2ee9000e4feb`

## Runtime proof

A fresh `mainnetDebug` installation consumed `com.synonym:paykit-android:0.1.1-rc1-16kb.20260724.2` on Android 17/API 37 with a true 16 KB runtime page size.

- The final APK/AAB native-library gate passed every ABI and packaged library.
- The fresh install showed no compatibility alert and reported `pageSizeCompat=0`.
- `libpaykit.so` loaded successfully.
- Wallet creation and persisted restart succeeded.
- QR scanning parsed a BIP21 payment request.

## Validation

- `cd paykit-ffi && ./build.sh all` with NDK r28c selected through both `ANDROID_NDK_HOME` and `ANDROID_NDK_ROOT`
- Final exact-NDK Android regeneration and Maven Local publication with `./build_android.sh`
- Pre-strip, post-strip, source-library, and final-AAR ELF identity and 16 KB checks for `armeabi-v7a`, `arm64-v8a`, `x86`, and `x86_64`
- Generated Kotlin/native contract `29/29`, exact 149-symbol checksum set, and all 149 checksum values for every ABI
- Negative checksum fixture: contract `29` remained unchanged while Kotlin `4824` versus native `4823` failed on the exact API symbol
- Negative ABI fixtures: `arm64-v8a` labeled as `x86_64` and `x86_64` labeled as `arm64-v8a` both fail on ELF identity before checksum validation
- Negative NDK fixtures: differing `ANDROID_NDK_HOME`/`ANDROID_NDK_ROOT` paths and revision r28b both fail the standalone Gradle release validator
- Manual release-target detection under `bash -eo pipefail`: HTTP `200` enables symbol upload, HTTP `404` keeps tag-only package publication safe, and unexpected statuses fail closed
- `./paykit-ffi/bindings/android/gradlew --project-dir paykit-ffi/bindings/android clean build`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `cargo +1.91.1 check --workspace --all-features`
- Swift package inspection and XCFramework checksum verification
- `actionlint .github/workflows/ci.yml .github/workflows/gradle-publish.yml`
- Two independent mechanically validated full reviews at `0b79ae933a9d153bb97f6cb87208efce4cd45bcd`, each with an empty canonical finding ledger

## Hosted release verification

- GitHub-hosted NDK r28c selection, final-AAR validation, and action runtime warnings are verified on the release workflow after merge.
- The released `0.1.1-rc1` Android package is reconfirmed in the Android 17/API 37 `mainnetDebug` runtime journey after release.
- The Android package and iOS XCFramework resolve from the `v0.1.1-rc1` release.

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets --all-features` is clean
- [x] `cargo test` passes (unit + doc tests)
- [x] `cargo doc --no-deps` builds without warnings
- [x] Native packaging checks cover the required positive and failure paths
- [x] The public API remains unchanged
- [x] Platform bindings rebuilt for all targets (`cd paykit-ffi && ./build.sh all`)
- [x] I reviewed this PR myself and asked an LLM to review it and check whether it can be simplified
