### PR TITLE
Clarify Receipt decryption access control

### DIFF
--- a/paykit-lib/src/receipt/crypto.rs
+++ b/paykit-lib/src/receipt/crypto.rs
@@ -89,6 +89,16 @@ impl Receipt {
     /// `key` and `location` normally come from a [`ReceiptAccess`] message. The
     /// location path is authenticated as AEAD associated data and the decrypted
     /// Receipt ID must match the canonical path.
+    ///
+    /// # Access control
+    ///
+    /// The Receipt Decryption Key is a possession-based access secret. A matching
+    /// Receipt Location is required as AEAD associated data, but the location is
+    /// not itself an authorization credential. The stateless Paykit Library has
+    /// no caller identity and does not compare `recipient_public_key`; callers
+    /// must compare it with the expected local Pubky identity. The SDK retrieval
+    /// path applies `validate_receipt_matches_access` to the plaintext Receipt
+    /// after decryption.
     pub fn decrypt(
         encrypted_json: &str,
         key: &ReceiptDecryptionKey,
@@ -174,6 +184,16 @@ impl Receipt {
 /// normally come from a [`ReceiptAccess`] message. The `location` path is
 /// authenticated as additional data, and the decrypted Receipt ID must match
 /// that path.
+///
+/// # Access control
+///
+/// The Receipt Decryption Key is a possession-based access secret. A matching
+/// Receipt Location is required as AEAD associated data, but the location is
+/// not itself an authorization credential. The stateless Paykit Library has
+/// no caller identity and does not compare `recipient_public_key`; callers
+/// must compare it with the expected local Pubky identity. The SDK retrieval
+/// path applies `validate_receipt_matches_access` to the plaintext Receipt
+/// after decryption.
 ///
 /// Receipt Decryption Keys are sensitive. [`ReceiptDecryptionKey`] redacts its
 /// `Debug` and `Display` output, but callers must still avoid logging raw values


### PR DESCRIPTION
## Problem

The public Receipt decryption APIs describe the key and Receipt Location mechanics but do not state the authorization boundary clearly. A caller holding matching access material can decrypt, while the stateless Paykit Library has no caller identity with which to validate recipient_public_key.

Reference: [Receipts](https://github.com/pubky/paykit-rs/blob/master/README.md#receipts).

## Change

Add matching access-control sections to Receipt::decrypt and decrypt_receipt. The documentation explains that the Receipt Decryption Key is possession-based, the Receipt Location is authenticated data rather than an authorization credential, callers must validate the recipient identity, and the SDK retrieval path performs that validation.

## Protocol impact

None. Encryption, associated data, wire formats, validation behavior, storage paths, and serialized data are unchanged. No old stored data is affected.

## Public API/bindings impact

Documentation-only. Public signatures and exposed structs and enums are unchanged. There are no capability-string changes and no Swift or Kotlin binding impact. Platform bindings were not rebuilt because no FFI or generated interface changed.

## Verification

- cargo test -p paykit-lib test_encrypt_receipt_roundtrip_binds_location
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- RUSTDOCFLAGS="-D warnings" cargo doc --no-deps