### PR TITLE
Document exhaustive Paykit protocol enums

### DIFF
--- a/paykit-lib/src/encrypted_link/private_application_message.rs
+++ b/paykit-lib/src/encrypted_link/private_application_message.rs
@@ -16,6 +16,11 @@ const INVALID_UTF8_PRIVATE_MESSAGE_PREFIX: &str = "paykit.invalid_utf8_private_m
 const LIST_PAGE_LIMIT: u16 = 100;
 
 /// Private Message Kind values understood by Paykit.
+///
+/// This enum is intentionally exhaustive. Adding a variant must produce
+/// compile-time failures in routing, validation, and backup-validation matches
+/// until the new Private Message Kind is classified explicitly. Do not add
+/// `#[non_exhaustive]` without a coordinated team decision.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PrivateMessageKind {
     /// Private Payment List Latest-State Message (`paykit.private_payment_list`).

--- a/paykit-lib/src/payment_request/types.rs
+++ b/paykit-lib/src/payment_request/types.rs
@@ -42,6 +42,11 @@ impl AsRef<str> for PaymentRequestId {
 }
 
 /// Recurrence unit for recurring Payment Requests.
+///
+/// This enum is intentionally exhaustive. Adding a variant must produce
+/// compile-time failures in canonical wire serialization and SDK conversion
+/// matches until the new Recurrence unit is mapped explicitly. Do not add
+/// `#[non_exhaustive]` without a coordinated team decision.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RecurrenceUnit {
     /// Minute-based recurrence.
@@ -408,6 +413,11 @@ impl PaymentProof {
 }
 
 /// One recognized Payment Request protocol Event Message in FIFO receive order.
+///
+/// This enum is intentionally exhaustive. Adding a variant must produce
+/// compile-time failures in serialization, lifecycle, and replay matches until
+/// the new Payment Request Event Message is classified explicitly. Do not add
+/// `#[non_exhaustive]` without a coordinated team decision.
 #[derive(Clone, PartialEq)]
 pub enum PaymentRequestEvent {
     /// `paykit.payment_request` proposal event.


### PR DESCRIPTION
## Problem

The Paykit Library deliberately keeps public protocol enums exhaustive so that new typed variants force coordinated updates at security-sensitive match sites. That policy is not visible in the API documentation, making an inappropriate non_exhaustive change more likely.

Reference: [Payment Requests specification](https://github.com/pubky/paykit-rs/blob/master/specs/payment-requests.md).

## Change

Document the intentional exhaustiveness of PrivateMessageKind, RecurrenceUnit, and PaymentRequestEvent. Each paragraph identifies the compile-time update points and explicitly requires a coordinated team decision before adding the non_exhaustive attribute.

## Protocol impact

None. Enum variants, wire values, parsing, serialization, lifecycle handling, replay, backup validation, and stored data are unchanged.

## Public API/bindings impact

Public API documentation changes only. Exposed enum definitions and serialized formats are unchanged. There are no capability-string changes and no Swift or Kotlin binding impact. Platform bindings were not rebuilt because no FFI or generated interface changed.

## Verification

- cargo test -p paykit-lib test_parse_event_non_request_kind_ignored
- cargo test -p paykit-lib valid_event_round_trips
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- RUSTDOCFLAGS="-D warnings" cargo doc --no-deps