### PR TITLE
Document embedded Postgres failure semantics

### DIFF
--- a/paykit-lib/src/tests/mod.rs
+++ b/paykit-lib/src/tests/mod.rs
@@ -13,6 +13,10 @@ mod payment_request_properties;
 mod private_payment_list;
 mod receipt_access;
 
+// A panicked OnceCell initializer leaves the cell empty for retry; libtest
+// isolates the panic per test. Repeated failures can cause opaque, correlated
+// panics; a post-init server exit leaves an unrecoverable stale handle. Nextest's
+// process-per-test model changes sharing and multiplies leaks; statics are not dropped.
 static SHARED_POSTGRES: OnceCell<EmbeddedPostgres> = OnceCell::const_new();
 static TESTNET_BUILD_LOCK: TokioMutex<()> = TokioMutex::const_new(());
 

--- a/paykit-sdk/tests/testnet_e2e/harness.rs
+++ b/paykit-sdk/tests/testnet_e2e/harness.rs
@@ -20,6 +20,10 @@ use paykit_sdk::{
 use pubky_testnet::{embedded_postgres::EmbeddedPostgres, pubky::Keypair, EphemeralTestnet};
 use tokio::sync::{Mutex as TokioMutex, OnceCell};
 
+// A panicked OnceCell initializer leaves the cell empty for retry; libtest
+// isolates the panic per test. Repeated failures can cause opaque, correlated
+// panics; a post-init server exit leaves an unrecoverable stale handle. Nextest's
+// process-per-test model changes sharing and multiplies leaks; statics are not dropped.
 static SHARED_POSTGRES: OnceCell<EmbeddedPostgres> = OnceCell::const_new();
 static TESTNET_BUILD_LOCK: TokioMutex<()> = TokioMutex::const_new(());
 


### PR DESCRIPTION
## Problem

The two shared embedded-Postgres test harnesses have non-obvious failure and lifetime behavior. Panicked OnceCell initialization is retryable and isolated per libtest case, while repeated initialization failures, a post-initialization server exit, and process-scoped static ownership have different consequences.

References: [Tokio OnceCell](https://docs.rs/tokio/1.50.0/tokio/sync/struct.OnceCell.html), [nextest process-per-test design](https://nexte.st/docs/design/why-process-per-test/), and [Rust static items](https://doc.rust-lang.org/reference/items/static-items.html).

## Change

Add the same four-line invariant comment above SHARED_POSTGRES in both harnesses. It records retry and panic isolation, opaque correlated failures, the unrecoverable stale-handle case, and the cleanup-leak multiplication that a process-per-test model can introduce because statics are not dropped.

## Protocol impact

None. This changes test-harness comments only; runtime, network, storage, serialization, and protocol behavior are unchanged.

## Public API/bindings impact

None. No public API, exposed struct or enum, capability string, FFI representation, Swift binding, or Kotlin binding changes. Platform bindings were not rebuilt because no binding source or generated interface changed.

## Verification

- cargo test -p paykit-sdk --test testnet_e2e -- --list
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- RUSTDOCFLAGS="-D warnings" cargo doc --no-deps