### PR TITLE
Remove orphaned rc24 changelog reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,7 +389,6 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 [0.1.0-rc27]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc27
 [0.1.0-rc26]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc26
 [0.1.0-rc25]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc25
-[0.1.0-rc24]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc24
 [0.1.0-rc23]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc23
 [0.1.0-rc21]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc21
 [0.1.0-rc19]: https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc19


### PR DESCRIPTION
## Problem

CHANGELOG.md defines a link for the rc24 release but has no matching rc24 section or use. The unused definition is invisible in rendered Markdown and is inconsistent with other undocumented release tags.

Reference: [v0.1.0-rc24 release](https://github.com/pubky/paykit-rs/releases/tag/v0.1.0-rc24).

## Change

Delete the single orphaned Markdown link definition. No release section is synthesized because the documented history already records those changes under the following release.

## Protocol impact

None. No protocol, validation, storage, wire-format, or compatibility behavior changes.

## Public API/bindings impact

None. Public APIs, exposed structs and enums, capability strings, serialized formats, Swift bindings, and Kotlin bindings are unchanged. Platform bindings were not rebuilt because no binding source or generated interface changed.

## Verification

- Confirmed no rc24 heading or remaining link definition
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- RUSTDOCFLAGS="-D warnings" cargo doc --no-deps