### PR TITLE
Add binding compilation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,12 @@ jobs:
         with:
           ndk-version: r28c
           add-to-path: true
-      - name: Export Android NDK root
-        run: echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
+      - name: Export Android NDK paths
+        run: |
+          echo "ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_PATH=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
+          echo "NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
       - name: Build all platform bindings
         working-directory: paykit-ffi
         run: ./build.sh all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,86 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  binding-changes:
+    name: Binding changes
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      bindings: ${{ steps.filter.outputs.bindings }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            bindings:
+              - '.cargo/**'
+              - '.github/workflows/ci.yml'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - 'paykit-ffi/**'
+              - 'paykit-lib/**'
+              - 'paykit-sdk/**'
+              - 'rust-toolchain*'
+              - 'vendor/**'
+
+  bindings:
+    name: Bindings (iOS + Android)
+    needs: binding-changes
+    if: needs.binding-changes.outputs.bindings == 'true'
+    permissions:
+      contents: read
+    runs-on: macos-15
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Set up Android NDK
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r28c
+          add-to-path: true
+      - name: Export Android NDK root
+        run: echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
+      - name: Build all platform bindings
+        working-directory: paykit-ffi
+        run: ./build.sh all
+      - name: Check generated binding sources
+        shell: bash
+        run: |
+          generated_sources=(
+            paykit-ffi/bindings/ios/PaykitPublicKeys.swift
+            paykit-ffi/bindings/ios/module.modulemap
+            paykit-ffi/bindings/ios/paykit.swift
+            paykit-ffi/bindings/ios/paykitFFI.h
+            paykit-ffi/bindings/android/lib/src/main/kotlin/com/synonym/paykit/paykit.android.kt
+            paykit-ffi/bindings/android/lib/src/main/kotlin/com/synonym/paykit/paykit.common.kt
+          )
+
+          if ! git diff --quiet -- "${generated_sources[@]}"; then
+            echo "::error::Generated binding sources are stale. Run 'cd paykit-ffi && ./build.sh all' and commit the updated sources."
+            git diff --name-only -- "${generated_sources[@]}"
+            exit 1
+          fi
+
   fmt:
     name: Formatting
     runs-on: ubuntu-latest

--- a/paykit-ffi/build.sh
+++ b/paykit-ffi/build.sh
@@ -135,4 +135,11 @@ if [ "$DO_RELEASE" = true ]; then
     bump_version "$BUMP_TYPE" "$USE_RC"
 fi
 
-./build_ios.sh && ./build_android.sh
+./build_ios.sh
+
+if [ "${CI:-}" = "true" ]; then
+    echo "Removing iOS build intermediates before the Android build..."
+    rm -rf ../target/aarch64-apple-ios ../target/aarch64-apple-ios-sim ../target/debug
+fi
+
+./build_android.sh

--- a/paykit-ffi/build_ios.sh
+++ b/paykit-ffi/build_ios.sh
@@ -49,6 +49,21 @@ fi
 echo "Normalizing generated Swift and header whitespace..."
 find ./bindings/ios -type f \( -name "*.swift" -o -name "*.h" -o -name "*.modulemap" \) -exec perl -0pi -e 's/[ \t]+(?=\n)//g; s/[ \t]+\z//; s/\n+\z/\n/; $_ .= "\n" unless /\n\z/' {} \;
 
+echo "Type-checking generated Swift bindings..."
+IOS_SIMULATOR_SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
+SWIFT_MODULE_CACHE="${TARGET_DIR}/swift-binding-module-cache"
+rm -rf "$SWIFT_MODULE_CACHE"
+mkdir -p "$SWIFT_MODULE_CACHE"
+xcrun --sdk iphonesimulator swiftc \
+    -typecheck \
+    -target arm64-apple-ios15.0-simulator \
+    -sdk "$IOS_SIMULATOR_SDK" \
+    -module-cache-path "$SWIFT_MODULE_CACHE" \
+    -I ./bindings/ios \
+    ./bindings/ios/paykit.swift \
+    ./bindings/ios/PaykitPublicKeys.swift \
+    || { echo "Failed to type-check generated Swift bindings"; exit 1; }
+
 echo "Cleaning up existing XCFramework..."
 rm -rf "bindings/ios/Paykit.xcframework"
 rm -rf "bindings/ios/Headers"


### PR DESCRIPTION
## Summary

- add a path-filtered macOS CI job that builds iOS and Android bindings together through `paykit-ffi/./build.sh all`
- type-check generated Swift bindings for an arm64 iOS simulator and fail when committed generated Swift/Kotlin sources are stale
- discard only CI build intermediates between platforms and avoid caching the large cross-target directory so the job fits hosted-runner storage

## Protocol impact

None.

## Downstream bindings

No exposed binding API changes. The all-platform build regenerated Swift and Kotlin sources without producing source changes.

## Verification

- `cargo fmt --all --check`
- workflow YAML parsing and `bash -n` for the modified scripts
- `CI=true cd paykit-ffi && ./build.sh all`
  - iOS device and simulator archives
  - generated Swift type-check and XCFramework packaging
  - all four Android ABIs, debug metadata, stripping, and 16 KB alignment
  - generated Kotlin compilation and release AAR publication to Maven Local

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets --all-features` is clean (or allows are justified)
- [x] `cargo test` passes (unit + doc tests)
- [x] `cargo doc --no-deps` builds without warnings
- [x] Added tests for new behaviour — not applicable; this changes CI/build validation
- [x] Public API changes include `///` docs and use THESAURUS.md vocabulary — no public API changes
- [x] Platform bindings rebuilt for **all** targets if FFI changed (`cd paykit-ffi && ./build.sh all`)
- [x] I reviewed this PR myself and asked an LLM to review it and check whether it can be simplified
